### PR TITLE
[on hold] Coaching planner

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "ndb-core",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11650,6 +11650,19 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng-drag-drop": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ng-drag-drop/-/ng-drag-drop-5.0.0.tgz",
+      "integrity": "sha1-rsRIMRQ6CVEC3CRQX3EqyInDuYw="
+    },
+    "ngx-filter-pipe": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-filter-pipe/-/ngx-filter-pipe-2.1.0.tgz",
+      "integrity": "sha512-VtggKAtmWXi6wL32GBs0/Ko+4WaOAfNbP7CkGYIiZ8gu/0aNE+oA7FGc40MvnE+aeukiBBRlzVJ8VINkfTd9xw==",
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
     "ngx-papaparse": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/ngx-papaparse/-/ngx-papaparse-2.1.4.tgz",
@@ -16619,6 +16632,11 @@
           }
         }
       }
+    },
+    "uniqid": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.0.3.tgz",
+      "integrity": "sha512-R2qx3X/LYWSdGRaluio4dYrPXAJACTqyUjuyXHoJLBUOIfmMcnYOyY2d6Y4clZcIz5lK6ZaI0Zzmm0cPfsIqzQ=="
     },
     "unique-filename": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "crypto-js": "~3.1.9-1",
     "file-saver": "^1.3.8",
     "font-awesome": "^4.7.0",
+    "ng-drag-drop": "^5.0.0",
+    "ngx-filter-pipe": "^2.1.0",
     "ngx-papaparse": "^2.1.4",
     "pouchdb": "6.4.x",
     "pouchdb-authentication": "1.1.x",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,6 +88,7 @@ export class AppModule {
     _navigationItemsService.addMenuItem(new MenuItem('Dashboard', 'home', ['/dashboard']));
     _navigationItemsService.addMenuItem(new MenuItem('Children', 'child', ['/child']));
     _navigationItemsService.addMenuItem(new MenuItem('Schools', 'university', ['/school']));
+    _navigationItemsService.addMenuItem(new MenuItem('Coaching Planner', 'book', ['/coachings']));
     _navigationItemsService.addMenuItem(new MenuItem('Admin', 'wrench', ['/admin'], true));
   }
 }

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -26,6 +26,7 @@ import {ChildrenListComponent} from './children/children-list/children-list.comp
 import {ChildAttendanceComponent} from './children/attendance/child-attendance/child-attendance.component';
 import {AdminComponent} from './admin/admin/admin.component';
 import {AdminGuard} from './admin/admin.guard';
+import {CoachingPlannerComponent} from './children/coaching-planner/coaching-planner.component';
 
 export const routes: Routes = [
   {path: '', component: DashboardComponent},
@@ -35,6 +36,7 @@ export const routes: Routes = [
   {path: 'child', component: ChildrenListComponent},
   {path: 'child/:id', component: ChildDetailsComponent},
   {path: 'child/:id/attendance', component: ChildAttendanceComponent},
+  {path: 'coachings', component: CoachingPlannerComponent},
   {path: 'admin', component: AdminComponent, canActivate: [AdminGuard]},
   {path: '**', redirectTo: '/'},
 ];

--- a/src/app/children/aser/aser-block/aser-block.component.html
+++ b/src/app/children/aser/aser-block/aser-block.component.html
@@ -1,0 +1,5 @@
+<span>
+  <span class="aser-level w-{{entity?.getWarningLevelReading(entity?.hindi)}}">HINDI: {{entity?.hindi}}</span> |
+  <span class="aser-level w-{{entity?.getWarningLevelReading(entity?.english)}}">ENGLISH: {{entity?.english}}</span> |
+  <span class="aser-level w-{{entity?.getWarningLevelMath(entity?.math)}}">MATH: {{entity?.math}}</span>
+</span>

--- a/src/app/children/aser/aser-block/aser-block.component.scss
+++ b/src/app/children/aser/aser-block/aser-block.component.scss
@@ -1,0 +1,3 @@
+.aser-level {
+
+}

--- a/src/app/children/aser/aser-block/aser-block.component.spec.ts
+++ b/src/app/children/aser/aser-block/aser-block.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AserBlockComponent } from './aser-block.component';
+
+describe('AserBlockComponent', () => {
+  let component: AserBlockComponent;
+  let fixture: ComponentFixture<AserBlockComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AserBlockComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AserBlockComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/children/aser/aser-block/aser-block.component.ts
+++ b/src/app/children/aser/aser-block/aser-block.component.ts
@@ -1,0 +1,17 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {Aser} from '../aser';
+
+@Component({
+  selector: 'app-aser-block',
+  templateUrl: './aser-block.component.html',
+  styleUrls: ['./aser-block.component.scss']
+})
+export class AserBlockComponent implements OnInit {
+  @Input() entity: Aser;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/children/aser/aser.ts
+++ b/src/app/children/aser/aser.ts
@@ -46,7 +46,6 @@ export class Aser extends Entity {
   math = '';
   remarks = '';
 
-
   static isReadingPassedOrNA(level: string) {
     if (level === '' || level === undefined) {
       // not applicable
@@ -76,6 +75,37 @@ export class Aser extends Entity {
       data.date = new Date(data.date);
     }
 
+    if (data.english === 'Read Story') {
+      data.english = 'Read Paragraph';
+    }
+    if (data.hindi === 'Read Story') {
+      data.hindi = 'Read Paragraph';
+    }
+    if (data.bengali === 'Read Story') {
+      data.bengali = 'Read Paragraph';
+    }
+    if (data.english === 'Read Sentences') {
+      data.english = 'Read Sentence';
+    }
+    if (data.hindi === 'Read Sentences') {
+      data.hindi = 'Read Sentence';
+    }
+    if (data.bengali === 'Read Sentences') {
+      data.bengali = 'Read Sentence';
+    }
+    if (data.english === 'Read Nothing') {
+      data.english = 'Nothing';
+    }
+    if (data.hindi === 'Read Nothing') {
+      data.hindi = 'Nothing';
+    }
+    if (data.bengali === 'Read Nothing') {
+      data.bengali = 'Nothing';
+    }
+    if (data.math === 'Subraction') {
+      data.math = 'Subtraction';
+    }
+
     return super.load(data);
   }
 
@@ -91,6 +121,36 @@ export class Aser extends Entity {
     }
 
     return warningLevel;
+  }
+
+
+  getWarningLevelReading (level): WarningLevel {
+    switch (level) {
+      case Aser.ReadingLevels[0]:
+        return WarningLevel.URGENT;
+      case Aser.ReadingLevels[1]:
+        return WarningLevel.URGENT;
+      case Aser.ReadingLevels[2]:
+        return WarningLevel.WARNING;
+      case Aser.ReadingLevels[3]:
+        return WarningLevel.WARNING;
+      case Aser.ReadingLevels[4]:
+        return WarningLevel.OK;
+    }
+  }
+  getWarningLevelMath (level): WarningLevel {
+    switch (level) {
+      case Aser.MathLevels[0]:
+        return WarningLevel.URGENT;
+      case Aser.MathLevels[1]:
+        return WarningLevel.URGENT;
+      case Aser.MathLevels[2]:
+        return WarningLevel.URGENT;
+      case Aser.MathLevels[3]:
+        return WarningLevel.WARNING;
+      case Aser.MathLevels[4]:
+        return WarningLevel.OK;
+    }
   }
 
 }

--- a/src/app/children/child.ts
+++ b/src/app/children/child.ts
@@ -82,4 +82,25 @@ export class Child extends Entity {
     return this.name;
   }
 
+  getClassAsNumber() {
+    if (this.schoolClass === undefined || this.schoolClass === '') {
+      return undefined;
+    }
+
+    if (this.schoolClass.toUpperCase().startsWith('KG')) {
+      return 0;
+    } else {
+      return parseInt(this.schoolClass, 10);
+    }
+  }
+
+
+
+  public load(data: any) {
+    if (data.schoolClass !== undefined) {
+      data.schoolClass = data.schoolClass.toString();
+    }
+
+    return super.load(data);
+  }
 }

--- a/src/app/children/children.module.ts
+++ b/src/app/children/children.module.ts
@@ -52,6 +52,7 @@ import { ChildSelectComponent } from './child-select/child-select.component';
 import {SchoolsModule} from '../schools/schools.module';
 import { EducationalMaterialComponent } from './educational-material/educational-material.component';
 import {AserComponent} from './aser/aser.component';
+import { AserBlockComponent } from './aser/aser-block/aser-block.component';
 
 
 @NgModule({
@@ -93,6 +94,7 @@ import {AserComponent} from './aser/aser.component';
     ChildSelectComponent,
     EducationalMaterialComponent,
     AserComponent,
+    AserBlockComponent,
   ],
   providers: [ChildrenService, DatePipe, PercentPipe],
   exports: [

--- a/src/app/children/children.module.ts
+++ b/src/app/children/children.module.ts
@@ -52,7 +52,10 @@ import { ChildSelectComponent } from './child-select/child-select.component';
 import {SchoolsModule} from '../schools/schools.module';
 import { EducationalMaterialComponent } from './educational-material/educational-material.component';
 import {AserComponent} from './aser/aser.component';
+import { CoachingPlannerComponent } from './coaching-planner/coaching-planner.component';
 import { AserBlockComponent } from './aser/aser-block/aser-block.component';
+import {NgDragDropModule} from 'ng-drag-drop';
+import {FilterPipeModule} from 'ngx-filter-pipe';
 
 
 @NgModule({
@@ -77,6 +80,8 @@ import { AserBlockComponent } from './aser/aser-block/aser-block.component';
     MatDialogModule,
     MatAutocompleteModule,
     ReactiveFormsModule,
+    NgDragDropModule.forRoot(),
+    FilterPipeModule,
     UiHelperModule,
     SchoolsModule,
   ],
@@ -94,6 +99,7 @@ import { AserBlockComponent } from './aser/aser-block/aser-block.component';
     ChildSelectComponent,
     EducationalMaterialComponent,
     AserComponent,
+    CoachingPlannerComponent,
     AserBlockComponent,
   ],
   providers: [ChildrenService, DatePipe, PercentPipe],

--- a/src/app/children/coaching-planner/coaching-planner.component.html
+++ b/src/app/children/coaching-planner/coaching-planner.component.html
@@ -2,6 +2,10 @@
   Coaching Planner
 </h1>
 
+<p class='dev-notice'>
+  This feature is currently only a preview. Saving changes and other functionalities are not available yet.
+</p>
+
 <div fxLayout='row' fxLayoutGap='10px'>
   <div fxFlex='30' class='coaching-container' *ngFor='let container of containers'
        droppable (onDrop)="doDrop($event, container)">

--- a/src/app/children/coaching-planner/coaching-planner.component.html
+++ b/src/app/children/coaching-planner/coaching-planner.component.html
@@ -1,0 +1,25 @@
+<h1>
+  Coaching Planner
+</h1>
+
+<div fxLayout='row' fxLayoutGap='10px'>
+  <div fxFlex='30' class='coaching-container' *ngFor='let container of containers'
+       droppable (onDrop)="doDrop($event, container)">
+
+    <p>{{(children | filterBy: {'container': container})?.length}} students</p>
+
+    <mat-card *ngFor="let child of children | filterBy: {'container': container}" draggable [dragData]='child'>
+      <mat-card-header>
+        <app-child-block [entity]='child'></app-child-block>
+      </mat-card-header>
+      <mat-card-content>
+        <p>class {{child.schoolClass}}, {{child.getAge()}} years</p>
+        <p><app-aser-block [entity]='child.lastAser'></app-aser-block></p>
+      </mat-card-content>
+    </mat-card>
+
+  </div>
+  <div fxFlex='10' droppable (onDrop)='doDrop($event, "")' class='coaching-container-hide'>
+
+  </div>
+</div>

--- a/src/app/children/coaching-planner/coaching-planner.component.scss
+++ b/src/app/children/coaching-planner/coaching-planner.component.scss
@@ -1,0 +1,7 @@
+.coaching-container {
+  border: 1px black;
+  background-color: lightgray;
+}
+.coaching-container-hide {
+  background-color: lightpink;
+}

--- a/src/app/children/coaching-planner/coaching-planner.component.spec.ts
+++ b/src/app/children/coaching-planner/coaching-planner.component.spec.ts
@@ -1,0 +1,37 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CoachingPlannerComponent } from './coaching-planner.component';
+import {FilterPipeModule} from 'ngx-filter-pipe';
+import {MatCardModule, MatIconModule} from '@angular/material';
+import {NgDragDropModule} from 'ng-drag-drop';
+import {ChildBlockComponent} from '../child-block/child-block.component';
+import {AserBlockComponent} from '../aser/aser-block/aser-block.component';
+import {SchoolBlockComponent} from '../../schools/school-block/school-block.component';
+import {ChildrenService} from '../children.service';
+import {EntityMapperService} from '../../entity/entity-mapper.service';
+import {Database} from '../../database/database';
+import {MockDatabase} from '../../database/mock-database';
+
+describe('CoachingPlannerComponent', () => {
+  let component: CoachingPlannerComponent;
+  let fixture: ComponentFixture<CoachingPlannerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CoachingPlannerComponent, ChildBlockComponent, AserBlockComponent, SchoolBlockComponent ],
+      imports: [ FilterPipeModule, MatCardModule, NgDragDropModule.forRoot(), MatIconModule ],
+      providers: [ChildrenService, EntityMapperService, { provide: Database, useClass: MockDatabase }],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CoachingPlannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/children/coaching-planner/coaching-planner.component.ts
+++ b/src/app/children/coaching-planner/coaching-planner.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit } from '@angular/core';
+import {ChildrenService} from '../children.service';
+import {Aser} from '../aser/aser';
+import {EntityMapperService} from '../../entity/entity-mapper.service';
+
+@Component({
+  selector: 'app-coaching-planner',
+  templateUrl: './coaching-planner.component.html',
+  styleUrls: ['./coaching-planner.component.scss']
+})
+export class CoachingPlannerComponent implements OnInit {
+
+  children: any[];
+  containers = ['A', 'B', 'C'];
+
+  constructor(private childrenService: ChildrenService) { }
+
+  ngOnInit() {
+    this.childrenService.getChildren()
+      .subscribe(results => {
+        this.children = this.initChildren(results);
+      });
+  }
+
+  private initChildren(results) {
+    results = results.filter(c => c.isActive());
+
+    // TODO: proper filtering with UI
+    results = results.filter(c => c.center === 'Liluah');
+    results = results.filter(c => c.getClassAsNumber() < 9);
+
+    results.forEach(r => {
+      r.container = 'A';
+      this.childrenService.getAserResultsOfChild(r.getId())
+        .subscribe(asers => this.initLatestASER(r, asers));
+    });
+
+    return results;
+  }
+
+  private initLatestASER(child, asers: Aser[]) {
+    asers = asers.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+    if (asers.length === 0) {
+      child.lastAser = new Aser('');
+    } else {
+      child.lastAser = asers[0];
+    }
+  }
+
+
+  doDrop(event, container) {
+    console.log(event);
+    event.dragData.container = container;
+  }
+
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,3 +116,12 @@ td.mat-cell, td.mat-footer-cell, th.mat-header-cell {
 .w-URGENT {
   background-color: #fd727280;
 }
+
+
+.dev-notice {
+  padding: 10px;
+  background-color: red;
+  font-style: italic;
+  color: white;
+  font-weight: bold;
+}


### PR DESCRIPTION
_development on this is currently on hold as other issues and features have higher priority_

### Visible/Frontend Changes
- [x] New page and menu entry `/coachings`
- [x] Cards displaying the educational details of each child.
- [x] Drag&Drop UI to move around children on the screen, assigning them to different sections.
- [ ] Filter tools to limit the displayed children to a certain center, school or class range.

### Architectural/Backend Changes
- [ ] possibility to save the drag&drop assignment of children
