### PR TITLE
Fix saving of children

### DIFF
--- a/src/app/children/child-details/child-details.component.ts
+++ b/src/app/children/child-details/child-details.component.ts
@@ -144,12 +144,13 @@ export class ChildDetailsComponent implements OnInit {
   }
 
   save() {
-    this.assignFormValuesToChild(this.child, this.form);
+    const child = this.child.getChild();
+    this.assignFormValuesToChild(child, this.form);
 
-    this.entityMapperService.save<Child>(this.child)
+    this.entityMapperService.save<Child>(child)
       .then(() => {
         if (this.creatingNew) {
-          this.router.navigate(['/child', this.child.getId()]);
+          this.router.navigate(['/child', child.getId()]);
           this.creatingNew = false;
         }
         this.switchEdit();


### PR DESCRIPTION
see issue: #302 

An error occured because of the wrong usage of the `ChildWithRelation` class. The class was saved to the database which is not what the class is ment for. This was changed to only save the `Child`-Object withing the `ChildWithRelation` object.
