### PR TITLE
Reflect metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-browser": "7.0.x",
     "raven-js": "^3.27.1",
+    "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.2",
     "stream": "0.0.2",
     "uniqid": "^5.0.3",

--- a/src/app/children/aser/aser.ts
+++ b/src/app/children/aser/aser.ts
@@ -69,19 +69,19 @@ export class Aser extends Entity {
   date: Date = new Date();
 
   @DatabaseField('string=')
-  hindi = '';
+  hindi: string = '';
 
   @DatabaseField('string=')
-  bengali = '';
+  bengali: string = '';
 
   @DatabaseField('string=')
-  english = '';
+  english: string = '';
 
   @DatabaseField('string=')
-  math = '';
+  math: string = '';
 
   @DatabaseField('string')
-  remarks = '';
+  remarks: string = '';
 
 
   getWarningLevel (): WarningLevel {

--- a/src/app/entity/database-field.decorator.ts
+++ b/src/app/entity/database-field.decorator.ts
@@ -1,16 +1,21 @@
 import 'reflect-metadata'
+import {SchemaFieldOptions} from './schema/entity-schema';
+
 /**
  * Decorator (Annotation `@DatabaseEntity()`) to set the string ENTITY_TYPE to an Entity Type.
  * Note: Property decorators are called before class decorators.
  * @param fieldSchema The schema definition for this property.
+ * @param arrayType (optional) needs to be provided if property is an array.
  */
-import {SchemaFieldOptions} from './schema/entity-schema';
-
-export function DatabaseField(dataType: string, options: SchemaFieldOptions = {}) {
+export function DatabaseField(dataType: string, options: SchemaFieldOptions = {}, arrayType = '') {
   return (targetEntity, property: string) => {
-    let design =  Reflect.getMetadata('design:type', targetEntity, property);
-    let types =  Reflect.getMetadata('design:paramtypes', targetEntity, property);
-    console.log('design', design, 'types', types);
+    let expDataType = Reflect.getMetadata('design:type', targetEntity, property).name.toLowerCase();
+    if (expDataType === 'array') {
+        expDataType = arrayType;
+        options['isArray'] = true;
+    }
+    console.log('property', property, 'name', expDataType);
+
     // Adding a dummy object to store the schemas // TODO: document why "localSchema" is needed
     if (!targetEntity.constructor.hasOwnProperty('localSchema')) {
       targetEntity.constructor.localSchema = {};

--- a/src/app/entity/database-field.decorator.ts
+++ b/src/app/entity/database-field.decorator.ts
@@ -1,4 +1,4 @@
-
+import 'reflect-metadata'
 /**
  * Decorator (Annotation `@DatabaseEntity()`) to set the string ENTITY_TYPE to an Entity Type.
  * Note: Property decorators are called before class decorators.
@@ -6,7 +6,9 @@
  */
 export function DatabaseField(fieldSchema: string) {
   return (targetEntity, property: string) => {
-
+    let design =  Reflect.getMetadata('design:type', targetEntity, property);
+    let types =  Reflect.getMetadata('design:paramtypes', targetEntity, property);
+    console.log('design', design, 'types', types);
     // Adding a dummy object to store the schemas // TODO: document why "localSchema" is needed
     if (!targetEntity.constructor.hasOwnProperty('localSchema')) {
       targetEntity.constructor.localSchema = {};


### PR DESCRIPTION
Added the `reflect-metadata` API to get decorators the ability to retrieve type info of the decorated properties.