### PR TITLE
Add a `Back` button to the final view of the attendance-addition form

### DIFF
--- a/src/app/children/attendance/add-day-attendance/add-day-attendance.component.html
+++ b/src/app/children/attendance/add-day-attendance/add-day-attendance.component.html
@@ -93,7 +93,8 @@
   <div *ngIf='!rollCallListLoading && rollCallIndex>=rollCallList.length'>
     <div>Roll call completed.</div>
     <div>
-      <button mat-stroked-button (click)='currentStage = 0' class='nav-button' fxFlex>Finish</button>
+      <button mat-stroked-button (click)='currentStage = 0' class='nav-button' fxFlex><b>Finish</b></button>
+      <button mat-stroked-button (click)='rollCallIndex = rollCallIndex - 1' class='nav-button' fxFlex>Back</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
See issue #331 

### Visible/Frontend Changes

- [x] Added a `back` button to the final view of the attendance-addition list. This can be used to correct wrong data entered for the last child.
- [x] "Boldified" the `Finish` button to make it visually different to the `Back` button.

### Architectural/Backend Changes

*n/a*
