### PR TITLE
Change html to not overlap bottom screen

### DIFF
--- a/src/app/ui/ui/ui.component.css
+++ b/src/app/ui/ui/ui.component.css
@@ -35,7 +35,7 @@ app-ui {
   left: 0;
   right: 0;
   bottom: 0;
-  padding-bottom: 30px;
+  /* padding-bottom: 30px; */
 }
 
 .sidenav-menu {

--- a/src/app/ui/ui/ui.component.css
+++ b/src/app/ui/ui/ui.component.css
@@ -54,7 +54,7 @@ app-ui {
 
 .sidenav-content {
   padding: 24px;
-  overflow: scroll;
+  /* overflow: scroll; */
 }
 /* reduce padding for content when screen size is too small */
 @media (max-width: 599px) {

--- a/src/app/ui/ui/ui.component.html
+++ b/src/app/ui/ui/ui.component.html
@@ -53,9 +53,11 @@
 
 
 
-  <mat-sidenav-content class="sidenav-content">
-    <router-outlet *ngIf="isLoggedIn()"></router-outlet>
-    <app-login *ngIf="!isLoggedIn()"></app-login>
+  <mat-sidenav-content>
+    <div class="sidenav-content">
+      <router-outlet *ngIf="isLoggedIn()"></router-outlet>
+      <app-login *ngIf="!isLoggedIn()"></app-login>
+    </div>
   </mat-sidenav-content>
 
 


### PR DESCRIPTION
see issue: #252 

By wrapping the contents of the `<mat-sidenav-content>` element into a div, we now have a scrollable `<mat-sidenav-content>` whose contents can be padded correctly:
```diff
- <mat-sidenav-content class="sidenav-content">
+ <mat-sidenav-content>
+   <div class="sidenav-content">
      <router-outlet *ngIf="isLoggedIn()"></router-outlet>
      <app-login *ngIf="!isLoggedIn()"></app-login>
+   </div>
  </mat-sidenav-content>
```

I hope this changes are not too hacky.
