### PR TITLE
Show recently added note after creation

### DIFF
--- a/src/app/children/notes/notes-manager/notes-manager.component.ts
+++ b/src/app/children/notes/notes-manager/notes-manager.component.ts
@@ -135,11 +135,18 @@ export class NotesManagerComponent implements OnInit, AfterViewInit {
     newNote.date = new Date();
     newNote.author = this.sessionService.getCurrentUser().name;
 
-    this.showDetails(newNote);
+    this.showDetails(newNote, true);
   }
 
 
-  showDetails(entity: Note) {
-    this.dialog.open(NoteDetailsComponent, {width: '80%', data: {entity: entity}});
+  showDetails(entity: Note, newNote: boolean = false) {
+    const nextNote = this.dialog.open(NoteDetailsComponent, {width: '80%', data: {entity: entity}});
+
+    if (newNote) {
+      nextNote.afterClosed().subscribe(val => {
+        this.entityList = [val].concat(this.entityList);
+        this.applyFilterSelections();
+      });
+    }
   }
 }


### PR DESCRIPTION
When adding a new Note, it appears in the list of notes immediately
after saving.

see issue: #328

### Visible/Frontend Changes
- [x] Note appears in the full list after it was created

### Architectural/Backend Changes
- [ ] *n/a*
