### PR TITLE
Don't lint `ndb-core-e2e`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
-    "lint": "ng lint ndb-core ndb-core-e2e --type-check",
+    "lint": "ng lint ndb-core --type-check",
     "e2e": "ng e2e",
     "compodoc": "npx compodoc -c doc/compodoc_sources/.compodocrc.json"
   },


### PR DESCRIPTION
It doesn't have a sourceRoot specified and `ng lint` doesn't support
multiple projects in a single command, so the removal should be fine for
now.

Fixes #380