### PR TITLE
Bug fixes and improvements to AttendanceDay

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.html
@@ -3,15 +3,10 @@
 
 
 <div *ngIf='currentStage===0' fxLayout='column' fxLayoutAlign='space-around start'>
-  <mat-form-field fxFlex>
-    <mat-label>
-      Center
-    </mat-label>
-    <mat-select [(ngModel)]='center'>
-      <mat-option *ngFor="let c of centers" [value]='c'>
-        {{c}}
-      </mat-option>
-    </mat-select>
+  <mat-form-field>
+    <input matInput placeholder="Date" [value]='day' (dateChange)='day=$event.target.value' [matDatepicker]="addDayAttendanceDatepicker">
+    <mat-datepicker-toggle matSuffix [for]="addDayAttendanceDatepicker"></mat-datepicker-toggle>
+    <mat-datepicker #addDayAttendanceDatepicker></mat-datepicker>
   </mat-form-field>
 
   <div class='form-field' fxFlex>
@@ -21,82 +16,27 @@
     </mat-button-toggle-group>
   </div>
 
-  <mat-form-field>
-    <input matInput placeholder="Date" [value]='day' (dateChange)='day=$event.target.value' [matDatepicker]="addDayAttendanceDatepicker">
-    <mat-datepicker-toggle matSuffix [for]="addDayAttendanceDatepicker"></mat-datepicker-toggle>
-    <mat-datepicker #addDayAttendanceDatepicker></mat-datepicker>
-  </mat-form-field>
-
-  <div fxFlex>
-    <button mat-stroked-button (click)='finishCenterSelection()'
-            [disabled]='!center || !attendanceType || !day'>
-      Continue
-    </button>
-  </div>
+  <button mat-stroked-button (click)='finishBasicInformationStage()' [disabled]='!attendanceType || !day' fxFlex>
+    Continue
+  </button>
 </div>
 
 
 <div *ngIf='currentStage===1' fxLayout='column'>
-  <div *ngFor="let group of studentGroups.options" class='group-select-option' (click)='startRollCall(group)'>
-    <span style='text-align: right' class='fa fa-chevron-right'></span>&nbsp;
-    <span *ngIf='!group.type'>{{group.label}}</span>
-    <app-school-block *ngIf="group.type==='school'" [entityId]='group.label' [linkDisabled]='true'></app-school-block>
-  </div>
+  <app-select-group-children (valueChange)='finishStudentSelectionStage($event)'>
+  </app-select-group-children>
 
-  <div>
-    <button mat-stroked-button (click)='currentStage = currentStage - 1' class='nav-button' fxFlex>Back</button>
-  </div>
+
+  <button mat-stroked-button (click)='currentStage = currentStage - 1' class='nav-button' fxFlex>
+    Back
+  </button>
 </div>
 
 
 
 
 <div *ngIf='currentStage===2'>
-  <div *ngFor='let entry of rollCallList; let i = index' [ngClass]='{"hidden": (rollCallIndex!==i)}'>
-    <app-child-block [entity]='entry.child'></app-child-block>
-
-    <div fxLayout='column' fxLayoutAlign='space-between stretch' class='options-wrapper'>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.PRESENT)' [ngClass]="{'attendance-P': entry.attendanceDay.status===AttStatus.PRESENT}">
-        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.PRESENT'></span>
-        Present
-      </div>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.ABSENT)' [ngClass]="{'attendance-A': entry.attendanceDay.status===AttStatus.ABSENT}">
-        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.ABSENT'></span>
-        Absent
-      </div>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.LATE)' [ngClass]="{'attendance-L': entry.attendanceDay.status===AttStatus.LATE}">
-        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.LATE'></span>
-        Late
-      </div>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.HOLIDAY)' [ngClass]="{'attendance-H': entry.attendanceDay.status===AttStatus.HOLIDAY}">
-        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.HOLIDAY'></span>
-        Holiday
-      </div>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.EXCUSED)' [ngClass]="{'attendance-E': entry.attendanceDay.status===AttStatus.EXCUSED}">
-        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.EXCUSED'></span>
-        Excused
-      </div>
-      <div class='group-select-option' (click)='markAttendance(AttStatus.UNKNOWN)' [ngClass]="{'attendance-U': entry.attendanceDay.status===AttStatus.UNKNOWN}">Skip</div>
-    </div>
-
-    <div>
-      <button mat-stroked-button [disabled]='rollCallIndex<1' (click)='rollCallIndex = rollCallIndex - 1' class='nav-button'>Back</button>
-      <button mat-stroked-button (click)='currentStage = 0' class='nav-button'>Abort</button>
-    </div>
-  </div>
-
-
-  <div *ngIf='rollCallListLoading'>
-    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-    <div>Loading students ...</div>
-  </div>
-
-
-  <div *ngIf='!rollCallListLoading && rollCallIndex>=rollCallList.length'>
-    <div>Roll call completed.</div>
-    <div>
-      <button mat-stroked-button (click)='currentStage = 0' class='nav-button' fxFlex><b>Finish</b></button>
-      <button mat-stroked-button (click)='rollCallIndex = rollCallIndex - 1' class='nav-button' fxFlex>Back</button>
-    </div>
-  </div>
+  <app-roll-call [day]='day' [attendanceType]='attendanceType' [students]='students'
+                 (complete)='finishRollCallState()'>
+  </app-roll-call>
 </div>

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.scss
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.scss
@@ -2,28 +2,7 @@
   padding-bottom: 17px;
 }
 
-.group-select-option {
-  width: 100%;
-  padding: 16px;
-  cursor: pointer;
-  box-sizing: border-box;
-  border: 1px solid;
-  border-top: 0;
-}
-
-.group-select-option:first-child {
-  border-top: 1px solid;
-}
-
-.options-wrapper {
-  margin-top: 16px;
-}
-
 .nav-button {
   margin: 10px;
   flex: none;
-}
-
-.hidden {
-  display: none;
 }

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.spec.ts
@@ -1,22 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AddDayAttendanceComponent } from './add-day-attendance.component';
-import { MatButtonModule } from '@angular/material/button';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatSelectModule } from '@angular/material/select';
-import { FormsModule } from '@angular/forms';
-import { SchoolBlockComponent } from '../../schools/school-block/school-block.component';
-import { ChildBlockComponent } from '../../children/child-block/child-block.component';
 import { ChildrenService } from '../../children/children.service';
 import { Database } from '../../../core/database/database';
 import { MockDatabase } from '../../../core/database/mock-database';
-import { EntityModule } from '../../../core/entity/entity.module';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatDatepickerModule } from '@angular/material/datepicker';
+import { ChildrenModule } from '../../children/children.module';
+import { SchoolsModule } from '../../schools/schools.module';
 import { MatNativeDateModule } from '@angular/material/core';
 
 describe('AddDayAttendanceComponent', () => {
@@ -25,10 +14,11 @@ describe('AddDayAttendanceComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AddDayAttendanceComponent, SchoolBlockComponent, ChildBlockComponent ],
-      imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatButtonToggleModule,
-        MatIconModule, MatProgressBarModule, MatDatepickerModule, MatNativeDateModule, NoopAnimationsModule,
-        EntityModule],
+      imports: [
+        ChildrenModule,
+        SchoolsModule,
+        MatNativeDateModule,
+      ],
       providers: [
         {provide: ChildrenService, useClass: ChildrenService},
         {provide: Database, useClass: MockDatabase},

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
@@ -1,9 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { ChildrenService } from '../../children/children.service';
-import { FilterSelection } from '../../../core/ui-helper/filter-selection/filter-selection';
-import { EntityMapperService } from '../../../core/entity/entity-mapper.service';
-import { AttendanceDay, AttendanceStatus } from '../model/attendance-day';
-import { AttendanceMonth } from '../model/attendance-month';
+import { Component } from '@angular/core';
 import { Child } from '../../children/model/child';
 
 @Component({
@@ -11,111 +6,34 @@ import { Child } from '../../children/model/child';
   templateUrl: './add-day-attendance.component.html',
   styleUrls: ['./add-day-attendance.component.scss'],
 })
-export class AddDayAttendanceComponent implements OnInit {
+export class AddDayAttendanceComponent {
 
   currentStage = 0;
+
   day = new Date();
   attendanceType: string;
-  center: string;
-  studentGroups = new FilterSelection<Child>('Groups', [
-    { key: 'all', label: 'All Students', filterFun: (c: Child) => c.center === this.center},
-    ]);
-  rollCallList: {child: Child, attendanceDay: AttendanceDay, attendanceMonth: AttendanceMonth}[] = [];
-  rollCallIndex = 0;
-  rollCallListLoading;
-
-  centers: string[];
-  children: Child[];
+  students: Child[] = [];
 
   stages = [
-    'Select Center',
+    'Setup Roll Call',
     'Select Student Group',
     'Roll Call',
   ];
-  AttStatus = AttendanceStatus;
 
-  constructor(private childrenService: ChildrenService,
-              private entityMapper: EntityMapperService) { }
-
-  ngOnInit() {
-    this.childrenService.getChildren().subscribe(children => {
-      this.children = children.filter(c => c.isActive());
-      this.centers = this.children.map(c => c.center).filter((value, index, arr) => arr.indexOf(value) === index);
-    });
-  }
+  constructor() { }
 
 
-  finishCenterSelection() {
-    this.studentGroups.options.splice(1);
-
-    this.children
-      .filter(c => c.center === this.center)
-      .map(c => c.schoolId).filter((value, index, arr) => arr.indexOf(value) === index)
-      .forEach(schoolId => {
-        const filterOption = {
-          key: schoolId,
-          label: schoolId,
-          type: 'school',
-          filterFun: (c: Child) => c.schoolId === schoolId,
-        };
-        this.studentGroups.options.push(filterOption);
-      });
-
+  finishBasicInformationStage() {
     this.currentStage = 1;
   }
 
-
-  async startRollCall(group) {
-    const selectedChildren = this.children.filter(group.filterFun);
+  finishStudentSelectionStage(selectedStudents: Child[]) {
+    this.students = selectedStudents;
 
     this.currentStage = 2;
-    this.rollCallList = [];
-    this.rollCallListLoading = true;
-
-    const attendances = await this.childrenService.getAttendancesOfMonth(this.day).toPromise();
-    this.loadMonthAttendanceRecords(selectedChildren, attendances);
-    this.sortRollCallList();
-
-    this.rollCallListLoading = false;
   }
 
-  private loadMonthAttendanceRecords(children: Child[], monthsAttendances: AttendanceMonth[]) {
-    this.rollCallIndex = 0;
-
-    children.forEach(child => {
-      let attMonth: AttendanceMonth = monthsAttendances.find(a => a.student === child.getId() && a.institution === this.attendanceType);
-      if (attMonth === undefined) {
-        attMonth = AttendanceMonth.createAttendanceMonth(child.getId(), this.attendanceType);
-        attMonth.month = new Date(this.day.getTime());
-      }
-
-      const attDay = attMonth.dailyRegister.find(d => d.date.getDate() === this.day.getDate()
-        && d.date.getMonth() === this.day.getMonth() && d.date.getFullYear() === this.day.getFullYear());
-
-      this.rollCallList.push({child: child, attendanceMonth: attMonth, attendanceDay: attDay});
-    });
-  }
-
-  private sortRollCallList() {
-    interface RollCallEntry { child: Child; attendanceMonth: AttendanceMonth; attendanceDay: AttendanceDay; }
-    this.rollCallList.sort((a: RollCallEntry, b: RollCallEntry) => {
-      const diff = parseInt(a.child.schoolClass, 10) - parseInt(b.child.schoolClass, 10);
-      if (!isNaN(diff)) {
-        return diff;
-      }
-
-      if (a.child.schoolClass > b.child.schoolClass) { return 1; }
-      if (a.child.schoolClass < b.child.schoolClass) { return -1; }
-      return 0;
-    });
-  }
-
-
-  markAttendance(status: AttendanceStatus) {
-    const rollCallListEntry = this.rollCallList[this.rollCallIndex];
-    rollCallListEntry.attendanceDay.status = status;
-    this.entityMapper.save(rollCallListEntry.attendanceMonth);
-
-    setTimeout(() => this.rollCallIndex++, 750);
+  finishRollCallState() {
+    this.currentStage = 0;
   }
 }

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
@@ -86,7 +86,7 @@ export class AddDayAttendanceComponent implements OnInit {
       let attMonth: AttendanceMonth = monthsAttendances.find(a => a.student === child.getId() && a.institution === this.attendanceType);
       if (attMonth === undefined) {
         attMonth = AttendanceMonth.createAttendanceMonth(child.getId(), this.attendanceType);
-        attMonth.month = this.day;
+        attMonth.month = new Date(this.day.getTime());
       }
 
       const attDay = attMonth.dailyRegister.find(d => d.date.getDate() === this.day.getDate()

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call-record.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call-record.ts
@@ -1,0 +1,9 @@
+import { Child } from '../../../children/model/child';
+import { AttendanceDay } from '../../model/attendance-day';
+import { AttendanceMonth } from '../../model/attendance-month';
+
+export interface RollCallRecord {
+  child: Child;
+  attendanceDay: AttendanceDay;
+  attendanceMonth: AttendanceMonth;
+}

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
@@ -1,0 +1,76 @@
+<div *ngIf='isLoading'>
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  <div>Loading attendance list ...</div>
+</div>
+
+<div *ngIf='!isLoading'>
+
+  <!-- Individual Student's Page -->
+  <div *ngFor='let entry of rollCallList; let i = index' [ngClass]='{"hidden": (currentIndex!==i)}'>
+    <app-child-block [entity]='entry.child'></app-child-block>
+
+    <div fxLayout='column' fxLayoutAlign='space-between stretch' class='options-wrapper'>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.PRESENT)'
+           [ngClass]="{'attendance-P': entry.attendanceDay.status===AttStatus.PRESENT}">
+        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.PRESENT'></span>
+        Present
+      </div>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.ABSENT)'
+           [ngClass]="{'attendance-A': entry.attendanceDay.status===AttStatus.ABSENT}">
+        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.ABSENT'></span>
+        Absent
+      </div>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.LATE)'
+           [ngClass]="{'attendance-L': entry.attendanceDay.status===AttStatus.LATE}">
+        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.LATE'></span>
+        Late
+      </div>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.HOLIDAY)'
+           [ngClass]="{'attendance-H': entry.attendanceDay.status===AttStatus.HOLIDAY}">
+        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.HOLIDAY'></span>
+        Holiday
+      </div>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.EXCUSED)'
+           [ngClass]="{'attendance-E': entry.attendanceDay.status===AttStatus.EXCUSED}">
+        <span class='fa fa-check' *ngIf='entry.attendanceDay.status===AttStatus.EXCUSED'></span>
+        Excused
+      </div>
+      <div class='group-select-option'
+           (click)='markAttendance(AttStatus.UNKNOWN)'
+           [ngClass]="{'attendance-U': entry.attendanceDay.status===AttStatus.UNKNOWN}">
+        Skip
+      </div>
+    </div>
+
+  </div>
+
+
+  <!-- Completion Page -->
+  <div *ngIf='isFinished()' class='roll-call-complete' [@completeRollCall]>
+    <span class='fa fa-check-circle-o roll-call-complete-icon'></span><br>
+    Roll call completed.
+  </div>
+
+
+  <!-- Control Buttons -->
+  <div>
+    <button mat-stroked-button [disabled]='currentIndex < 1' (click)='currentIndex = currentIndex - 1'
+            class='nav-button' fxFlex>
+      Back
+    </button>
+
+    <button mat-stroked-button *ngIf='!isFinished()' (click)='endRollCall()' class='nav-button' fxFlex>
+      Abort
+    </button>
+
+    <button mat-stroked-button *ngIf='isFinished()' (click)='endRollCall()' class='nav-button' fxFlex>
+      <b>Finish</b>
+    </button>
+  </div>
+
+</div>

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.scss
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.scss
@@ -1,0 +1,39 @@
+
+.group-select-option {
+  width: 100%;
+  padding: 16px;
+  cursor: pointer;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-top: 0;
+}
+
+.group-select-option:first-child {
+  border-top: 1px solid;
+}
+
+.options-wrapper {
+  margin-top: 16px;
+}
+
+.hidden {
+  display: none;
+}
+
+.nav-button {
+  margin: 10px;
+  flex: none;
+}
+
+.roll-call-complete {
+  text-align: center;
+  line-height: 2em;
+
+  padding: 20px 0;
+
+  background-color: #C8E6C9;
+  border-radius: 5px;
+}
+.roll-call-complete-icon {
+  font-size: 40px;
+}

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -1,0 +1,141 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RollCallComponent } from './roll-call.component';
+import { ChildrenModule } from '../../../children/children.module';
+import { EntityMapperService } from '../../../../core/entity/entity-mapper.service';
+import { ChildrenService } from '../../../children/children.service';
+import { Child } from '../../../children/model/child';
+import { of } from 'rxjs';
+import { AttendanceMonth } from '../../model/attendance-month';
+import { AttendanceStatus } from '../../model/attendance-day';
+
+describe('RollCallComponent', () => {
+  let component: RollCallComponent;
+  let fixture: ComponentFixture<RollCallComponent>;
+
+  let mockEntityMapper;
+  let mockChildrenService;
+
+  beforeEach(async(() => {
+    mockEntityMapper = jasmine.createSpyObj(['save']);
+    mockChildrenService = jasmine.createSpyObj(['getAttendancesOfMonth']);
+
+    TestBed.configureTestingModule({
+      imports: [
+        ChildrenModule,
+      ],
+      providers: [
+        { provide: EntityMapperService, useValue: mockEntityMapper },
+        { provide: ChildrenService, useValue: mockChildrenService },
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RollCallComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+
+  it('should load correct list of attendance on init', async () => {
+    const testStudents = [
+      new Child('1'),
+      new Child('2'),
+    ];
+    const testAttendanceType = 'coaching';
+    const testDate = new Date('2020-01-05');
+
+    const testAttendances = [
+      new AttendanceMonth('a1'),
+      new AttendanceMonth('a2'),
+      new AttendanceMonth('a3'),
+      new AttendanceMonth('a4'),
+    ];
+    testAttendances[0].month = new Date('2020-01-02');
+    testAttendances[0].student = '1';
+    testAttendances[0].institution = testAttendanceType;
+    testAttendances[1].month = new Date('2020-01-02');
+    testAttendances[1].student = '2';
+    testAttendances[1].institution = testAttendanceType;
+    testAttendances[2].month = new Date('2020-01-02');
+    testAttendances[2].student = '2';
+    testAttendances[2].institution = 'school';
+    testAttendances[3].month = new Date('2020-01-02');
+    testAttendances[3].student = '3';
+    testAttendances[3].institution = testAttendanceType;
+
+    mockChildrenService.getAttendancesOfMonth.and.returnValue(of(testAttendances));
+
+    component.students = testStudents;
+    component.attendanceType = testAttendanceType;
+    component.day = testDate;
+    await component.ngOnInit();
+
+    expect(component.isLoading).toBe(false);
+    expect(component.rollCallList).toEqual([
+      { attendanceMonth: testAttendances[0], attendanceDay: testAttendances[0].dailyRegister[4], child: testStudents[0] },
+      { attendanceMonth: testAttendances[1], attendanceDay: testAttendances[1].dailyRegister[4], child: testStudents[1] },
+    ]);
+    expect(component.rollCallList[0].attendanceDay.date).toEqual(testDate);
+  });
+
+
+  it('should create new attendance records if none exist', async () => {
+    const testStudents = [
+      new Child('1'),
+    ];
+    const testAttendanceType = 'coaching';
+    const testDate = new Date('2020-01-05');
+
+    const testAttendances = [];
+
+    mockChildrenService.getAttendancesOfMonth.and.returnValue(of(testAttendances));
+
+    component.students = testStudents;
+    component.attendanceType = testAttendanceType;
+    component.day = testDate;
+    await component.ngOnInit();
+
+    expect(component.isLoading).toBe(false);
+    expect(component.rollCallList.length).toBe(1);
+    expect(component.rollCallList[0].child).toBe(testStudents[0]);
+    expect(component.rollCallList[0].attendanceMonth.institution).toBe(testAttendanceType);
+    expect(component.rollCallList[0].attendanceMonth.month.getFullYear()).toEqual(testDate.getFullYear());
+    expect(component.rollCallList[0].attendanceMonth.month.getMonth()).toEqual(testDate.getMonth());
+  });
+
+
+  it('should save entity when marking attendance', async () => {
+    const testStudents = [
+      new Child('1'),
+    ];
+    const testAttendanceType = 'coaching';
+    const testDate = new Date('2020-01-05');
+
+    const testAttendances = [
+      new AttendanceMonth('a1'),
+    ];
+    testAttendances[0].month = new Date('2020-01-02');
+    testAttendances[0].student = '1';
+    testAttendances[0].institution = testAttendanceType;
+
+    mockChildrenService.getAttendancesOfMonth.and.returnValue(of(testAttendances));
+
+    component.students = testStudents;
+    component.attendanceType = testAttendanceType;
+    component.day = testDate;
+    await component.ngOnInit();
+
+    component.markAttendance(AttendanceStatus.PRESENT);
+
+    expect(mockEntityMapper.save).toHaveBeenCalledWith(testAttendances[0]);
+    expect(testAttendances[0].dailyRegister[4].status).toBe(AttendanceStatus.PRESENT);
+  });
+});

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -19,6 +19,7 @@ describe('RollCallComponent', () => {
   beforeEach(async(() => {
     mockEntityMapper = jasmine.createSpyObj(['save']);
     mockChildrenService = jasmine.createSpyObj(['getAttendancesOfMonth']);
+    mockChildrenService.getAttendancesOfMonth.and.returnValue(of([]));
 
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -50,7 +50,9 @@ describe('RollCallComponent', () => {
       new Child('2'),
     ];
     const testAttendanceType = 'coaching';
+
     const testDate = new Date('2020-01-05');
+    testDate.setHours(0); // reset hours to avoid mismatch with AttendanceMonth dates constructed as utc
 
     const testAttendances = [
       new AttendanceMonth('a1'),
@@ -92,6 +94,7 @@ describe('RollCallComponent', () => {
       new Child('1'),
     ];
     const testAttendanceType = 'coaching';
+
     const testDate = new Date('2020-01-05');
 
     const testAttendances = [];

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -39,7 +39,7 @@ export class RollCallComponent implements OnInit {
   /**
    * The children for whom attendance will be recorded
    */
-  @Input() students: Child[];
+  @Input() students: Child[] = [];
 
   /**
    * Event emitted when the roll call is finished (or aborted).

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -1,0 +1,128 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AttendanceStatus } from '../../model/attendance-day';
+import { EntityMapperService } from '../../../../core/entity/entity-mapper.service';
+import { Child } from '../../../children/model/child';
+import { AttendanceMonth } from '../../model/attendance-month';
+import { ChildrenService } from '../../../children/children.service';
+import { RollCallRecord } from './roll-call-record';
+import { animate, style, transition, trigger } from '@angular/animations';
+
+/**
+ * Displays the given children one by one to the user to mark the attendance status for the given day and type.
+ * This component itself handles the loading and saving of the attendances entities internally.
+ */
+@Component({
+  selector: 'app-roll-call',
+  templateUrl: './roll-call.component.html',
+  styleUrls: ['./roll-call.component.scss'],
+  animations: [
+    trigger('completeRollCall', [
+      transition('void => *', [
+        style({ backgroundColor: 'white' }),
+        animate(1000),
+      ]),
+    ]),
+  ],
+})
+export class RollCallComponent implements OnInit {
+
+  /**
+   * The day for which attendance will be recorded
+   */
+  @Input() day: Date;
+
+  /**
+   * The attendance type to be checked and saved (e.g. 'coaching' or 'school')
+   */
+  @Input() attendanceType: string;
+
+  /**
+   * The children for whom attendance will be recorded
+   */
+  @Input() students: Child[];
+
+  /**
+   * Event emitted when the roll call is finished (or aborted).
+   */
+  @Output() complete = new EventEmitter();
+
+
+  isLoading: boolean = true;
+  currentIndex: number;
+  rollCallList: RollCallRecord[] = [];
+
+  AttStatus = AttendanceStatus;
+
+  constructor(
+    private entityMapper: EntityMapperService,
+    private childrenService: ChildrenService,
+  ) { }
+
+  async ngOnInit() {
+    await this.loadList();
+  }
+
+
+
+  private async loadList() {
+    this.isLoading = true;
+
+    this.currentIndex = 0;
+
+    this.rollCallList = await this.loadMonthAttendanceRecords(this.students);
+    this.sortRollCallList();
+
+    this.isLoading = false;
+  }
+
+  private async loadMonthAttendanceRecords(children: Child[]): Promise<RollCallRecord[]> {
+    const rollCallRecords: RollCallRecord[] = [];
+
+    const attendances = await this.childrenService.getAttendancesOfMonth(this.day).toPromise();
+    children.forEach(child => {
+      let attMonth: AttendanceMonth = attendances.find(a => a.student === child.getId() && a.institution === this.attendanceType);
+      if (attMonth === undefined) {
+        attMonth = AttendanceMonth.createAttendanceMonth(child.getId(), this.attendanceType);
+        attMonth.month = new Date(this.day.getTime());
+      }
+
+      const attDay = attMonth.dailyRegister.find(d => d.date.getDate() === this.day.getDate()
+        && d.date.getMonth() === this.day.getMonth() && d.date.getFullYear() === this.day.getFullYear());
+
+      rollCallRecords.push({child: child, attendanceMonth: attMonth, attendanceDay: attDay});
+    });
+
+    return rollCallRecords;
+  }
+
+  private sortRollCallList() {
+    this.rollCallList.sort((a: RollCallRecord, b: RollCallRecord) => {
+      const diff = parseInt(a.child.schoolClass, 10) - parseInt(b.child.schoolClass, 10);
+      if (!isNaN(diff)) {
+        return diff;
+      }
+
+      if (a.child.schoolClass > b.child.schoolClass) { return 1; }
+      if (a.child.schoolClass < b.child.schoolClass) { return -1; }
+      return 0;
+    });
+  }
+
+
+  markAttendance(status: AttendanceStatus) {
+    const rollCallListEntry = this.rollCallList[this.currentIndex];
+    rollCallListEntry.attendanceDay.status = status;
+    this.entityMapper.save(rollCallListEntry.attendanceMonth);
+
+    setTimeout(() => this.currentIndex++, 750);
+  }
+
+
+  endRollCall() {
+    this.complete.emit();
+  }
+
+  isFinished(): boolean {
+    return this.currentIndex >= this.rollCallList.length;
+  }
+}

--- a/src/app/child-dev-project/attendance/model/attendance-day.spec.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-day.spec.ts
@@ -1,0 +1,44 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AttendanceDay } from './attendance-day';
+import { async } from '@angular/core/testing';
+import { EntitySchemaService } from '../../../core/entity/schema/entity-schema.service';
+import { AttendanceMonth } from './attendance-month';
+
+describe('AttendanceDay', () => {
+  let entitySchemaService: EntitySchemaService;
+
+  beforeEach(async(() => {
+    entitySchemaService = new EntitySchemaService();
+  }));
+
+
+  it('(AttendanceMonth) saves date values as only YYYY-MM-dd', () => {
+    const month = new Date('2018-01-01');
+    const entity = new AttendanceMonth('');
+    entity.month = month;
+
+    const data = entitySchemaService.transformEntityToDatabaseFormat(entity);
+    expect(data.dailyRegister[1].date).toBe('2018-01-02'); // dailyRegister array is zero-based, index 1 is second day
+
+    const loadedEntity = new AttendanceMonth('');
+    entitySchemaService.loadDataIntoEntity(loadedEntity, data);
+    expect(loadedEntity.dailyRegister[1].date).toEqual(new Date('2018-01-02'));
+  });
+
+});

--- a/src/app/child-dev-project/attendance/model/attendance-day.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-day.ts
@@ -16,6 +16,8 @@
  */
 
 
+import { DatabaseField } from '../../../core/entity/database-field.decorator';
+
 export enum AttendanceStatus {
   UNKNOWN = '?',
   HOLIDAY = 'H',
@@ -27,9 +29,9 @@ export enum AttendanceStatus {
 
 
 export class AttendanceDay {
-  date: Date;
-  status: AttendanceStatus;
-  remarks = '';
+  @DatabaseField({ dataType: 'date-only' }) date: Date;
+  @DatabaseField() status: AttendanceStatus;
+  @DatabaseField() remarks: string = '';
 
   constructor (date: Date, status: AttendanceStatus = AttendanceStatus.UNKNOWN) {
     this.date = date;

--- a/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
@@ -17,7 +17,6 @@
 
 import { AttendanceMonth, daysInMonth } from './attendance-month';
 import { WarningLevel } from '../../warning-level';
-import { AttendanceDay } from './attendance-day';
 import { async } from '@angular/core/testing';
 import { Entity } from '../../../core/entity/entity';
 import { EntitySchemaService } from '../../../core/entity/schema/entity-schema.service';
@@ -77,7 +76,8 @@ describe('AttendanceMonth', () => {
 
     const rawData = entitySchemaService.transformEntityToDatabaseFormat(entity);
 
-    expectedData.dailyRegister = entity.dailyRegister; // dailyRegister is auto-generated and expected in rawData also
+    expect(rawData.dailyRegister.length).toBe(31);
+    expectedData.dailyRegister = rawData.dailyRegister; // simplify the overall comparison by ignoring dailyRegister diff
     expect(rawData).toEqual(expectedData);
   });
 
@@ -211,22 +211,4 @@ describe('AttendanceMonth', () => {
     entitySchemaService.loadDataIntoEntity(entity, data);
     expect(entity.month).toEqual(new Date(data.month));
   });
-
-
-  it('loads AttendanceDay.date values as Date objects', () => {
-    const month = new Date('2018-01-01');
-    const entity = new AttendanceMonth('');
-    entity.month = month;
-
-    expect(entity.dailyRegister.length).toBeGreaterThan(0);
-    const data = entitySchemaService.transformEntityToDatabaseFormat(entity);
-
-    const entity2 = new AttendanceMonth('');
-    entitySchemaService.loadDataIntoEntity(entity2, data);
-    const day1 = entity2.dailyRegister[0];
-
-    expect(day1 instanceof AttendanceDay).toBeTruthy();
-    expect(day1.date instanceof Date).toBeTruthy();
-  });
-
 });

--- a/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
@@ -211,4 +211,22 @@ describe('AttendanceMonth', () => {
     entitySchemaService.loadDataIntoEntity(entity, data);
     expect(entity.month).toEqual(new Date(data.month));
   });
+
+
+  it('creates correct instance using static createAttendanceMonth', () => {
+    const testInstitution = 'coaching';
+    const testChildId = 'childId1';
+    const now = new Date();
+
+    const actualInstance = AttendanceMonth.createAttendanceMonth(testChildId, testInstitution);
+
+    expect(actualInstance.student).toBe(testChildId);
+    expect(actualInstance.institution).toBe(testInstitution);
+    expect(actualInstance.month.getFullYear()).toBe(now.getFullYear());
+    expect(actualInstance.month.getMonth()).toBe(now.getMonth());
+
+    expect(actualInstance.getId()).toContain(testChildId);
+    expect(actualInstance.getId()).toContain(testInstitution);
+    expect(actualInstance.getId()).toContain(now.getFullYear() + '-' + (now.getMonth() + 1));
+  });
 });

--- a/src/app/child-dev-project/attendance/model/attendance-month.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.ts
@@ -28,9 +28,9 @@ export class AttendanceMonth extends Entity {
 
 
   public static createAttendanceMonth(childId: string, institution: string) {
-    // TODO: logical way to assign entityId to Attendance?
-    const newAtt = new AttendanceMonth(childId + '_' + Date.now().toString() + institution);
-    newAtt.month = new Date();
+    const month = new Date();
+    const newAtt = new AttendanceMonth(childId + '_' + month.getFullYear() + '-' + (month.getMonth() + 1) + '_' + institution);
+    newAtt.month = month;
     newAtt.student = childId;
     newAtt.institution = institution;
     return newAtt;

--- a/src/app/child-dev-project/attendance/model/attendance-month.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.ts
@@ -130,7 +130,7 @@ export class AttendanceMonth extends Entity {
     }
     this._dailyRegister = value;
   }
-  @DatabaseField()
+  @DatabaseField({ arrayDataType: 'schema-embed', ext: AttendanceDay })
   get dailyRegister(): AttendanceDay[] {
     return this._dailyRegister;
   }

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -67,6 +67,8 @@ import { AttendanceManagerComponent } from '../attendance/attendance-manager/att
 import { HealthCheckupComponent } from '../health-checkup/health-checkup-component/health-checkup.component';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { PreviousSchoolsComponent } from '../previous-schools/previous-schools.component';
+import { SelectGroupChildrenComponent } from './select-group-children/select-group-children.component';
+import { RollCallComponent } from '../attendance/add-day-attendance/roll-call/roll-call.component';
 
 
 @NgModule({
@@ -122,6 +124,8 @@ import { PreviousSchoolsComponent } from '../previous-schools/previous-schools.c
     AttendanceDaysComponent,
     AttendanceDetailsComponent,
     AddDayAttendanceComponent,
+    RollCallComponent,
+    SelectGroupChildrenComponent,
     AttendanceWeekDashboardComponent,
     AttendanceManagerComponent,
     HealthCheckupComponent,

--- a/src/app/child-dev-project/children/select-group-children/select-group-children.component.html
+++ b/src/app/child-dev-project/children/select-group-children/select-group-children.component.html
@@ -1,0 +1,23 @@
+<div fxLayout='column'>
+  <div>
+    <mat-form-field fxFlex>
+      <mat-label>
+        Select a center
+      </mat-label>
+      <mat-select (valueChange)='loadStudentGroupFilterForCenter($event)'>
+        <mat-option *ngFor="let c of centers" [value]='c'>
+          {{c}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div>
+    <div *ngFor="let group of studentGroupFilters.options" class='group-select-option' (click)='updateSelectedChildren(group)'>
+      <span style='text-align: right' class='fa fa-chevron-right'></span>&nbsp;
+      <span *ngIf='!group.type'>{{group.label}}</span>
+      <app-school-block *ngIf="group.type==='school'" [entityId]='group.label' [linkDisabled]='true'></app-school-block>
+    </div>
+  </div>
+
+</div>

--- a/src/app/child-dev-project/children/select-group-children/select-group-children.component.scss
+++ b/src/app/child-dev-project/children/select-group-children/select-group-children.component.scss
@@ -1,0 +1,13 @@
+
+.group-select-option {
+  width: 100%;
+  padding: 16px;
+  cursor: pointer;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-top: 0;
+}
+
+.group-select-option:first-child {
+  border-top: 1px solid;
+}

--- a/src/app/child-dev-project/children/select-group-children/select-group-children.component.spec.ts
+++ b/src/app/child-dev-project/children/select-group-children/select-group-children.component.spec.ts
@@ -1,0 +1,159 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SelectGroupChildrenComponent } from './select-group-children.component';
+import { ChildrenService } from '../children.service';
+import { BehaviorSubject } from 'rxjs';
+import { Child } from '../model/child';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatOptionModule } from '@angular/material/core';
+import { SchoolsModule } from '../../schools/schools.module';
+import { MatSelectModule } from '@angular/material/select';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('SelectGroupChildrenComponent', () => {
+  let component: SelectGroupChildrenComponent;
+  let fixture: ComponentFixture<SelectGroupChildrenComponent>;
+
+  let mockChildrenService;
+  const mockChildrenObservable = new BehaviorSubject([]);
+
+  beforeEach(async(() => {
+    mockChildrenService = jasmine.createSpyObj(['getChildren']);
+    mockChildrenService.getChildren.and.returnValue(mockChildrenObservable);
+
+    TestBed.configureTestingModule({
+      declarations: [
+        SelectGroupChildrenComponent,
+      ],
+      imports: [
+        MatFormFieldModule,
+        MatOptionModule,
+        MatSelectModule,
+        NoopAnimationsModule,
+        SchoolsModule,
+      ],
+      providers: [
+        { provide: ChildrenService, useValue: mockChildrenService },
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SelectGroupChildrenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should extract all centers', () => {
+    const mockChildren = [
+      new Child('0'),
+      new Child('1'),
+    ];
+    mockChildren[0].center = 'Center A';
+    mockChildren[1].center = 'Center B';
+
+    mockChildrenObservable.next(mockChildren);
+
+    expect(component.centers).toEqual([mockChildren[0].center, mockChildren[1].center]);
+  });
+
+
+  it('should extract all schools of selected center', () => {
+    const selectedCenter = 'Center A';
+    const mockChildren = [
+      new Child('0'),
+      new Child('1'),
+      new Child('2'),
+      new Child('3'),
+    ];
+    mockChildren[0].center = selectedCenter;
+    mockChildren[0].schoolId = 'School:1';
+    mockChildren[1].center = selectedCenter;
+    mockChildren[1].schoolId = 'School:2';
+    mockChildren[3].center = 'other center';
+    mockChildren[3].schoolId = 'School:3';
+
+    mockChildrenObservable.next(mockChildren);
+
+    component.loadStudentGroupFilterForCenter(selectedCenter);
+
+    expect(component.studentGroupFilters.options.length).toBe(3); // includes default option "all schools"
+    expect(component.studentGroupFilters.options[1].key).toBe('School:1');
+    expect(component.studentGroupFilters.options[2].key).toBe('School:2');
+  });
+
+  it('should not list empty filter for undefined schools', () => {
+    const selectedCenter = 'Center A';
+    const mockChildren = [
+      new Child('0'),
+      new Child('1'),
+    ];
+    mockChildren[0].center = selectedCenter;
+    mockChildren[0].schoolId = 'School:1';
+    mockChildren[1].center = selectedCenter;
+    // mockChildren[1].schoolId is not set
+
+    mockChildrenObservable.next(mockChildren);
+
+    component.loadStudentGroupFilterForCenter(selectedCenter);
+
+    expect(component.studentGroupFilters.options.length).toBe(2); // includes default option "all schools"
+    expect(component.studentGroupFilters.options[1].key).toBe('School:1');
+  });
+
+
+  it('should emit selected children correctly filtered by center and school', () => {
+    const selectedCenter = 'Center A';
+    const selectedSchool = 'School:1';
+
+    const mockChildren = [
+      new Child('0'),
+      new Child('1'),
+      new Child('2'),
+    ];
+    mockChildren[0].center = selectedCenter;
+    mockChildren[0].schoolId = selectedSchool;
+    mockChildren[1].center = selectedCenter;
+    // mockChildren[1].schoolId is not set
+    mockChildren[2].center = 'other center';
+    mockChildren[2].schoolId = selectedSchool;
+
+    mockChildrenObservable.next(mockChildren);
+
+    spyOn(component.valueChange, 'emit');
+
+    component.loadStudentGroupFilterForCenter(selectedCenter);
+    component.updateSelectedChildren(component.studentGroupFilters.options.find(o => o.key === selectedSchool));
+
+    expect(component.valueChange.emit).toHaveBeenCalledWith([mockChildren[0]]);
+  });
+
+  it('should emit all children of center for default filter', () => {
+    const selectedCenter = 'Center A';
+
+    const mockChildren = [
+      new Child('0'),
+      new Child('1'),
+      new Child('2'),
+    ];
+    mockChildren[0].center = selectedCenter;
+    mockChildren[0].schoolId = 'School:1';
+    mockChildren[1].center = selectedCenter;
+    // mockChildren[1].schoolId is not set
+    mockChildren[2].center = 'other center';
+    mockChildren[2].schoolId = 'School:1';
+
+    mockChildrenObservable.next(mockChildren);
+
+    spyOn(component.valueChange, 'emit');
+
+    component.loadStudentGroupFilterForCenter(selectedCenter);
+    component.updateSelectedChildren(component.studentGroupFilters.options.find(o => o.key === 'all'));
+
+    expect(component.valueChange.emit).toHaveBeenCalledWith([ mockChildren[0], mockChildren[1] ]);
+  });
+});

--- a/src/app/child-dev-project/children/select-group-children/select-group-children.component.ts
+++ b/src/app/child-dev-project/children/select-group-children/select-group-children.component.ts
@@ -1,0 +1,68 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Child } from '../model/child';
+import { ChildrenService } from '../children.service';
+import { FilterSelection, FilterSelectionOption } from '../../../core/ui-helper/filter-selection/filter-selection';
+
+
+/**
+ * Use this component in your template to allow the user to select a group of children.
+ */
+@Component({
+  selector: 'app-select-group-children',
+  templateUrl: './select-group-children.component.html',
+  styleUrls: ['./select-group-children.component.scss'],
+})
+export class SelectGroupChildrenComponent implements OnInit {
+
+  @Output() valueChange = new EventEmitter<Child[]>();
+
+  private value: Child[] = [];
+  centers: string[];
+  children: Child[];
+  studentGroupFilters = new FilterSelection<Child>('Groups', [ ]);
+
+  constructor(
+    private childrenService: ChildrenService,
+  ) { }
+
+  ngOnInit() {
+    this.childrenService.getChildren().subscribe(children => {
+      this.children = children.filter(c => c.isActive());
+      this.centers = this.children.map(c => c.center).filter((value, index, arr) => arr.indexOf(value) === index);
+    });
+  }
+
+
+  loadStudentGroupFilterForCenter(center: string) {
+    this.studentGroupFilters.options = [ this.getAllSchoolsFilterOption(center) ];
+
+    this.children
+      .filter(c => c.center === center)
+      .map(c => c.schoolId).filter((value, index, arr) => arr.indexOf(value) === index)
+      .forEach(schoolId => {
+        if (!schoolId) { return; }
+
+        const filterOption = {
+          key: schoolId,
+          label: schoolId,
+          type: 'school',
+          filterFun: (c: Child) => c.schoolId === schoolId && c.center === center,
+        };
+        this.studentGroupFilters.options.push(filterOption);
+      });
+  }
+
+  private getAllSchoolsFilterOption(center: string): FilterSelectionOption<Child> {
+    return {
+      key: 'all',
+      label: 'All Students',
+      filterFun: (c: Child) => c.center === center,
+    };
+  }
+
+
+  updateSelectedChildren(group: FilterSelectionOption<Child>) {
+    this.value = this.children.filter(group.filterFun);
+    this.valueChange.emit(this.value);
+  }
+}

--- a/src/app/core/entity/database-field.decorator.spec.ts
+++ b/src/app/core/entity/database-field.decorator.spec.ts
@@ -39,8 +39,6 @@ describe('@DatabaseField Decorator', () => {
   });
 
   it('results in full schema', async () => {
-    const testClass = new TestClass('1');
-
     expect(TestClass.schema).toEqual(new Map([
       ['fieldUndefined', { dataType: 'string' }],
       ['fieldWithDefault', { dataType: 'string' }],

--- a/src/app/core/entity/schema-datatypes/datatype-array.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-array.ts
@@ -1,0 +1,56 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import { EntitySchemaDatatype } from '../schema/entity-schema-datatype';
+import { EntitySchemaField } from '../schema/entity-schema-field';
+import { EntitySchemaService } from '../schema/entity-schema.service';
+
+export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
+  name: 'array',
+
+  transformToDatabaseFormat: (value: any[], schemaField: EntitySchemaField, schemaService: EntitySchemaService) => {
+    if (!Array.isArray(value)) {
+      console.warn('property to be transformed with "array" EntitySchema is not an array', value);
+      return value;
+    }
+
+    const arrayElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(schemaField.arrayDataType);
+    return value.map((el) => arrayElementDatatype
+      .transformToDatabaseFormat(el, generateSubSchemaField(schemaField), schemaService));
+  },
+
+
+  transformToObjectFormat: (value: any[], schemaField: EntitySchemaField, schemaService: EntitySchemaService) => {
+    if (!Array.isArray(value)) {
+      console.warn('property to be transformed with "array" EntitySchema is not an array', value);
+      return value;
+    }
+
+    const arrayElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(schemaField.arrayDataType);
+
+    return value.map((el) => arrayElementDatatype
+      .transformToObjectFormat(el, generateSubSchemaField(schemaField), schemaService));
+  },
+};
+
+function generateSubSchemaField(arraySchemaField: EntitySchemaField) {
+  const subSchemaField = Object.assign({}, arraySchemaField);
+  subSchemaField.dataType = arraySchemaField.arrayDataType;
+  delete subSchemaField.arrayDataType;
+  return subSchemaField;
+}

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -1,0 +1,47 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EntitySchemaDatatype } from '../schema/entity-schema-datatype';
+
+/**
+ * Converter to serialize a Date object to a simple date string (YYYY-MM-dd) discarding the time.
+ * Use through the EntitySchema system by annotating a property with `@DatabaseField({ dataType: 'date-only' })`
+ */
+export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
+  name: 'date-only',
+
+  transformToDatabaseFormat: (value: Date) => {
+    return dateObjectToSimpleDateString(value);
+  },
+
+  transformToObjectFormat: (value) => {
+    let date;
+    if (!value || value === '') {
+      date = null;
+    } else {
+      date = new Date(value);
+      if (isNaN(date.getTime())) {
+        throw new Error('failed to convert data to Date object: ' + value);
+      }
+    }
+    return date;
+  },
+};
+
+function dateObjectToSimpleDateString(value: Date) {
+  return value.getFullYear() + '-' + (value.getMonth() + 1).toString().padStart(2, '0') + '-' + value.getDate().toString().padStart(2, '0');
+}

--- a/src/app/core/entity/schema-datatypes/datatype-schema-embed.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-schema-embed.ts
@@ -1,0 +1,41 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import { EntitySchemaDatatype } from '../schema/entity-schema-datatype';
+import { EntitySchemaField } from '../schema/entity-schema-field';
+import { EntitySchemaService } from '../schema/entity-schema.service';
+
+/**
+ * (De)serialize instances of any class recognizing the normal @DatabaseField() annotations.
+ *
+ * Requires the class constructor as extension field in the schema field annotation:
+ * `@DatabaseField({ dataType: 'schema-embed', ext: MyClass })`
+ * see the unit tests in entity-schema.service.spec.ts for an example
+ */
+export const schemaEmbedEntitySchemaDatatype: EntitySchemaDatatype = {
+  name: 'schema-embed',
+
+  transformToDatabaseFormat: (value: any, schemaField: EntitySchemaField, schemaService: EntitySchemaService) => {
+    return schemaService.transformEntityToDatabaseFormat(value, schemaField.ext.schema);
+  },
+
+
+  transformToObjectFormat: (value: any, schemaField: EntitySchemaField, schemaService: EntitySchemaService) => {
+    return schemaService.transformDatabaseToEntityFormat(value, schemaField.ext.schema);
+  },
+};

--- a/src/app/core/entity/schema/entity-schema-datatype.ts
+++ b/src/app/core/entity/schema/entity-schema-datatype.ts
@@ -16,11 +16,14 @@
  */
 
 
+import { EntitySchemaField } from './entity-schema-field';
+import { EntitySchemaService } from './entity-schema.service';
+
 /**
  * Interface to be implemented by any Datatype transformer of the Schema system.
  */
 export interface EntitySchemaDatatype {
   name: string;
-  transformToDatabaseFormat(value: any): any;
-  transformToObjectFormat(value: any): any;
+  transformToDatabaseFormat(value: any, schemaField: EntitySchemaField, schemaService: EntitySchemaService): any;
+  transformToObjectFormat(value: any, schemaField: EntitySchemaField, schemaService: EntitySchemaService): any;
 }

--- a/src/app/core/entity/schema/entity-schema-field.ts
+++ b/src/app/core/entity/schema/entity-schema-field.ts
@@ -34,4 +34,9 @@ export interface EntitySchemaField {
    * Set to true to make the framework automatically create an index to retrieve/filter Entities quickly based on this field
    */
   generateIndex?: boolean; // TODO: implement index support in EntitySchema
+
+  /**
+   * (Optional) Assign any custom configuration you need for a specific datatype extension.
+   */
+  ext?: any;
 }

--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -114,6 +114,26 @@ describe('EntitySchemaService', () => {
     expect(rawData.month).toEqual('2018-2');
   });
 
+  it('schema:date-only converts between YYYY-MM-dd and Date objects', function () {
+    class TestEntity extends Entity {
+      @DatabaseField({dataType: 'date-only'}) day: Date;
+    }
+    const id = 'test1';
+    const entity = new TestEntity(id);
+
+    const data = {
+      _id: 'test2',
+      day: '2018-01-15',
+    };
+    entitySchemaService.loadDataIntoEntity(entity, data);
+
+    const expectedDate = new Date('2018-01-15');
+    expect(entity.day).toEqual(expectedDate);
+
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(entity);
+    expect(rawData.day).toBe('2018-01-15');
+  });
+
 
 
   it('schema:array converts contained dates to month for saving', function () {

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -26,6 +26,8 @@ import { stringEntitySchemaDatatype } from '../schema-datatypes/datatype-string'
 import { numberEntitySchemaDatatype } from '../schema-datatypes/datatype-number';
 import { dateEntitySchemaDatatype } from '../schema-datatypes/datatype-date';
 import { monthEntitySchemaDatatype } from '../schema-datatypes/datatype-month';
+import { arrayEntitySchemaDatatype } from '../schema-datatypes/datatype-array';
+import { schemaEmbedEntitySchemaDatatype } from '../schema-datatypes/datatype-schema-embed';
 
 
 /**
@@ -49,6 +51,8 @@ export class EntitySchemaService {
     this.registerSchemaDatatype(numberEntitySchemaDatatype);
     this.registerSchemaDatatype(dateEntitySchemaDatatype);
     this.registerSchemaDatatype(monthEntitySchemaDatatype);
+    this.registerSchemaDatatype(arrayEntitySchemaDatatype);
+    this.registerSchemaDatatype(schemaEmbedEntitySchemaDatatype);
   }
 
 
@@ -62,7 +66,7 @@ export class EntitySchemaService {
   }
 
   public getDatatypeOrDefault(datatypeName: string) {
-    datatypeName = datatypeName.toLowerCase();
+    datatypeName = datatypeName ? datatypeName.toLowerCase() : undefined;
 
     if (this.schemaTypes.has(datatypeName)) {
       return this.schemaTypes.get(datatypeName);
@@ -76,7 +80,8 @@ export class EntitySchemaService {
     for (const key of schema.keys()) {
       const schemaField: EntitySchemaField = schema.get(key);
       if (data[key] !== undefined) {
-        data[key] = this.getDatatypeOrDefault(schemaField.dataType).transformToObjectFormat(data[key]);
+        data[key] = this.getDatatypeOrDefault(schemaField.dataType)
+          .transformToObjectFormat(data[key], schemaField, this);
       }
 
       if (schemaField.generateIndex) {
@@ -93,18 +98,25 @@ export class EntitySchemaService {
   }
 
 
-  public transformEntityToDatabaseFormat(entity: Entity): any {
+  public transformEntityToDatabaseFormat(entity: Entity, schema?: EntitySchema): any {
+    if (!schema) {
+      schema = entity.getConstructor().schema;
+    }
+
     const data = {};
 
-    for (const key of entity.getConstructor().schema.keys()) {
-      const schemaField: EntitySchemaField = entity.getConstructor().schema.get(key);
+    for (const key of schema.keys()) {
+      const schemaField: EntitySchemaField = schema.get(key);
 
       if (entity[key] !== undefined) {
-        data[key] = this.getDatatypeOrDefault(schemaField.dataType).transformToDatabaseFormat(entity[key]);
+        data[key] = this.getDatatypeOrDefault(schemaField.dataType)
+          .transformToDatabaseFormat(entity[key], schemaField, this);
       }
     }
 
-    data['searchIndices'] = entity.generateSearchIndices();
+    if (entity.generateSearchIndices) {
+      data['searchIndices'] = entity.generateSearchIndices();
+    }
 
     return data;
   }

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -28,6 +28,7 @@ import { dateEntitySchemaDatatype } from '../schema-datatypes/datatype-date';
 import { monthEntitySchemaDatatype } from '../schema-datatypes/datatype-month';
 import { arrayEntitySchemaDatatype } from '../schema-datatypes/datatype-array';
 import { schemaEmbedEntitySchemaDatatype } from '../schema-datatypes/datatype-schema-embed';
+import { dateOnlyEntitySchemaDatatype } from '../schema-datatypes/datatype-date-only';
 
 
 /**
@@ -50,6 +51,7 @@ export class EntitySchemaService {
     this.registerSchemaDatatype(stringEntitySchemaDatatype);
     this.registerSchemaDatatype(numberEntitySchemaDatatype);
     this.registerSchemaDatatype(dateEntitySchemaDatatype);
+    this.registerSchemaDatatype(dateOnlyEntitySchemaDatatype);
     this.registerSchemaDatatype(monthEntitySchemaDatatype);
     this.registerSchemaDatatype(arrayEntitySchemaDatatype);
     this.registerSchemaDatatype(schemaEmbedEntitySchemaDatatype);

--- a/src/app/core/ui-helper/filter-selection/filter-selection.ts
+++ b/src/app/core/ui-helper/filter-selection/filter-selection.ts
@@ -18,40 +18,47 @@
 
 export class FilterSelection<T> {
 
-  public selectedOption = '';
+    public selectedOption = '';
 
-  constructor (public name: string,
-               public options: { key: string, label: string, filterFun: (c: T) => boolean}[] ) {
+    constructor(public name: string,
+                public options: FilterSelectionOption<T>[]) {
 
-  }
-
-  defaultFilterFunction = (c: T) => true;
-
-  getOption(key: string) {
-    return this.options.find((option) => option.key === key);
-  }
-
-  public getFilterFunction(key: string) {
-    const option = this.getOption(key);
-
-    if (!option) {
-      return this.defaultFilterFunction;
-    } else {
-      return option.filterFun;
     }
-  }
 
-  public getSelectedFilterFunction() {
-    return this.getFilterFunction(this.selectedOption);
-  }
+    defaultFilterFunction = (c: T) => true;
 
-  public initOptions(keys: any[], attributeName: string) {
-    const options = [{key: '', label: 'All', filterFun: (e: T) => true}];
+    getOption(key: string) {
+        return this.options.find((option) => option.key === key);
+    }
 
-    keys.forEach(k => {
-      options.push({key: k.toLowerCase(), label: k.toString(), filterFun: (e: T) => e[attributeName] === k});
-    });
+    public getFilterFunction(key: string) {
+        const option = this.getOption(key);
 
-    this.options = options;
-  }
+        if (!option) {
+            return this.defaultFilterFunction;
+        } else {
+            return option.filterFun;
+        }
+    }
+
+    public getSelectedFilterFunction() {
+        return this.getFilterFunction(this.selectedOption);
+    }
+
+    public initOptions(keys: any[], attributeName: string) {
+        const options = [{key: '', label: 'All', filterFun: (e: T) => true}];
+
+        keys.forEach(k => {
+            options.push({key: k.toLowerCase(), label: k.toString(), filterFun: (e: T) => e[attributeName] === k});
+        });
+
+        this.options = options;
+    }
+}
+
+
+export interface FilterSelectionOption<T> {
+    key: string;
+    label: string;
+    filterFun: (c: T) => boolean;
 }


### PR DESCRIPTION
Fix problems with the attendance records. Especially an issue that the roll call (add day's attendance) feature wrongly jumped to a certain date instead of the selected date.

see issues: #390, #402 

### Visible/Frontend Changes
- [x] Fix problem that "add day's attendance' displayed previously entered status from a different than the selected day
- [x] Fix problems when using attendance records in different timezones (causing records to be shifted by one day)
- [x] Make hidden duplicates (two records with different IDs referring to the same AttendanceMonth) less likely by better ID generation.

### Architectural/Backend Changes
- [x] Add EntitySchema datatype "array" to configure (de)serialization of arrays through the `@DatabaseField()` annotation
- [x] Add EntitySchema datatype "schema-embed" (_**suggestions for a better name welcome!**_) to configure (de)serialization of complex objects through the `@DatabaseField()` annotation, allowing annotations in the class type of that object recursively.
- [x] Add EntitySchema datatype "date-only" to configure (de)serialization of date objects to a simple string without time (YYYY-MM-dd) through the `@DatabaseField()` annotation
- [x] Refactor the components for the "add day's attendance" feature, splitting and simplifying the code
