### PR TITLE
Generate children which currently attend a school

### DIFF
--- a/src/app/child-dev-project/children/demo-data-generators/demo-child-school-relation-generator.service.ts
+++ b/src/app/child-dev-project/children/demo-data-generators/demo-child-school-relation-generator.service.ts
@@ -51,15 +51,15 @@ export class DemoChildSchoolRelationGenerator extends DemoDataGenerator<ChildSch
     let offset = 0;
     while (firstYear + offset <= finalYear && offset <= 12) {
       currentSchool = this.selectNextSchool(currentSchool);
-      const record = this.generateRecord(child, firstYear + offset, offset + 1, currentSchool);
+      data.push(
+        this.generateRecord(child, firstYear + offset, offset + 1, currentSchool),
+      );
 
       offset++;
-      if (firstYear + offset > finalYear && Math.random() < 0.8) {
-        // Last round
-        // 80% of the latest records for each child don't have an end date, which means the child currently attends this school.
-        record.end = null;
-      }
-      data.push(record);
+    }
+    if (Math.random() < 0.8) {
+      // 80% of the latest records for each child don't have an end date, which means the child currently attends this school.
+      (data[data.length - 1] as ChildSchoolRelation).end = null;
     }
 
     this.setChildSchoolAndClassForLegacyUse(child, data[data.length - 1]);

--- a/src/app/child-dev-project/children/demo-data-generators/demo-child-school-relation-generator.service.ts
+++ b/src/app/child-dev-project/children/demo-data-generators/demo-child-school-relation-generator.service.ts
@@ -51,11 +51,15 @@ export class DemoChildSchoolRelationGenerator extends DemoDataGenerator<ChildSch
     let offset = 0;
     while (firstYear + offset <= finalYear && offset <= 12) {
       currentSchool = this.selectNextSchool(currentSchool);
-      data.push(
-        this.generateRecord(child, firstYear + offset, offset + 1, currentSchool),
-      );
+      const record = this.generateRecord(child, firstYear + offset, offset + 1, currentSchool);
 
       offset++;
+      if (firstYear + offset > finalYear && Math.random() < 0.8) {
+        // Last round
+        // 80% of the latest records for each child don't have an end date, which means the child currently attends this school.
+        record.end = null;
+      }
+      data.push(record);
     }
 
     this.setChildSchoolAndClassForLegacyUse(child, data[data.length - 1]);

--- a/src/app/child-dev-project/schools/school-detail/school-detail.component.html
+++ b/src/app/child-dev-project/schools/school-detail/school-detail.component.html
@@ -89,7 +89,7 @@
     </mat-expansion-panel-header>
     <div class="example-container mat-elevation-z8">
 
-      <table mat-table #table [dataSource]="studentDataSource" matSort>
+      <table mat-table #table [dataSource]="studentDataSource" matSort style="width: 100%">
 
         <ng-container matColumnDef="id">
           <mat-header-cell *matHeaderCellDef mat-sort-header> PN </mat-header-cell>


### PR DESCRIPTION
Issue #362 refers to the problem that when using the demo data, no children are displayed under the school detail component where the attending students are listed. 
This however, is not a bug in the component as @RichardNutt correctly  summarized [here](https://github.com/Aam-Digital/ndb-core/issues/362#issuecomment-566688561).
Instead, the demo data generator always created `ChildSchoolRelations` with the end date being set. 
Internally we say a student currently attends a school if there exists  a `ChildSchoolRelation` with this student and the school where the `end` attribute is `null`.
To create better demo data I changed the generator to make 80% of the students currently attending a school or in other words set the end date of the last `ChildSchoolRelation` to `null` with a 80% chance for each child.