### PR TITLE
remove alternative text from image

### DIFF
--- a/src/app/child-dev-project/children/child-block/child-block.component.html
+++ b/src/app/child-dev-project/children/child-block/child-block.component.html
@@ -1,5 +1,5 @@
 <span *ngIf="entity" (mouseenter)="showTooltip()" (mouseleave)="hideTooltip()">
-  <img [src]="entity?.getPhoto()" class="child-pic" alt="child's photo">
+  <img [src]="entity?.getPhoto()" class="child-pic" >
   {{entity?.name}} <span style="font-size: x-small">({{entity?.projectNumber}})</span>
 </span>
 


### PR DESCRIPTION
see issue: #372 alt text for photos that can't be loaded 

### Visible/Frontend Changes
- [x] no alternative text if the image can't be displayed in the child block