### PR TITLE
style(notes-manager): add full width to notes table

### DIFF
--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.scss
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.scss
@@ -1,6 +1,10 @@
-.table-list{
+.table-list {
   width: 100%;
   margin-top: 10px;
+
+  table {
+    width: 100%;
+  }
 }
 
 .table-list td {


### PR DESCRIPTION
Closes #457

see issue: #457

### Visible/Frontend Changes
- [x] note table has full width again

### Architectural/Backend Changes
