### PR TITLE
fix(new-child): disable additional child information sections until f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ndb-core",
   "version": "2.14.6",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -216,10 +216,14 @@
     <mat-expansion-panel
       expanded="false"
       title="Education"
-      [disabled]="creatingNew"
-    >
+      [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
-        Education {{ creatingNew? '(Please save to enter further data)' : '' }}
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
+        Education
       </mat-expansion-panel-header>
 
       <div *ngIf="child.schoolId" matTooltip='To edit the current school or class, please add to the school history below'>
@@ -248,8 +252,14 @@
 
 
 
-    <mat-expansion-panel expanded="false" title="Attendance" [disabled]="creatingNew">
+    <mat-expansion-panel expanded="false" title="Attendance"
+                         [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
         Attendance
       </mat-expansion-panel-header>
 
@@ -266,8 +276,14 @@
     </mat-expansion-panel>
 
 
-    <mat-expansion-panel expanded="false" [disabled]="creatingNew">
+    <mat-expansion-panel expanded="false"
+                         [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
         Notes & Reports
       </mat-expansion-panel-header>
 
@@ -276,8 +292,14 @@
 
 
 
-    <mat-expansion-panel [expanded]="false" [disabled]="creatingNew">
+    <mat-expansion-panel [expanded]="false"
+                         [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
         Health
       </mat-expansion-panel-header>
 
@@ -349,8 +371,14 @@
 
 
 
-    <mat-expansion-panel [expanded]="false" [disabled]="creatingNew">
+    <mat-expansion-panel [expanded]="false"
+                         [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
         Educational Materials
       </mat-expansion-panel-header>
 
@@ -360,8 +388,14 @@
 
 
 
-    <mat-expansion-panel [expanded]="!child.isActive()" [disabled]="creatingNew">
+    <mat-expansion-panel [expanded]="!child.isActive()"
+                         [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
+        <mat-icon fontIcon="fa-exclamation-triangle" *ngIf="creatingNew"
+                  class="locked-icon"
+                  matTooltip="Please save before entering further data"
+                  [matTooltipDisabled]="!creatingNew">
+        </mat-icon>
         Dropout
       </mat-expansion-panel-header>
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -213,9 +213,13 @@
 
 
 
-    <mat-expansion-panel expanded="false" title="Education">
+    <mat-expansion-panel
+      expanded="false"
+      title="Education"
+      [disabled]="creatingNew"
+    >
       <mat-expansion-panel-header class='section-header'>
-        Education
+        Education {{ creatingNew? '(Please save to enter further data)' : '' }}
       </mat-expansion-panel-header>
 
       <div *ngIf="child.schoolId" matTooltip='To edit the current school or class, please add to the school history below'>
@@ -244,7 +248,7 @@
 
 
 
-    <mat-expansion-panel expanded="false" title="Attendance">
+    <mat-expansion-panel expanded="false" title="Attendance" [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
         Attendance
       </mat-expansion-panel-header>
@@ -262,7 +266,7 @@
     </mat-expansion-panel>
 
 
-    <mat-expansion-panel expanded="false">
+    <mat-expansion-panel expanded="false" [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
         Notes & Reports
       </mat-expansion-panel-header>
@@ -272,7 +276,7 @@
 
 
 
-    <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel [expanded]="false" [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
         Health
       </mat-expansion-panel-header>
@@ -345,7 +349,7 @@
 
 
 
-    <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel [expanded]="false" [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
         Educational Materials
       </mat-expansion-panel-header>
@@ -356,7 +360,7 @@
 
 
 
-    <mat-expansion-panel [expanded]="!child.isActive()">
+    <mat-expansion-panel [expanded]="!child.isActive()" [disabled]="creatingNew">
       <mat-expansion-panel-header class='section-header'>
         Dropout
       </mat-expansion-panel-header>

--- a/src/app/child-dev-project/children/child-details/child-details.component.scss
+++ b/src/app/child-dev-project/children/child-details/child-details.component.scss
@@ -66,3 +66,9 @@
   width: 120px;
   background: white;
 }
+
+.locked-icon {
+  line-height: 20px;
+  padding-left: 10px;
+  color: black;
+}


### PR DESCRIPTION
When creating a new child notes are not linked before saving the child initially

see issue: #365 

### Visible/Frontend Changes
- [x] disable additional sections in new-child dialog
- [x] add a hint to save data first 

### Architectural/Backend Changes
none
