### PR TITLE
Child Details Subcomponents

### DIFF
--- a/src/app/child-dev-project/aser/aser-component/aser.component.spec.ts
+++ b/src/app/child-dev-project/aser/aser-component/aser.component.spec.ts
@@ -3,7 +3,6 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AserComponent } from "./aser.component";
 import { EntitySubrecordModule } from "../../../core/entity-subrecord/entity-subrecord.module";
 import { FormsModule } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
 import { ChildrenService } from "../../children/children.service";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { MockDatabase } from "../../../core/database/mock-database";
@@ -42,10 +41,6 @@ describe("AserComponent", () => {
       ],
       providers: [
         DatePipe,
-        {
-          provide: ActivatedRoute,
-          useValue: { paramMap: of({ get: () => "22" }) },
-        },
         { provide: ChildrenService, useValue: mockChildrenService },
         EntityMapperService,
         EntitySchemaService,
@@ -58,6 +53,7 @@ describe("AserComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AserComponent);
     component = fixture.componentInstance;
+    component.child = new Child("22");
     fixture.detectChanges();
   });
 

--- a/src/app/child-dev-project/aser/aser-component/aser.component.ts
+++ b/src/app/child-dev-project/aser/aser-component/aser.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit } from "@angular/core";
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { DatePipe } from "@angular/common";
 import { Aser } from "../model/aser";
@@ -6,6 +12,7 @@ import { ColumnDescription } from "../../../core/entity-subrecord/entity-subreco
 import { ChildrenService } from "../../children/children.service";
 import { ColumnDescriptionInputType } from "../../../core/entity-subrecord/entity-subrecord/column-description-input-type.enum";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Child } from "../../children/model/child";
 
 @UntilDestroy()
 @Component({
@@ -14,8 +21,8 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
     '<app-entity-subrecord [records]="records" [columns]="columns" [newRecordFactory]="generateNewRecordFactory()">' +
     "</app-entity-subrecord>",
 })
-export class AserComponent implements OnInit {
-  childId: string;
+export class AserComponent implements OnChanges {
+  @Input() child: Child;
   records: Array<Aser>;
 
   columns: Array<ColumnDescription> = [
@@ -78,16 +85,14 @@ export class AserComponent implements OnInit {
   ];
 
   constructor(
-    private route: ActivatedRoute,
     private childrenService: ChildrenService,
     private datePipe: DatePipe
   ) {}
 
-  ngOnInit() {
-    this.route.paramMap.pipe(untilDestroyed(this)).subscribe((params) => {
-      this.childId = params.get("id").toString();
-      this.loadData(this.childId);
-    });
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.hasOwnProperty("child")) {
+      this.loadData(this.child.getId());
+    }
   }
 
   loadData(id: string) {
@@ -104,7 +109,7 @@ export class AserComponent implements OnInit {
 
   generateNewRecordFactory() {
     // define values locally because "this" is a different scope after passing a function as input to another component
-    const child = this.childId;
+    const child = this.child.getId();
 
     return () => {
       const newAtt = new Aser(Date.now().toString());

--- a/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.spec.ts
+++ b/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { ChildAttendanceComponent } from "./child-attendance.component";
-import { ActivatedRoute } from "@angular/router";
 import { Child } from "../../children/model/child";
 import { ChildrenService } from "../../children/children.service";
 import { DatePipe, PercentPipe } from "@angular/common";
@@ -173,9 +172,10 @@ describe("ChildAttendanceComponent", () => {
   let fixture: ComponentFixture<ChildAttendanceComponent>;
 
   const mockChildrenService = {
-    getChild: (id) => of(new Child(id)),
     getAttendances: () => of(ATTENDANCE_ENTITIES),
   };
+
+  const child: Child = new Child("22");
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -183,7 +183,6 @@ describe("ChildAttendanceComponent", () => {
       providers: [
         DatePipe,
         PercentPipe,
-        { provide: ActivatedRoute, useValue: { params: of({ id: "22" }) } },
         { provide: ChildrenService, useValue: mockChildrenService },
         EntityMapperService,
         EntitySchemaService,
@@ -196,6 +195,8 @@ describe("ChildAttendanceComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ChildAttendanceComponent);
     component = fixture.componentInstance;
+    component.child = child;
+    fixture.detectChanges();
   });
 
   it("should create", () => {

--- a/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.ts
@@ -14,7 +14,6 @@ import { Child } from "../../children/model/child";
   templateUrl: "./child-attendance.component.html",
 })
 export class ChildAttendanceComponent implements OnChanges {
-  @Input() childId: string;
   @Input() institution: string;
   @Input() showDailyAttendanceOfLatest = false;
   @Input() child: Child;
@@ -80,7 +79,9 @@ export class ChildAttendanceComponent implements OnChanges {
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    this.loadData(this.childId);
+    if (changes.hasOwnProperty("child")) {
+      this.loadData(this.child.getId());
+    }
   }
 
   loadData(id: string) {
@@ -114,14 +115,17 @@ export class ChildAttendanceComponent implements OnChanges {
       this.records[0].month.getMonth() !== now.getMonth()
     ) {
       this.records.unshift(
-        AttendanceMonth.createAttendanceMonth(this.childId, this.institution)
+        AttendanceMonth.createAttendanceMonth(
+          this.child.getId(),
+          this.institution
+        )
       );
     }
   }
 
   generateNewRecordFactory() {
     // define values locally because 'this' is a different scope after passing a function as input to another component
-    const child = this.childId;
+    const child = this.child.getId();
     const institution = this.institution;
 
     return () => {

--- a/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/child-attendance/child-attendance.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { AttendanceMonth } from "../model/attendance-month";
 import { ChildrenService } from "../../children/children.service";
 import { ColumnDescription } from "../../../core/entity-subrecord/entity-subrecord/column-description";
@@ -7,19 +6,21 @@ import { DatePipe, PercentPipe } from "@angular/common";
 import { AttendanceDetailsComponent } from "../attendance-details/attendance-details.component";
 import { ColumnDescriptionInputType } from "../../../core/entity-subrecord/entity-subrecord/column-description-input-type.enum";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Child } from "../../children/model/child";
 
 @UntilDestroy()
 @Component({
   selector: "app-child-attendance",
   templateUrl: "./child-attendance.component.html",
 })
-export class ChildAttendanceComponent implements OnInit {
+export class ChildAttendanceComponent implements OnChanges {
   childId: string;
   records: Array<AttendanceMonth>;
   detailsComponent = AttendanceDetailsComponent;
 
   @Input() institution: string;
   @Input() showDailyAttendanceOfLatest = false;
+  @Input() child: Child;
 
   columns: Array<ColumnDescription> = [
     new ColumnDescription(
@@ -73,17 +74,15 @@ export class ChildAttendanceComponent implements OnInit {
   ];
 
   constructor(
-    private route: ActivatedRoute,
     private childrenService: ChildrenService,
     private datePipe: DatePipe,
     private percentPipe: PercentPipe
   ) {}
 
-  ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
-      this.childId = params.get("id").toString();
-      this.loadData(this.childId);
-    });
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.hasOwnProperty("child")) {
+      this.loadData(this.child.getId());
+    }
   }
 
   loadData(id: string) {

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -387,20 +387,10 @@
         Education
       </mat-expansion-panel-header>
 
-      <div
-        *ngIf="child.schoolId"
-        matTooltip="To edit the current school or class, please add to the school history below"
-      >
-        <em>
-          Currently attending class {{ child.schoolClass }} at
-          <app-school-block [entityId]="child.schoolId"></app-school-block>
-        </em>
-      </div>
-
       <div>
         <h3>School History</h3>
         <app-previous-schools
-          [childId]="child.getId()"
+          [child]="child"
           (changedRecordInEntitySubrecord)="changedRecordInEntitySubrecord()"
         >
         </app-previous-schools>

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -409,25 +409,7 @@
         </mat-icon>
         Attendance
       </mat-expansion-panel-header>
-
-      <div fxLayout="row wrap" fxLayout.lt-lg="column" fxLayoutGap="2em">
-        <div fxFlex="45">
-          <h3>School Attendance</h3>
-          <app-child-attendance
-            [childId]="child.getId()"
-            institution="school"
-            [showDailyAttendanceOfLatest]="true"
-          ></app-child-attendance>
-        </div>
-        <div fxFlex="45">
-          <h3>Coaching Attendance</h3>
-          <app-child-attendance
-            [childId]="child.getId()"
-            institution="coaching"
-            [showDailyAttendanceOfLatest]="true"
-          ></app-child-attendance>
-        </div>
-      </div>
+      <app-grouped-child-attendance [child]="child"></app-grouped-child-attendance>
     </mat-expansion-panel>
 
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -386,17 +386,11 @@
         </mat-icon>
         Education
       </mat-expansion-panel-header>
-
-      <div>
-        <h3>School History</h3>
-        <app-previous-schools [child]="child"></app-previous-schools>
-      </div>
-      <br />
-
-      <div>
-        <h3>ASER Results</h3>
-        <app-aser [child]="child"></app-aser>
-      </div>
+      <h3>School History</h3>
+      <app-previous-schools [child]="child"></app-previous-schools>
+      <br/>
+      <h3>ASER Results</h3>
+      <app-aser [child]="child"></app-aser>
     </mat-expansion-panel>
 
     <mat-expansion-panel expanded="false" title="Attendance"
@@ -438,10 +432,9 @@
         Health
       </mat-expansion-panel-header>
       <app-health-form [child]="child"></app-health-form>
-      <div>
-        <h3>Height & Weight Tracking</h3>
-        <app-health-checkup></app-health-checkup>
-      </div>
+      <br/>
+      <h3>Height & Weight Tracking</h3>
+      <app-health-checkup [child]="child"></app-health-checkup>
     </mat-expansion-panel>
 
     <mat-expansion-panel [expanded]="false"
@@ -454,7 +447,6 @@
         </mat-icon>
         Educational Materials
       </mat-expansion-panel-header>
-
       <app-educational-material [child]="child"></app-educational-material>
     </mat-expansion-panel>
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -424,7 +424,7 @@
         Notes & Reports
       </mat-expansion-panel-header>
 
-      <app-notes-of-child [childId]="child.getId()"></app-notes-of-child>
+      <app-notes-of-child [child]="child"></app-notes-of-child>
     </mat-expansion-panel>
 
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -468,40 +468,7 @@
         </mat-icon>
         Dropout
       </mat-expansion-panel-header>
-
-      <mat-form-field>
-        <input
-          matInput
-          formControlName="dropoutDate"
-          placeholder="Dropout Date"
-          [matDatepicker]="dropoutDatepicker"
-          [disabled]="!editing"
-        />
-        <mat-datepicker-toggle
-          matSuffix
-          [for]="dropoutDatepicker"
-        ></mat-datepicker-toggle>
-        <mat-datepicker #dropoutDatepicker></mat-datepicker>
-      </mat-form-field>
-
-      <mat-form-field>
-        <input
-          matInput
-          formControlName="dropoutType"
-          placeholder="Dropout Type"
-          type="text"
-        />
-      </mat-form-field>
-
-      <mat-form-field>
-        <textarea
-          matInput
-          formControlName="dropoutRemarks"
-          placeholder="Dropout Remarks"
-          type="text"
-        >
-        </textarea>
-      </mat-form-field>
+      <app-dropout-form [child]="child"></app-dropout-form>
     </mat-expansion-panel>
   </form>
 </mat-accordion>

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -395,7 +395,7 @@
 
       <div>
         <h3>ASER Results</h3>
-        <app-aser></app-aser>
+        <app-aser [child]="child"></app-aser>
       </div>
     </mat-expansion-panel>
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -455,7 +455,7 @@
         Educational Materials
       </mat-expansion-panel-header>
 
-      <app-educational-material></app-educational-material>
+      <app-educational-material [child]="child"></app-educational-material>
     </mat-expansion-panel>
 
     <mat-expansion-panel [expanded]="!child.isActive()"

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -389,11 +389,7 @@
 
       <div>
         <h3>School History</h3>
-        <app-previous-schools
-          [child]="child"
-          (changedRecordInEntitySubrecord)="changedRecordInEntitySubrecord()"
-        >
-        </app-previous-schools>
+        <app-previous-schools [child]="child"></app-previous-schools>
       </div>
       <br />
 

--- a/src/app/child-dev-project/children/child-details/child-details.component.html
+++ b/src/app/child-dev-project/children/child-details/child-details.component.html
@@ -423,7 +423,6 @@
         </mat-icon>
         Notes & Reports
       </mat-expansion-panel-header>
-
       <app-notes-of-child [child]="child"></app-notes-of-child>
     </mat-expansion-panel>
 
@@ -438,127 +437,7 @@
         </mat-icon>
         Health
       </mat-expansion-panel-header>
-
-      <div>
-        <mat-form-field>
-          <mat-label>
-            Vaccination Status
-          </mat-label>
-          <mat-select
-            [disabled]="!editing"
-            [(ngModel)]="child.health_vaccinationStatus"
-            [ngModelOptions]="{ standalone: true }"
-          >
-            <mat-option
-              *ngFor="let value of vaccinationStatusValues"
-              [value]="value"
-              >{{ value }}</mat-option
-            >
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field>
-          <mat-label>
-            Eye Status
-          </mat-label>
-          <mat-select
-            [disabled]="!editing"
-            [(ngModel)]="child.health_eyeHealthStatus"
-            [ngModelOptions]="{ standalone: true }"
-          >
-            <mat-option *ngFor="let value of eyeStatusValues" [value]="value">{{
-              value
-            }}</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field>
-          <!-- TODO: replace bloodGroup text field with a custom-select, once it is user configurable (#236) -->
-          <input
-            matInput
-            formControlName="health_bloodGroup"
-            placeholder="Blood Group"
-            type="text"
-          />
-        </mat-form-field>
-      </div>
-
-      <div>
-        <mat-form-field>
-          <input
-            matInput
-            formControlName="health_lastDentalCheckup"
-            placeholder="Last Dental Check-Up"
-            [matDatepicker]="lastDentalCheckupDatepicker"
-            [disabled]="!editing"
-          />
-          <mat-datepicker-toggle
-            matSuffix
-            [for]="lastDentalCheckupDatepicker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #lastDentalCheckupDatepicker></mat-datepicker>
-        </mat-form-field>
-
-        <mat-form-field>
-          <input
-            matInput
-            formControlName="health_lastEyeCheckup"
-            placeholder="Last Eye Check-Up"
-            [matDatepicker]="lastEyeCheckupDatepicker"
-            [disabled]="!editing"
-          />
-          <mat-datepicker-toggle
-            matSuffix
-            [for]="lastEyeCheckupDatepicker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #lastEyeCheckupDatepicker></mat-datepicker>
-        </mat-form-field>
-
-        <mat-form-field>
-          <input
-            matInput
-            formControlName="health_lastENTCheckup"
-            placeholder="Last ENT Check-Up"
-            [matDatepicker]="lastENTCheckupDatepicker"
-            [disabled]="!editing"
-          />
-          <mat-datepicker-toggle
-            matSuffix
-            [for]="lastENTCheckupDatepicker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #lastENTCheckupDatepicker></mat-datepicker>
-        </mat-form-field>
-
-        <mat-form-field>
-          <input
-            matInput
-            formControlName="health_lastVitaminD"
-            placeholder="Last Vitamin D"
-            [matDatepicker]="lastVitaminDDatepicker"
-            [disabled]="!editing"
-          />
-          <mat-datepicker-toggle
-            matSuffix
-            [for]="lastVitaminDDatepicker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #lastVitaminDDatepicker></mat-datepicker>
-        </mat-form-field>
-        <mat-form-field>
-          <input
-            matInput
-            formControlName="health_lastDeworming"
-            placeholder="Last De-Worming"
-            [matDatepicker]="lastDewormingDatepicker"
-            [disabled]="!editing"
-          />
-          <mat-datepicker-toggle
-            matSuffix
-            [for]="lastDewormingDatepicker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #lastDewormingDatepicker></mat-datepicker>
-        </mat-form-field>
-      </div>
-
+      <app-health-form [child]="child"></app-health-form>
       <div>
         <h3>Height & Weight Tracking</h3>
         <app-health-checkup></app-health-checkup>

--- a/src/app/child-dev-project/children/child-details/child-details.component.ts
+++ b/src/app/child-dev-project/children/child-details/child-details.component.ts
@@ -42,7 +42,6 @@ export class ChildDetailsComponent implements OnInit {
 
   validateForm = false;
   form: FormGroup;
-  healthCheckForm: FormGroup;
   creatingNew = false;
   editing = false;
   enablePhotoUpload;
@@ -165,7 +164,7 @@ export class ChildDetailsComponent implements OnInit {
             this.router.navigate(["/child", this.child.getId()]);
             this.creatingNew = false;
           }
-          this.alertService.addInfo("Saving Succesfull");
+          this.alertService.addInfo("Saving Successful");
           this.switchEdit();
         })
         .catch((err) =>

--- a/src/app/child-dev-project/children/child-details/child-details.component.ts
+++ b/src/app/child-dev-project/children/child-details/child-details.component.ts
@@ -121,33 +121,6 @@ export class ChildDetailsComponent implements OnInit {
       // rationCard:     [{value: this.child.has_rationCard,     disabled: !this.editing}],
       // bplCard:        [{value: this.child.has_BplCard,        disabled: !this.editing}],
 
-      // health_vaccinationStatus:    [{value: this.child.health_vaccinationStatus,    disabled: !this.editing}],
-      health_bloodGroup: [
-        { value: this.child.health_bloodGroup, disabled: !this.editing },
-      ],
-      health_lastDentalCheckup: [
-        { value: this.child.health_lastDentalCheckup, disabled: !this.editing },
-      ],
-      health_lastEyeCheckup: [
-        { value: this.child.health_lastEyeCheckup, disabled: !this.editing },
-      ],
-      // health_eyeHealthStatus:   [{value: this.child.health_eyeHealthStatus,    disabled: !this.editing}],
-      health_lastENTCheckup: [
-        { value: this.child.health_lastENTCheckup, disabled: !this.editing },
-      ],
-      health_lastVitaminD: [
-        { value: this.child.health_lastVitaminD, disabled: !this.editing },
-      ],
-      health_lastDeworming: [
-        { value: this.child.health_lastDeworming, disabled: !this.editing },
-      ],
-
-      dropoutDate: [{ value: this.child.dropoutDate, disabled: !this.editing }],
-      dropoutType: [{ value: this.child.dropoutType, disabled: !this.editing }],
-      dropoutRemarks: [
-        { value: this.child.dropoutRemarks, disabled: !this.editing },
-      ],
-
       photoFile: [{ value: this.child.photoFile, disabled: !this.editing }],
     });
   }

--- a/src/app/child-dev-project/children/child-details/child-details.component.ts
+++ b/src/app/child-dev-project/children/child-details/child-details.component.ts
@@ -177,15 +177,6 @@ export class ChildDetailsComponent implements OnInit {
     this.initForm();
   }
 
-  changedRecordInEntitySubrecord() {
-    this.childrenService
-      .getChild(this.child.getId())
-      .pipe(untilDestroyed(this))
-      .subscribe((child) => {
-        this.child = child;
-      });
-  }
-
   switchEdit() {
     this.editing = !this.editing;
     this.enablePhotoUpload = this.childPhotoService.canSetImage();

--- a/src/app/child-dev-project/children/child-details/child-details.component.ts
+++ b/src/app/child-dev-project/children/child-details/child-details.component.ts
@@ -58,13 +58,7 @@ export class ChildDetailsComponent implements OnInit {
     "not eligible",
     "",
   ];
-  eyeStatusValues = ["Good", "Has Glasses", "Needs Glasses", "Needs Checkup"];
-  vaccinationStatusValues = [
-    "Good",
-    "Vaccination Due",
-    "Needs Checking",
-    "No Card/Information",
-  ];
+
   isAdminUser: boolean;
 
   constructor(

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.html
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.html
@@ -1,40 +1,65 @@
-<mat-form-field>
-    <input
-            matInput
-            [(ngModel)]="child.dropoutDate"
-            placeholder="Dropout Date"
-            [matDatepicker]="dropoutDatepicker"
-    />
-    <mat-datepicker-toggle
-            matSuffix
-            [for]="dropoutDatepicker"
-    ></mat-datepicker-toggle>
-    <mat-datepicker #dropoutDatepicker></mat-datepicker>
-</mat-form-field>
-
-<mat-form-field>
-    <input
-            matInput
-            [(ngModel)]="child.dropoutType"
-            placeholder="Dropout Type"
-            type="text"
-    />
-</mat-form-field>
-
-<mat-form-field>
-        <textarea
+<div>
+    <mat-form-field>
+        <input
                 matInput
-                [(ngModel)]="child.dropoutRemarks"
-                placeholder="Dropout Remarks"
+                [(ngModel)]="child.dropoutDate"
+                placeholder="Dropout Date"
+                [matDatepicker]="dropoutDatepicker"
+                [disabled]="!editing"
+        />
+        <mat-datepicker-toggle
+                matSuffix
+                [for]="dropoutDatepicker"
+        ></mat-datepicker-toggle>
+        <mat-datepicker #dropoutDatepicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field>
+        <input
+                matInput
+                [(ngModel)]="child.dropoutType"
+                placeholder="Dropout Type"
                 type="text"
-        >
-        </textarea>
-</mat-form-field>
-<button
-        mat-stroked-button
-        class="edit-button"
-        (click)="save()"
-        style="float: right;"
->Save Dropout</button>
-<!--    clear floating from save button -->
-<div style="clear: both;"></div>
+                [disabled]="!editing"
+        />
+    </mat-form-field>
+
+    <mat-form-field>
+            <textarea
+                    matInput
+                    [(ngModel)]="child.dropoutRemarks"
+                    placeholder="Dropout Remarks"
+                    type="text"
+                    [disabled]="!editing"
+            >
+            </textarea>
+    </mat-form-field>
+</div>
+<div>
+    <button
+            *ngIf="editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="save()"
+    >
+        Save
+    </button>
+
+    <button
+            *ngIf="editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="cancel()"
+    >
+        Cancel
+    </button>
+
+    <button
+            *ngIf="!editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="edit()"
+    >
+        Edit
+    </button>
+</div>

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.html
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.html
@@ -1,0 +1,40 @@
+<mat-form-field>
+    <input
+            matInput
+            [(ngModel)]="child.dropoutDate"
+            placeholder="Dropout Date"
+            [matDatepicker]="dropoutDatepicker"
+    />
+    <mat-datepicker-toggle
+            matSuffix
+            [for]="dropoutDatepicker"
+    ></mat-datepicker-toggle>
+    <mat-datepicker #dropoutDatepicker></mat-datepicker>
+</mat-form-field>
+
+<mat-form-field>
+    <input
+            matInput
+            [(ngModel)]="child.dropoutType"
+            placeholder="Dropout Type"
+            type="text"
+    />
+</mat-form-field>
+
+<mat-form-field>
+        <textarea
+                matInput
+                [(ngModel)]="child.dropoutRemarks"
+                placeholder="Dropout Remarks"
+                type="text"
+        >
+        </textarea>
+</mat-form-field>
+<button
+        mat-stroked-button
+        class="edit-button"
+        (click)="save()"
+        style="float: right;"
+>Save Dropout</button>
+<!--    clear floating from save button -->
+<div style="clear: both;"></div>

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.scss
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.scss
@@ -1,0 +1,7 @@
+.mat-form-field {
+  margin-right: 10px;
+}
+
+.edit-button {
+  margin-left: 10px;
+}

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.spec.ts
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { DropoutFormComponent } from "./dropout-form.component";
+
+describe("DropoutFormComponent", () => {
+  let component: DropoutFormComponent;
+  let fixture: ComponentFixture<DropoutFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DropoutFormComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DropoutFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.spec.ts
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.spec.ts
@@ -1,6 +1,17 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { DropoutFormComponent } from "./dropout-form.component";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+import { Database } from "../../../../core/database/database";
+import { MockDatabase } from "../../../../core/database/mock-database";
+import { EntitySchemaService } from "../../../../core/entity/schema/entity-schema.service";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatDatepickerModule } from "@angular/material/datepicker";
+import { MatNativeDateModule } from "@angular/material/core";
+import { Child } from "../../model/child";
+import { MatInputModule } from "@angular/material/input";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { FormsModule } from "@angular/forms";
 
 describe("DropoutFormComponent", () => {
   let component: DropoutFormComponent;
@@ -9,12 +20,26 @@ describe("DropoutFormComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DropoutFormComponent],
+      imports: [
+        MatFormFieldModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        MatInputModule,
+        NoopAnimationsModule,
+        FormsModule,
+      ],
+      providers: [
+        EntityMapperService,
+        EntitySchemaService,
+        { provide: Database, useClass: MockDatabase },
+      ],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DropoutFormComponent);
     component = fixture.componentInstance;
+    component.child = new Child("1");
     fixture.detectChanges();
   });
 

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.ts
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from "@angular/core";
+import { Child } from "../../model/child";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+
+@Component({
+  selector: "app-dropout-form",
+  templateUrl: "./dropout-form.component.html",
+  styleUrls: ["./dropout-form.component.scss"],
+})
+export class DropoutFormComponent {
+  @Input() child: Child;
+
+  constructor(private entityMapper: EntityMapperService) {}
+
+  save() {
+    // Saving will save all the fields of the child, not just the dropout information
+    // Undoing changes that were not saved yet can be done by re-entering the view
+    this.entityMapper.save<Child>(this.child);
+  }
+}

--- a/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.ts
+++ b/src/app/child-dev-project/children/child-details/dropout-form/dropout-form.component.ts
@@ -9,12 +9,27 @@ import { EntityMapperService } from "../../../../core/entity/entity-mapper.servi
 })
 export class DropoutFormComponent {
   @Input() child: Child;
+  editing: boolean = false;
 
   constructor(private entityMapper: EntityMapperService) {}
 
   save() {
-    // Saving will save all the fields of the child, not just the dropout information
-    // Undoing changes that were not saved yet can be done by re-entering the view
+    this.editing = false;
     this.entityMapper.save<Child>(this.child);
+  }
+
+  edit() {
+    this.editing = true;
+  }
+
+  cancel() {
+    this.editing = false;
+    this.entityMapper
+      .load<Child>(Child, this.child.getId())
+      .then((tmpChild) => {
+        this.child.dropoutDate = tmpChild.dropoutDate;
+        this.child.dropoutType = tmpChild.dropoutType;
+        this.child.dropoutRemarks = tmpChild.dropoutRemarks;
+      });
   }
 }

--- a/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.html
+++ b/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.html
@@ -1,0 +1,18 @@
+<div fxLayout="row wrap" fxLayout.lt-lg="column" fxLayoutGap="2em">
+    <div fxFlex="45">
+        <h3>School Attendance</h3>
+        <app-child-attendance
+                [child]="child"
+                institution="school"
+                [showDailyAttendanceOfLatest]="true"
+        ></app-child-attendance>
+    </div>
+    <div fxFlex="45">
+        <h3>Coaching Attendance</h3>
+        <app-child-attendance
+                [child]="child"
+                institution="coaching"
+                [showDailyAttendanceOfLatest]="true"
+        ></app-child-attendance>
+    </div>
+</div>

--- a/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.spec.ts
+++ b/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { GroupedChildAttendanceComponent } from "./grouped-child-attendance.component";
+
+describe("GroupedChildAttendanceComponent", () => {
+  let component: GroupedChildAttendanceComponent;
+  let fixture: ComponentFixture<GroupedChildAttendanceComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [GroupedChildAttendanceComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupedChildAttendanceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.ts
+++ b/src/app/child-dev-project/children/child-details/grouped-child-attendance/grouped-child-attendance.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { Child } from "../../model/child";
+
+@Component({
+  selector: "app-grouped-child-attendance",
+  templateUrl: "./grouped-child-attendance.component.html",
+  styleUrls: ["./grouped-child-attendance.component.scss"],
+})
+export class GroupedChildAttendanceComponent {
+  @Input() child: Child;
+
+  constructor() {}
+}

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.html
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.html
@@ -1,0 +1,119 @@
+<div>
+    <mat-form-field>
+        <mat-label>
+            Vaccination Status
+        </mat-label>
+        <mat-select
+                [(ngModel)]="child.health_vaccinationStatus"
+                [ngModelOptions]="{ standalone: true }"
+        >
+            <mat-option
+                    *ngFor="let value of vaccinationStatusValues"
+                    [value]="value"
+            >{{ value }}</mat-option
+            >
+        </mat-select>
+    </mat-form-field>
+
+    <mat-form-field>
+        <mat-label>
+            Eye Status
+        </mat-label>
+        <mat-select
+                [(ngModel)]="child.health_eyeHealthStatus"
+                [ngModelOptions]="{ standalone: true }"
+        >
+            <mat-option *ngFor="let value of eyeStatusValues" [value]="value">
+                {{value}}
+            </mat-option>
+        </mat-select>
+    </mat-form-field>
+
+    <mat-form-field>
+        <!-- TODO: replace bloodGroup text field with a custom-select, once it is user configurable (#236) -->
+        <input
+                matInput
+                [(ngModel)]="child.health_bloodGroup"
+                placeholder="Blood Group"
+                type="text"
+        />
+    </mat-form-field>
+    <div>
+        <mat-form-field>
+            <input
+                    matInput
+                    [(ngModel)]="child.health_lastDentalCheckup"
+                    placeholder="Last Dental Check-Up"
+                    [matDatepicker]="lastDentalCheckupDatepicker"
+            />
+            <mat-datepicker-toggle
+                    matSuffix
+                    [for]="lastDentalCheckupDatepicker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #lastDentalCheckupDatepicker></mat-datepicker>
+        </mat-form-field>
+
+        <mat-form-field>
+            <input
+                    matInput
+                    [(ngModel)]="child.health_lastEyeCheckup"
+                    placeholder="Last Eye Check-Up"
+                    [matDatepicker]="lastEyeCheckupDatepicker"
+            />
+            <mat-datepicker-toggle
+                    matSuffix
+                    [for]="lastEyeCheckupDatepicker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #lastEyeCheckupDatepicker></mat-datepicker>
+        </mat-form-field>
+
+        <mat-form-field>
+            <input
+                    matInput
+                    [(ngModel)]="child.health_lastENTCheckup"
+                    placeholder="Last ENT Check-Up"
+                    [matDatepicker]="lastENTCheckupDatepicker"
+            />
+            <mat-datepicker-toggle
+                    matSuffix
+                    [for]="lastENTCheckupDatepicker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #lastENTCheckupDatepicker></mat-datepicker>
+        </mat-form-field>
+
+        <mat-form-field>
+            <input
+                    matInput
+                    [(ngModel)]="child.health_lastVitaminD"
+                    placeholder="Last Vitamin D"
+                    [matDatepicker]="lastVitaminDDatepicker"
+            />
+            <mat-datepicker-toggle
+                    matSuffix
+                    [for]="lastVitaminDDatepicker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #lastVitaminDDatepicker></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field>
+            <input
+                    matInput
+                    [(ngModel)]="child.health_lastDeworming"
+                    placeholder="Last De-Worming"
+                    [matDatepicker]="lastDewormingDatepicker"
+            />
+            <mat-datepicker-toggle
+                    matSuffix
+                    [for]="lastDewormingDatepicker"
+            ></mat-datepicker-toggle>
+            <mat-datepicker #lastDewormingDatepicker></mat-datepicker>
+        </mat-form-field>
+        <button
+                mat-stroked-button
+                class="edit-button"
+                (click)="save()"
+                style="float: right;"
+        >Save Health</button>
+    </div>
+<!--    clear floating from save button -->
+    <div style="clear: both;"></div>
+</div>

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.html
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.html
@@ -6,6 +6,7 @@
         <mat-select
                 [(ngModel)]="child.health_vaccinationStatus"
                 [ngModelOptions]="{ standalone: true }"
+                [disabled]="!editing"
         >
             <mat-option
                     *ngFor="let value of vaccinationStatusValues"
@@ -22,6 +23,7 @@
         <mat-select
                 [(ngModel)]="child.health_eyeHealthStatus"
                 [ngModelOptions]="{ standalone: true }"
+                [disabled]="!editing"
         >
             <mat-option *ngFor="let value of eyeStatusValues" [value]="value">
                 {{value}}
@@ -36,6 +38,7 @@
                 [(ngModel)]="child.health_bloodGroup"
                 placeholder="Blood Group"
                 type="text"
+                [disabled]="!editing"
         />
     </mat-form-field>
     <div>
@@ -45,6 +48,7 @@
                     [(ngModel)]="child.health_lastDentalCheckup"
                     placeholder="Last Dental Check-Up"
                     [matDatepicker]="lastDentalCheckupDatepicker"
+                    [disabled]="!editing"
             />
             <mat-datepicker-toggle
                     matSuffix
@@ -59,6 +63,7 @@
                     [(ngModel)]="child.health_lastEyeCheckup"
                     placeholder="Last Eye Check-Up"
                     [matDatepicker]="lastEyeCheckupDatepicker"
+                    [disabled]="!editing"
             />
             <mat-datepicker-toggle
                     matSuffix
@@ -73,6 +78,7 @@
                     [(ngModel)]="child.health_lastENTCheckup"
                     placeholder="Last ENT Check-Up"
                     [matDatepicker]="lastENTCheckupDatepicker"
+                    [disabled]="!editing"
             />
             <mat-datepicker-toggle
                     matSuffix
@@ -87,6 +93,7 @@
                     [(ngModel)]="child.health_lastVitaminD"
                     placeholder="Last Vitamin D"
                     [matDatepicker]="lastVitaminDDatepicker"
+                    [disabled]="!editing"
             />
             <mat-datepicker-toggle
                     matSuffix
@@ -100,6 +107,7 @@
                     [(ngModel)]="child.health_lastDeworming"
                     placeholder="Last De-Worming"
                     [matDatepicker]="lastDewormingDatepicker"
+                    [disabled]="!editing"
             />
             <mat-datepicker-toggle
                     matSuffix
@@ -107,13 +115,33 @@
             ></mat-datepicker-toggle>
             <mat-datepicker #lastDewormingDatepicker></mat-datepicker>
         </mat-form-field>
-        <button
-                mat-stroked-button
-                class="edit-button"
-                (click)="save()"
-                style="float: right;"
-        >Save Health</button>
     </div>
-<!--    clear floating from save button -->
-    <div style="clear: both;"></div>
+</div>
+<div>
+    <button
+            *ngIf="editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="save()"
+    >
+        Save
+    </button>
+
+    <button
+            *ngIf="editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="cancel()"
+    >
+        Cancel
+    </button>
+
+    <button
+            *ngIf="!editing"
+            mat-stroked-button
+            class="edit-button"
+            (click)="edit()"
+    >
+        Edit
+    </button>
 </div>

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.scss
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.scss
@@ -1,0 +1,7 @@
+.mat-form-field {
+  margin-right: 10px;
+}
+
+.edit-button {
+  margin-left: 10px;
+}

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.spec.ts
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { HealthFormComponent } from "./health-form.component";
+
+describe("HealthFormComponent", () => {
+  let component: HealthFormComponent;
+  let fixture: ComponentFixture<HealthFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [HealthFormComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HealthFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.spec.ts
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.spec.ts
@@ -1,6 +1,18 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { HealthFormComponent } from "./health-form.component";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+import { Database } from "../../../../core/database/database";
+import { MockDatabase } from "../../../../core/database/mock-database";
+import { EntitySchemaService } from "../../../../core/entity/schema/entity-schema.service";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatDatepickerModule } from "@angular/material/datepicker";
+import { MatNativeDateModule, MatOptionModule } from "@angular/material/core";
+import { Child } from "../../model/child";
+import { MatInput, MatInputModule } from "@angular/material/input";
+import { MatSelect, MatSelectModule } from "@angular/material/select";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { FormsModule } from "@angular/forms";
 
 describe("HealthFormComponent", () => {
   let component: HealthFormComponent;
@@ -9,12 +21,28 @@ describe("HealthFormComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [HealthFormComponent],
+      imports: [
+        MatFormFieldModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        MatInputModule,
+        MatSelectModule,
+        MatOptionModule,
+        NoopAnimationsModule,
+        FormsModule,
+      ],
+      providers: [
+        EntityMapperService,
+        EntitySchemaService,
+        { provide: Database, useClass: MockDatabase },
+      ],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HealthFormComponent);
     component = fixture.componentInstance;
+    component.child = new Child("1");
     fixture.detectChanges();
   });
 

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
@@ -1,13 +1,6 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
-} from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { Child } from "../../model/child";
 import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
-import { FormBuilder, FormGroup } from "@angular/forms";
 
 @Component({
   selector: "app-health-form",

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
@@ -16,12 +16,32 @@ export class HealthFormComponent {
   ];
   eyeStatusValues = ["Good", "Has Glasses", "Needs Glasses", "Needs Checkup"];
   @Input() child: Child;
+  editing: boolean = false;
 
   constructor(private entityMapper: EntityMapperService) {}
 
   save() {
-    // Saving will save all the fields of the child, not just the health information
-    // Undoing changes that were not saved yet can be done by re-entering the view
+    this.editing = false;
     this.entityMapper.save<Child>(this.child);
+  }
+
+  edit() {
+    this.editing = true;
+  }
+
+  cancel() {
+    this.editing = false;
+    this.entityMapper
+      .load<Child>(Child, this.child.getId())
+      .then((tmpChild) => {
+        this.child.health_vaccinationStatus = tmpChild.health_vaccinationStatus;
+        this.child.health_eyeHealthStatus = tmpChild.health_eyeHealthStatus;
+        this.child.health_bloodGroup = tmpChild.health_bloodGroup;
+        this.child.health_lastDentalCheckup = tmpChild.health_lastDentalCheckup;
+        this.child.health_lastEyeCheckup = tmpChild.health_lastEyeCheckup;
+        this.child.health_lastENTCheckup = tmpChild.health_lastENTCheckup;
+        this.child.health_lastVitaminD = tmpChild.health_lastVitaminD;
+        this.child.health_lastDeworming = tmpChild.health_lastDeworming;
+      });
   }
 }

--- a/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
+++ b/src/app/child-dev-project/children/child-details/health-form/health-form.component.ts
@@ -1,0 +1,34 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from "@angular/core";
+import { Child } from "../../model/child";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+import { FormBuilder, FormGroup } from "@angular/forms";
+
+@Component({
+  selector: "app-health-form",
+  templateUrl: "./health-form.component.html",
+  styleUrls: ["./health-form.component.scss"],
+})
+export class HealthFormComponent {
+  vaccinationStatusValues = [
+    "Good",
+    "Vaccination Due",
+    "Needs Checking",
+    "No Card/Information",
+  ];
+  eyeStatusValues = ["Good", "Has Glasses", "Needs Glasses", "Needs Checkup"];
+  @Input() child: Child;
+
+  constructor(private entityMapper: EntityMapperService) {}
+
+  save() {
+    // Saving will save all the fields of the child, not just the health information
+    // Undoing changes that were not saved yet can be done by re-entering the view
+    this.entityMapper.save<Child>(this.child);
+  }
+}

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -81,6 +81,7 @@ import { Angulartics2Module } from "angulartics2";
 import { AttendanceAnalysisComponent } from "../attendance/attendance-analysis/attendance-analysis.component";
 import { GroupedChildAttendanceComponent } from "./child-details/grouped-child-attendance/grouped-child-attendance.component";
 import { HealthFormComponent } from "./child-details/health-form/health-form.component";
+import { DropoutFormComponent } from "./child-details/dropout-form/dropout-form.component";
 
 @NgModule({
   imports: [
@@ -150,6 +151,8 @@ import { HealthFormComponent } from "./child-details/health-form/health-form.com
     PreviousSchoolsComponent,
     GroupedChildAttendanceComponent,
     HealthFormComponent,
+    DropoutFormComponent,
+    DropoutFormComponent,
   ],
   providers: [
     ChildrenService,

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -152,7 +152,6 @@ import { DropoutFormComponent } from "./child-details/dropout-form/dropout-form.
     GroupedChildAttendanceComponent,
     HealthFormComponent,
     DropoutFormComponent,
-    DropoutFormComponent,
   ],
   providers: [
     ChildrenService,

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -80,6 +80,7 @@ import { MatPaginatorModule } from "@angular/material/paginator";
 import { Angulartics2Module } from "angulartics2";
 import { AttendanceAnalysisComponent } from "../attendance/attendance-analysis/attendance-analysis.component";
 import { GroupedChildAttendanceComponent } from "./child-details/grouped-child-attendance/grouped-child-attendance.component";
+import { HealthFormComponent } from "./child-details/health-form/health-form.component";
 
 @NgModule({
   imports: [
@@ -148,6 +149,7 @@ import { GroupedChildAttendanceComponent } from "./child-details/grouped-child-a
     HealthCheckupComponent,
     PreviousSchoolsComponent,
     GroupedChildAttendanceComponent,
+    HealthFormComponent,
   ],
   providers: [
     ChildrenService,

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -79,6 +79,7 @@ import { AttendanceMonthConflictResolutionStrategy } from "../attendance/attenda
 import { MatPaginatorModule } from "@angular/material/paginator";
 import { Angulartics2Module } from "angulartics2";
 import { AttendanceAnalysisComponent } from "../attendance/attendance-analysis/attendance-analysis.component";
+import { GroupedChildAttendanceComponent } from "./child-details/grouped-child-attendance/grouped-child-attendance.component";
 
 @NgModule({
   imports: [
@@ -146,6 +147,7 @@ import { AttendanceAnalysisComponent } from "../attendance/attendance-analysis/a
     AttendanceAnalysisComponent,
     HealthCheckupComponent,
     PreviousSchoolsComponent,
+    GroupedChildAttendanceComponent,
   ],
   providers: [
     ChildrenService,

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
@@ -2,7 +2,6 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EducationalMaterialComponent } from "./educational-material.component";
 import { FormsModule } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
 import { ChildrenService } from "../../children/children.service";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { MockDatabase } from "../../../core/database/mock-database";
@@ -33,10 +32,6 @@ describe("EducationalMaterialComponent", () => {
       imports: [FormsModule, NoopAnimationsModule, ChildrenModule],
       providers: [
         DatePipe,
-        {
-          provide: ActivatedRoute,
-          useValue: { paramMap: of({ get: () => "22" }) },
-        },
         { provide: ChildrenService, useValue: mockChildrenService },
         EntityMapperService,
         EntitySchemaService,
@@ -49,6 +44,7 @@ describe("EducationalMaterialComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EducationalMaterialComponent);
     component = fixture.componentInstance;
+    component.child = new Child("22");
     fixture.detectChanges();
   });
 

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -87,7 +87,6 @@ export class EducationalMaterialComponent implements OnChanges {
 
       // use last entered date as default, otherwise today's date
       newAtt.date = this.records.length > 0 ? this.records[0].date : new Date();
-
       newAtt.child = child;
 
       return newAtt;

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -1,19 +1,19 @@
-import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { DatePipe } from "@angular/common";
 import { EducationalMaterial } from "../model/educational-material";
 import { ColumnDescription } from "../../../core/entity-subrecord/entity-subrecord/column-description";
 import { ChildrenService } from "../../children/children.service";
 import { ColumnDescriptionInputType } from "../../../core/entity-subrecord/entity-subrecord/column-description-input-type.enum";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Child } from "../../children/model/child";
 
 @UntilDestroy()
 @Component({
   selector: "app-educational-material",
   templateUrl: "./educational-material.component.html",
 })
-export class EducationalMaterialComponent implements OnInit {
-  childId: string;
+export class EducationalMaterialComponent implements OnChanges {
+  @Input() child: Child;
   records = new Array<EducationalMaterial>();
 
   materialTypes = EducationalMaterial.MATERIAL_ALL;
@@ -56,16 +56,14 @@ export class EducationalMaterialComponent implements OnInit {
   ];
 
   constructor(
-    private route: ActivatedRoute,
     private childrenService: ChildrenService,
     private datePipe: DatePipe
   ) {}
 
-  ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
-      this.childId = params.get("id").toString();
-      this.loadData(this.childId);
-    });
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.hasOwnProperty("child")) {
+      this.loadData(this.child.getId());
+    }
   }
 
   loadData(id: string) {
@@ -82,7 +80,7 @@ export class EducationalMaterialComponent implements OnInit {
 
   generateNewRecordFactory() {
     // define values locally because "this" is a different scope after passing a function as input to another component
-    const child = this.childId;
+    const child = this.child.getId();
 
     return () => {
       const newAtt = new EducationalMaterial(Date.now().toString());

--- a/src/app/child-dev-project/health-checkup/health-checkup-component/health-checkup.component.spec.ts
+++ b/src/app/child-dev-project/health-checkup/health-checkup-component/health-checkup.component.spec.ts
@@ -42,10 +42,6 @@ describe("HealthCheckupComponent", () => {
         MatSnackBar,
         ConfirmationDialogService,
         MatDialog,
-        {
-          provide: ActivatedRoute,
-          useValue: { paramMap: of({ get: () => "22" }) },
-        },
         { provide: ChildrenService, useValue: mockChildrenService },
         { provide: EntityMapperService, useValue: mockEntityMapper },
         AlertService,
@@ -56,6 +52,7 @@ describe("HealthCheckupComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HealthCheckupComponent);
     component = fixture.componentInstance;
+    component.child = new Child("22");
     fixture.detectChanges();
   });
 

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.html
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.html
@@ -2,5 +2,5 @@
                       [columns]="columns"
                       [newRecordFactory]="generateNewRecordFactory()"
                       [detailsComponent]="detailsComponent"
-                      [entityId]="childId">
+                      [entityId]="child.getId()">
 </app-entity-subrecord>

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
@@ -5,31 +5,21 @@ import { MatNativeDateModule } from "@angular/material/core";
 import { ChildrenService } from "../../children/children.service";
 import { DatePipe } from "@angular/common";
 import { Note } from "../model/note";
-import { RouterTestingModule } from "@angular/router/testing";
-import { Observable } from "rxjs";
-import { ActivatedRoute } from "@angular/router";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { MockDatabase } from "../../../core/database/mock-database";
 import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
 import { Database } from "../../../core/database/database";
-import { User } from "../../../core/user/user";
 import { SessionService } from "../../../core/session/session-service/session.service";
+import { Child } from "../../children/model/child";
+import { User } from "../../../core/user/user";
 
-const mockedRoute = {
-  paramMap: Observable.create((observer) =>
-    observer.next({
-      get: () => "1",
-    })
-  ),
-};
+const allChildren: Array<Note> = [];
 
 const mockedSessionService = {
   getCurrentUser(): User {
     return new User("1");
   },
 };
-
-const allChildren: Array<Note> = [];
 
 describe("NotesOfChildComponent", () => {
   let component: NotesOfChildComponent;
@@ -43,7 +33,7 @@ describe("NotesOfChildComponent", () => {
     ]);
 
     TestBed.configureTestingModule({
-      imports: [NotesModule, MatNativeDateModule, RouterTestingModule],
+      imports: [NotesModule, MatNativeDateModule],
       providers: [
         { provide: ChildrenService, useValue: mockChildrenService },
         EntitySchemaService,
@@ -51,7 +41,6 @@ describe("NotesOfChildComponent", () => {
         { provide: SessionService, useValue: mockedSessionService },
         { provide: Database, useClass: MockDatabase },
         { provide: DatePipe, useValue: new DatePipe("medium") },
-        { provide: ActivatedRoute, useValue: mockedRoute },
       ],
     }).compileComponents();
   });
@@ -59,7 +48,8 @@ describe("NotesOfChildComponent", () => {
   beforeEach(async () => {
     fixture = TestBed.createComponent(NotesOfChildComponent);
     component = fixture.componentInstance;
-    component.ngOnInit();
+    component.child = new Child("1");
+    fixture.detectChanges();
   });
 
   it("should create", () => {

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
@@ -14,6 +14,7 @@ import { SessionService } from "../../../core/session/session-service/session.se
 import { ColumnDescription } from "../../../core/entity-subrecord/entity-subrecord/column-description";
 import { ColumnDescriptionInputType } from "../../../core/entity-subrecord/entity-subrecord/column-description-input-type.enum";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Child } from "../../children/model/child";
 
 /**
  * The component that is responsible for listing the Notes that are related to a certain child
@@ -24,8 +25,8 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
   templateUrl: "./notes-of-child.component.html",
   styleUrls: ["./notes-of-child.component.scss"],
 })
-export class NotesOfChildComponent implements OnInit, OnChanges {
-  @Input() childId: string;
+export class NotesOfChildComponent implements OnChanges {
+  @Input() child: Child;
   records: Array<Note> = [];
   detailsComponent = NoteDetailsComponent;
 
@@ -82,23 +83,15 @@ export class NotesOfChildComponent implements OnInit, OnChanges {
     private datePipe: DatePipe
   ) {}
 
-  ngOnInit() {
-    this.initNotesOfChild();
-  }
-
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.hasOwnProperty("childId")) {
+    if (changes.hasOwnProperty("child")) {
       this.initNotesOfChild();
     }
   }
 
   private initNotesOfChild() {
-    if (!this.childId || this.childId === "") {
-      return;
-    }
-
     this.childrenService
-      .getNotesOfChild(this.childId)
+      .getNotesOfChild(this.child.getId())
       .pipe(untilDestroyed(this))
       .subscribe((notes: Note[]) => {
         notes.sort((a, b) => {
@@ -117,7 +110,7 @@ export class NotesOfChildComponent implements OnInit, OnChanges {
     const user = this.sessionService.getCurrentUser()
       ? this.sessionService.getCurrentUser().name
       : "";
-    const childId = this.childId;
+    const childId = this.child.getId();
 
     return () => {
       const newNote = new Note(Date.now().toString());

--- a/src/app/child-dev-project/previous-schools/previous-schools.component.html
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.html
@@ -1,3 +1,13 @@
+<div
+        *ngIf="child.schoolId"
+        matTooltip="To edit the current school or class, please add to the school history below"
+>
+    <em>
+        Currently attending class {{ child.schoolClass }} at
+        <app-school-block [entityId]="child.schoolId"></app-school-block>
+    </em>
+</div>
+
 <app-entity-subrecord
   (changedRecordsInEntitySubrecordEvent)="changedRecordInEntitySubrecord.emit()"
   [records]="records"

--- a/src/app/child-dev-project/previous-schools/previous-schools.component.spec.ts
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.spec.ts
@@ -14,13 +14,14 @@ import { SessionService } from "../../core/session/session-service/session.servi
 import { ChildPhotoService } from "../children/child-photo-service/child-photo.service";
 import { ConfirmationDialogModule } from "../../core/confirmation-dialog/confirmation-dialog.module";
 import { SimpleChange } from "@angular/core";
+import { Child } from "../children/model/child";
 
 describe("PreviousSchoolsComponent", () => {
   let component: PreviousSchoolsComponent;
   let fixture: ComponentFixture<PreviousSchoolsComponent>;
 
   const mockedSession = { getCurrentUser: () => "testUser" };
-  const testChildId = "22";
+  const testChild = new Child("22");
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -56,15 +57,15 @@ describe("PreviousSchoolsComponent", () => {
     spyOn(component, "loadData").and.callThrough();
     spyOn(childrenService, "getSchoolsWithRelations").and.callThrough();
 
-    component.childId = testChildId;
+    component.child = testChild;
     component.ngOnChanges({
-      childId: new SimpleChange(undefined, testChildId, false),
+      child: new SimpleChange(undefined, testChild, false),
     });
 
     fixture.whenStable().then(() => {
-      expect(component.loadData).toHaveBeenCalledWith(testChildId);
+      expect(component.loadData).toHaveBeenCalledWith(testChild.getId());
       expect(childrenService.getSchoolsWithRelations).toHaveBeenCalledWith(
-        testChildId
+        testChild.getId()
       );
       done();
     });

--- a/src/app/child-dev-project/previous-schools/previous-schools.component.spec.ts
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.spec.ts
@@ -45,6 +45,7 @@ describe("PreviousSchoolsComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PreviousSchoolsComponent);
     component = fixture.componentInstance;
+    component.child = testChild;
     fixture.detectChanges();
   });
 
@@ -52,12 +53,11 @@ describe("PreviousSchoolsComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("calls children service with id from route", (done) => {
+  it("it calls children service with id from passed child", (done) => {
     const childrenService = fixture.debugElement.injector.get(ChildrenService);
     spyOn(component, "loadData").and.callThrough();
     spyOn(childrenService, "getSchoolsWithRelations").and.callThrough();
 
-    component.child = testChild;
     component.ngOnChanges({
       child: new SimpleChange(undefined, testChild, false),
     });

--- a/src/app/child-dev-project/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.ts
@@ -16,6 +16,7 @@ import { ColumnDescription } from "../../core/entity-subrecord/entity-subrecord/
 import { ColumnDescriptionInputType } from "../../core/entity-subrecord/entity-subrecord/column-description-input-type.enum";
 import moment from "moment";
 import { isValidDate } from "../../utils/utils";
+import { Child } from "../children/model/child";
 
 @Component({
   selector: "app-previous-schools",
@@ -39,7 +40,7 @@ export class PreviousSchoolsComponent implements OnInit, OnChanges {
     return "hsl(" + color + ", 100%, 85%)";
   }
 
-  @Input() childId: string;
+  @Input() child: Child;
   @Output() changedRecordInEntitySubrecord = new EventEmitter<any>();
   records = new Array<ChildSchoolRelation>();
   columns = new Array<ColumnDescription>();
@@ -56,12 +57,12 @@ export class PreviousSchoolsComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.hasOwnProperty("childId")) {
-      this.loadData(this.childId);
+      this.loadData(this.child.getId());
     }
   }
 
   async loadData(id: string) {
-    if (!this.childId || this.childId === "") {
+    if (!this.child.getId() || this.child.getId() === "") {
       return;
     }
 
@@ -121,7 +122,7 @@ export class PreviousSchoolsComponent implements OnInit, OnChanges {
   }
 
   generateNewRecordFactory() {
-    const childId = this.childId;
+    const childId = this.child.getId();
     return () => {
       const newPreviousSchool = new ChildSchoolRelation(uniqid());
       newPreviousSchool.childId = childId;

--- a/src/app/child-dev-project/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.ts
@@ -56,7 +56,7 @@ export class PreviousSchoolsComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.hasOwnProperty("childId")) {
+    if (changes.hasOwnProperty("child")) {
       this.loadData(this.child.getId());
     }
   }


### PR DESCRIPTION
see issue: #500

Besides the basic information, all the other components in the child details section only get the child object as an input. This is a step towards the goal, that the components which will later be displayed on the child details screen should be customizable.

I also created two new components for the `health` and the `dropout` information. These components are able to alter the child object of the surrounding child details class. This means clicking the save button in either of these components, saves the whole child entity and not just the `health` and `dropout` fields. 

### Visible/Frontend Changes
- Additional save buttons for the `health` and `dropout` seection
- The form in `health` and `dropout` is always editable but only saved once the save button is pressed

### Architectural/Backend Changes
- All used components in the child details view only depend on the child object
