### PR TITLE
Schema datatype map

### DIFF
--- a/src/app/child-dev-project/attendance/model/attendance-month.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.ts
@@ -140,7 +140,7 @@ export class AttendanceMonth extends Entity {
     }
     this._dailyRegister = value;
   }
-  @DatabaseField({ arrayDataType: "schema-embed", ext: AttendanceDay })
+  @DatabaseField({ innerDataType: "schema-embed", ext: AttendanceDay })
   get dailyRegister(): AttendanceDay[] {
     return this._dailyRegister;
   }

--- a/src/app/core/entity/schema-datatypes/datatype-array.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-array.ts
@@ -27,7 +27,7 @@ import { EntitySchemaService } from "../schema/entity-schema.service";
  * As TypeScript array types are not reliable, you have to explicitly configure the dataType for array items with the annotation.
  * For example:
  *
- * `@DatabaseField({ arrayDataType: 'month' }) dateArr: Date[];`
+ * `@DatabaseField({ innerDataType: 'month' }) dateArr: Date[];`
  * will ensure that in the database this property is saved as an array of "month" date strings
  * using the {@link monthEntitySchemaDatatype} (e.g. resulting in `['2020-01', '2020-04']` in the database).
  */
@@ -49,7 +49,7 @@ export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
     }
 
     const arrayElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
-      schemaField.arrayDataType
+      schemaField.innerDataType
     );
     return value.map((el) =>
       arrayElementDatatype.transformToDatabaseFormat(
@@ -76,7 +76,7 @@ export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
     }
 
     const arrayElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
-      schemaField.arrayDataType
+      schemaField.innerDataType
     );
 
     return value.map((el) =>
@@ -99,7 +99,7 @@ export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
  */
 export function generateSubSchemaField(arraySchemaField: EntitySchemaField) {
   const subSchemaField = Object.assign({}, arraySchemaField);
-  subSchemaField.dataType = arraySchemaField.arrayDataType;
-  delete subSchemaField.arrayDataType;
+  subSchemaField.dataType = arraySchemaField.innerDataType;
+  delete subSchemaField.innerDataType;
   return subSchemaField;
 }

--- a/src/app/core/entity/schema-datatypes/datatype-array.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-array.ts
@@ -97,7 +97,7 @@ export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
  *
  * @param arraySchemaField The schema field config as received by the array datatype from the annotation
  */
-function generateSubSchemaField(arraySchemaField: EntitySchemaField) {
+export function generateSubSchemaField(arraySchemaField: EntitySchemaField) {
   const subSchemaField = Object.assign({}, arraySchemaField);
   subSchemaField.dataType = arraySchemaField.arrayDataType;
   delete subSchemaField.arrayDataType;

--- a/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
@@ -1,0 +1,88 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Entity } from "../entity";
+import { async } from "@angular/core/testing";
+import { DatabaseField } from "../database-field.decorator";
+import { EntitySchemaService } from "../schema/entity-schema.service";
+
+describe("Schema data type: map", () => {
+  class TestEntity extends Entity {
+    @DatabaseField({ arrayDataType: "month" }) dateMap: Map<
+      string,
+      Date
+    > = new Map();
+  }
+
+  let entitySchemaService: EntitySchemaService;
+
+  beforeEach(async(() => {
+    entitySchemaService = new EntitySchemaService();
+  }));
+
+  it("converts contained dates to month for saving", () => {
+    const id = "test1";
+    const entity = new TestEntity(id);
+    entity.dateMap.set("a", new Date("2020-01-01"));
+    entity.dateMap.set("b", new Date("1999-01-25"));
+
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(entity);
+
+    expect(rawData.dateMap).toEqual({ a: "2020-01", b: "1999-01" });
+  });
+
+  it("converts contained month strings to dates when loading", () => {
+    const id = "test1";
+    const entity = new TestEntity(id);
+
+    const data = {
+      _id: "test2",
+      dateMap: { a: "2020-01", b: "1999-01" },
+    };
+    entitySchemaService.loadDataIntoEntity(entity, data);
+
+    expect(entity.dateMap.get("a")).toEqual(new Date("2020-01-01"));
+    expect(entity.dateMap.get("b")).toEqual(new Date("1999-01-01"));
+  });
+
+  it("reproduces exact same values after save and load", () => {
+    const id = "test1";
+    const originalEntity = new TestEntity(id);
+    originalEntity.dateMap.set("a", new Date("2020-01-01"));
+    originalEntity.dateMap.set("b", new Date("2019-02-01"));
+
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(
+      originalEntity
+    );
+
+    const loadedEntity = new TestEntity("");
+    entitySchemaService.loadDataIntoEntity(loadedEntity, rawData);
+
+    expect(loadedEntity.dateMap).toEqual(originalEntity.dateMap);
+  });
+
+  it("keeps value unchanged if it is not a map", () => {
+    const id = "test1";
+    const entity = new TestEntity(id);
+    // @ts-ignore
+    entity.dateMap = "not a map";
+
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(entity);
+
+    expect(rawData.dateMap).toEqual("not a map");
+  });
+});

--- a/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
@@ -22,7 +22,7 @@ import { EntitySchemaService } from "../schema/entity-schema.service";
 
 describe("Schema data type: map", () => {
   class TestEntity extends Entity {
-    @DatabaseField({ arrayDataType: "month" }) dateMap: Map<
+    @DatabaseField({ innerDataType: "month" }) dateMap: Map<
       string,
       Date
     > = new Map();

--- a/src/app/core/entity/schema-datatypes/datatype-map.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-map.ts
@@ -27,7 +27,7 @@ import { generateSubSchemaField } from "./datatype-array";
  *
  * For example:
  *
- * `@DatabaseField({ arrayDataType: 'month' }) dateMap: Map<string, Date>;`
+ * `@DatabaseField({ innerDataType: 'month' }) dateMap: Map<string, Date>;`
  * will ensure that in the database this property is saved as "month" date string for each key
  * using the {@link monthEntitySchemaDatatype} (e.g. resulting in `{'a': '2020-01', 'b': '2020-04'}` in the database).
  */
@@ -49,7 +49,7 @@ export const mapEntitySchemaDatatype: EntitySchemaDatatype = {
     }
 
     const innerElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
-      schemaField.arrayDataType
+      schemaField.innerDataType
     );
     const result = {};
     value.forEach((item, key) => {
@@ -78,7 +78,7 @@ export const mapEntitySchemaDatatype: EntitySchemaDatatype = {
     }
 
     const innerElementType: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
-      schemaField.arrayDataType
+      schemaField.innerDataType
     );
 
     const result = new Map();

--- a/src/app/core/entity/schema-datatypes/datatype-map.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-map.ts
@@ -1,0 +1,96 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EntitySchemaDatatype } from "../schema/entity-schema-datatype";
+import { EntitySchemaField } from "../schema/entity-schema-field";
+import { EntitySchemaService } from "../schema/entity-schema.service";
+import { generateSubSchemaField } from "./datatype-array";
+
+/**
+ * Datatype for the EntitySchemaService transforming values of a javascript `Map` recursively.
+ *
+ * (De)serialize each value according to the given Datatype transformer, similar to how arrays are handled.
+ *
+ * For example:
+ *
+ * `@DatabaseField({ arrayDataType: 'month' }) dateMap: Map<string, Date>;`
+ * will ensure that in the database this property is saved as "month" date string for each key
+ * using the {@link monthEntitySchemaDatatype} (e.g. resulting in `{'a': '2020-01', 'b': '2020-04'}` in the database).
+ */
+export const mapEntitySchemaDatatype: EntitySchemaDatatype = {
+  name: "map",
+
+  transformToDatabaseFormat: (
+    value: any[],
+    schemaField: EntitySchemaField,
+    schemaService: EntitySchemaService,
+    parent
+  ) => {
+    if (!(value instanceof Map)) {
+      console.warn(
+        'property to be transformed with "map" EntitySchema is not of expected type',
+        value
+      );
+      return value;
+    }
+
+    const innerElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
+      schemaField.arrayDataType
+    );
+    const result = {};
+    value.forEach((item, key) => {
+      result[key] = innerElementDatatype.transformToDatabaseFormat(
+        item,
+        generateSubSchemaField(schemaField),
+        schemaService,
+        parent
+      );
+    });
+    return result;
+  },
+
+  transformToObjectFormat: (
+    value: any[],
+    schemaField: EntitySchemaField,
+    schemaService: EntitySchemaService,
+    parent
+  ) => {
+    if (typeof value !== "object" || value === null) {
+      console.warn(
+        'property to be transformed with "map" EntitySchema is not an object',
+        value
+      );
+      return value;
+    }
+
+    const innerElementType: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(
+      schemaField.arrayDataType
+    );
+
+    const result = new Map();
+    for (const key of Object.keys(value)) {
+      const transformedElement = innerElementType.transformToObjectFormat(
+        value[key],
+        generateSubSchemaField(schemaField),
+        schemaService,
+        parent
+      );
+      result.set(key, transformedElement);
+    }
+    return result;
+  },
+};

--- a/src/app/core/entity/schema/entity-schema-field.ts
+++ b/src/app/core/entity/schema/entity-schema-field.ts
@@ -31,11 +31,12 @@ export interface EntitySchemaField {
   dataType?: string;
 
   /**
-   * In case of an array field (dataType==='array') define the datatype of the values contained in the array
+   * In case of a map or array field (e.g. dataType==='array') define the datatype of the values contained in the array.
    *
-   * see {@link arrayDataType}
+   * see {@link /miscellaneous/variables.html#arrayEntitySchemaDatatype},
+   * {@link /miscellaneous/variables.html#mapEntitySchemaDatatype}
    */
-  arrayDataType?: string;
+  innerDataType?: string;
 
   /**
    * Set to true to make the framework automatically create an index to retrieve/filter Entities quickly based on this field

--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -137,7 +137,7 @@ describe("EntitySchemaService", () => {
 
   it("schema:array converts contained dates to month for saving", function () {
     class TestEntity extends Entity {
-      @DatabaseField({ arrayDataType: "month" }) dateArr: Date[];
+      @DatabaseField({ innerDataType: "month" }) dateArr: Date[];
     }
     const id = "test1";
     const entity = new TestEntity(id);
@@ -150,7 +150,7 @@ describe("EntitySchemaService", () => {
 
   it("schema:array converts contained month strings to dates when loading", function () {
     class TestEntity extends Entity {
-      @DatabaseField({ arrayDataType: "month" }) dateArr: Date[];
+      @DatabaseField({ innerDataType: "month" }) dateArr: Date[];
     }
     const id = "test1";
     const entity = new TestEntity(id);

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -28,6 +28,7 @@ import { monthEntitySchemaDatatype } from "../schema-datatypes/datatype-month";
 import { arrayEntitySchemaDatatype } from "../schema-datatypes/datatype-array";
 import { schemaEmbedEntitySchemaDatatype } from "../schema-datatypes/datatype-schema-embed";
 import { dateOnlyEntitySchemaDatatype } from "../schema-datatypes/datatype-date-only";
+import { mapEntitySchemaDatatype } from "../schema-datatypes/datatype-map";
 
 /**
  * Transform between entity instances and database objects
@@ -61,6 +62,7 @@ export class EntitySchemaService {
     this.registerSchemaDatatype(monthEntitySchemaDatatype);
     this.registerSchemaDatatype(arrayEntitySchemaDatatype);
     this.registerSchemaDatatype(schemaEmbedEntitySchemaDatatype);
+    this.registerSchemaDatatype(mapEntitySchemaDatatype);
   }
 
   /**


### PR DESCRIPTION

### Architectural/Backend Changes
- [x] add new datatype for EntitySchema system that transforms JavaScript `Map` to a simple object
