### PR TITLE
Fix Webdav proxy

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -32,7 +32,7 @@ server {
 
     location /webdav {
         rewrite /webdav/(.*) /$1 break;
-        proxy_pass ${WEBDAV_URL};
+        proxy_pass $WEBDAV_URL;
     }
 }
 

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -35,4 +35,4 @@ ENV PORT=80
 COPY ./deploy/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist/ /usr/share/nginx/html
 # sed is needed to insert the $PORT into the nginx config
-CMD sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'
+CMD sed -i -e 's/$PORT/'"$PORT"'/g' -e 's/$WEBDAV_URL/'"$WEBDAV_URL"'/g' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'


### PR DESCRIPTION
The proxy for Webdav is specified in the nginx config file `default.conf` and dependes on a environment variable.
This variable is now injected into the config file to fix the proxy.

### Architectural/Backend Changes
- Webdav url injection
