### PR TITLE
Improved Cache and Coverage Fix

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
@@ -37,6 +42,7 @@ jobs:
           build-args: RUN_TESTS=${{ true }}
           outputs: type=local,dest=./img
           cache-from: type=registry,ref=aamdigital/ndb-server:cache
+          cache-to: type=registry,ref=aamdigital/ndb-server:cache,mode=max
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v2.7.5
         env:

--- a/build/karma-ci.conf.js
+++ b/build/karma-ci.conf.js
@@ -40,7 +40,7 @@ module.exports = function (config) {
       'text/x-typescript': ['ts','tsx']
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../../coverage'), reports: [ 'lcovonly' ],
+      dir: require('path').join(__dirname, '../coverage'), reports: [ 'lcovonly' ],
       fixWebpackSourcePaths: true
     },
     angularCli: {


### PR DESCRIPTION
The GitHub workflow currently only uploaded a new Docker cache when a new tag was pushed. On changes that for example only affect the Dockerfile, no new tag is created by semantic release. In this case the Docker cache wont be updated but because the Dockerfile looks different than the one in the cache, the image have to be rebuilt every time. This change will now update the Docker cache on every build on the master as well as on tagged commits. The updating of the cache multiple times should not be a problem.

Due to the change of the folder structure of the `karma-ci.conf.js` the coverage exporter pointed to a wrong location which resulted in the coverage results not being found by the coverage exporter

### Architectural/Backend Changes
- The Docker cache is updated on every build on the master branch
- Fixed the Coverage results path
