### PR TITLE
fix(core): properly reload routing for config from database

### DIFF
--- a/src/app/core/view/dynamic-routing/router.service.spec.ts
+++ b/src/app/core/view/dynamic-routing/router.service.spec.ts
@@ -10,6 +10,7 @@ import { LoggingService } from "../../logging/logging.service";
 
 import { RouterService } from "./router.service";
 import { EntityDetailsComponent } from "../../entity-components/entity-details/entity-details.component";
+import { ViewConfig } from "./view-config.interface";
 
 class TestComponent extends Component {}
 
@@ -92,5 +93,30 @@ describe("RouterService", () => {
     service.reloadRouting(testViewConfigs, existingRoutes);
 
     expect(router.resetConfig).toHaveBeenCalledWith(expectedRoutes);
+  });
+
+  it("should update existing routes when config changes", () => {
+    const routeConfigs1: ViewConfig[] = [
+      { _id: "view:child", component: "ChildrenList" },
+      { _id: "view:other", component: "EntityDetails" },
+    ];
+    const routeConfigs2: ViewConfig[] = [
+      { _id: "view:child", component: "ChildrenList", config: { foo: 1 } },
+      { _id: "view:child2", component: "ChildrenList", config: { foo: 2 } },
+    ];
+
+    mockConfigService.getAllConfigs.and.returnValue(routeConfigs1);
+    service.initRouting();
+
+    mockConfigService.getAllConfigs.and.returnValue(routeConfigs2);
+    service.initRouting();
+
+    const router = TestBed.inject<Router>(Router);
+    expect(router.config.find((r) => r.path === "child").data).toEqual({
+      foo: 1,
+    });
+    expect(router.config.find((r) => r.path === "child2").data).toEqual({
+      foo: 2,
+    });
   });
 });

--- a/src/app/core/view/dynamic-routing/router.service.spec.ts
+++ b/src/app/core/view/dynamic-routing/router.service.spec.ts
@@ -41,7 +41,7 @@ describe("RouterService", () => {
     const router = TestBed.inject<Router>(Router);
     spyOn(router, "resetConfig");
 
-    service.reloadRouting(testRoutes);
+    service.reloadRouting([], testRoutes);
 
     expect(router.resetConfig).toHaveBeenCalledWith(testRoutes);
   });
@@ -70,8 +70,7 @@ describe("RouterService", () => {
     const router = TestBed.inject<Router>(Router);
     spyOn(router, "resetConfig");
 
-    mockConfigService.getAllConfigs.and.returnValue(testViewConfigs);
-    service.reloadRouting();
+    service.reloadRouting(testViewConfigs);
 
     expect(router.resetConfig).toHaveBeenCalledWith(expectedRoutes);
   });
@@ -90,8 +89,7 @@ describe("RouterService", () => {
     const router = TestBed.inject<Router>(Router);
     spyOn(router, "resetConfig");
 
-    mockConfigService.getAllConfigs.and.returnValue(testViewConfigs);
-    service.reloadRouting(existingRoutes);
+    service.reloadRouting(testViewConfigs, existingRoutes);
 
     expect(router.resetConfig).toHaveBeenCalledWith(expectedRoutes);
   });

--- a/src/app/core/view/dynamic-routing/router.service.ts
+++ b/src/app/core/view/dynamic-routing/router.service.ts
@@ -28,12 +28,10 @@ export class RouterService {
    * Initialize routes from the config while respecting existing routes.
    */
   initRouting() {
-    this.configService.configUpdated.subscribe(() => {
-      const viewConfigs = this.configService.getAllConfigs<ViewConfig>(
-        RouterService.PREFIX_VIEW_CONFIG
-      );
-      this.reloadRouting(viewConfigs, this.router.config, true);
-    });
+    const viewConfigs = this.configService.getAllConfigs<ViewConfig>(
+      RouterService.PREFIX_VIEW_CONFIG
+    );
+    this.reloadRouting(viewConfigs, this.router.config, true);
   }
 
   /**
@@ -53,18 +51,19 @@ export class RouterService {
     for (const view of viewConfigs) {
       const route = this.generateRouteFromConfig(view);
 
-      if (additionalRoutes.find((r) => r.path === route.path)) {
-        // special skip and warning rules if the route already exists:
-        if (view.lazyLoaded) {
-          continue;
-        }
-        if (!overwriteExistingRoutes) {
-          this.loggingService.warn(
-            "ignoring route from view config because the path is already defined: " +
-              view._id
-          );
-          continue;
-        }
+      if (view.lazyLoaded) {
+        // lazy-loaded views' routing is still hardcoded in the app.routing
+        continue;
+      }
+      if (
+        !overwriteExistingRoutes &&
+        additionalRoutes.find((r) => r.path === route.path)
+      ) {
+        this.loggingService.warn(
+          "ignoring route from view config because the path is already defined: " +
+            view._id
+        );
+        continue;
       }
 
       routes.push(route);


### PR DESCRIPTION
the app did not reflect config loaded from the database and instead always displayed the default config until now
