### PR TITLE
Configurable attendance status [Event Attendance Part +1]

### DIFF
--- a/src/app/child-dev-project/attendance/activity-attendance-section/activity-attendance-section.stories.ts
+++ b/src/app/child-dev-project/attendance/activity-attendance-section/activity-attendance-section.stories.ts
@@ -11,7 +11,7 @@ import {
   ActivityAttendance,
   generateEventWithAttendance,
 } from "../model/activity-attendance";
-import { AttendanceStatus } from "../model/attendance-status";
+import { AttendanceLogicalStatus } from "../model/attendance-status";
 import { MatNativeDateModule } from "@angular/material/core";
 import { ChildrenService } from "../../children/children.service";
 import { of } from "rxjs";
@@ -24,30 +24,30 @@ const attendanceRecords = [
   ActivityAttendance.create(new Date("2020-01-01"), [
     generateEventWithAttendance(
       {
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.PRESENT,
-        "3": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.PRESENT,
+        "3": AttendanceLogicalStatus.ABSENT,
       },
       new Date("2020-01-01")
     ),
     generateEventWithAttendance(
       {
-        "1": AttendanceStatus.LATE,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       },
       new Date("2020-01-02")
     ),
     generateEventWithAttendance(
       {
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       },
       new Date("2020-01-03")
     ),
     generateEventWithAttendance(
       {
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       },
       new Date("2020-01-04")
     ),
@@ -55,12 +55,12 @@ const attendanceRecords = [
 
   ActivityAttendance.create(new Date("2020-02-01"), [
     generateEventWithAttendance({
-      "1": AttendanceStatus.ABSENT,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.ABSENT,
+      "2": AttendanceLogicalStatus.ABSENT,
     }),
     generateEventWithAttendance({
-      "1": AttendanceStatus.PRESENT,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.PRESENT,
+      "2": AttendanceLogicalStatus.ABSENT,
     }),
   ]),
 ];

--- a/src/app/child-dev-project/attendance/activity-card/activity-card.stories.ts
+++ b/src/app/child-dev-project/attendance/activity-card/activity-card.stories.ts
@@ -45,7 +45,11 @@ demoChildren.forEach((c) => simpleEvent.addChild(c.getId()));
 const longEvent = Note.create(new Date(), "another meeting");
 longEvent.text =
   "a guardians meeting with all families who are in the neighbourhood";
-longEvent.category = { name: "Guardians Meeting", isMeeting: true };
+longEvent.category = {
+  id: "GUARDIAN_MEETING",
+  label: "Guardians Meeting",
+  isMeeting: true,
+};
 demoChildren.forEach((c) => longEvent.addChild(c.getId()));
 
 const activityEvent = Note.create(new Date(), "Coaching Batch C");

--- a/src/app/child-dev-project/attendance/activity-setup/activity-setup.stories.ts
+++ b/src/app/child-dev-project/attendance/activity-setup/activity-setup.stories.ts
@@ -31,7 +31,6 @@ import { ActivityCardComponent } from "../activity-card/activity-card.component"
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { FontAwesomeIconsModule } from "../../../core/icons/font-awesome-icons.module";
 import { DemoActivityGeneratorService } from "../demo-activity-generator.service";
-import { NoteConfigLoaderService } from "../../notes/note-config-loader/note-config-loader.service";
 import { SessionService } from "../../../core/session/session-service/session.service";
 import { User } from "../../../core/user/user";
 import { FormDialogModule } from "../../../core/form-dialog/form-dialog.module";
@@ -43,14 +42,14 @@ const demoEvents: Note[] = [
   Note.create(moment().subtract(1, "days").toDate(), "Discussion on values"),
   Note.create(new Date(), "Other Discussion"),
 ];
-demoEvents[0].category = { name: "Guardians", isMeeting: true };
-demoEvents[1].category = { name: "Guardians", isMeeting: true };
-demoEvents[2].category = { name: "Guardians", isMeeting: true };
-demoEvents[3].category = { name: "Life Skills", isMeeting: true };
-demoEvents[4].category = { name: "Other", isMeeting: true };
+demoEvents[0].category = { id: "G", label: "Guardians", isMeeting: true };
+demoEvents[1].category = { id: "G", label: "Guardians", isMeeting: true };
+demoEvents[2].category = { id: "G", label: "Guardians", isMeeting: true };
+demoEvents[3].category = { id: "LS", label: "Life Skills", isMeeting: true };
+demoEvents[4].category = { id: "OTHER", label: "Other", isMeeting: true };
 
 const demoEvent = Note.create(new Date(), "coaching");
-demoEvent.category = { name: "Coaching", isMeeting: true };
+demoEvent.category = { id: "COACHING", label: "Coaching", isMeeting: true };
 
 const demoChildren = [
   DemoChildGenerator.generateEntity("1"),
@@ -109,10 +108,6 @@ export default {
         {
           provide: SessionService,
           useValue: { getCurrentUser: () => new User("demo") },
-        },
-        {
-          provide: NoteConfigLoaderService,
-          useValue: { interactionTypes: [] },
         },
       ],
     }),

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
@@ -4,10 +4,10 @@
 
   <div fxLayout='column' fxLayoutAlign='space-between stretch' class='options-wrapper'>
     <div class='group-select-option' *ngFor="let option of availableStatus"
-         (click)='markAttendance(entries[currentIndex].childId, option.status)'
-         [ngClass]="entries[currentIndex].attendance.status===option.status ? option.style : ''">
-      <span class='fa fa-check' *ngIf='entries[currentIndex].attendance.status===option.status'></span>
-      {{ option.name }}
+         (click)='markAttendance(entries[currentIndex].childId, option)'
+         [ngClass]="entries[currentIndex].attendance.status.id===option.id ? option.style : ''">
+      <span class='fa fa-check' *ngIf='entries[currentIndex].attendance.status.id===option.id'></span>
+      {{ option.label }}
     </div>
   </div>
 </div>

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -3,17 +3,27 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RollCallComponent } from "./roll-call.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Note } from "../../../notes/model/note";
+import { By } from "@angular/platform-browser";
+import { ConfigService } from "../../../../core/config/config.service";
+import { ConfigurableEnumConfig } from "../../../../core/configurable-enum/configurable-enum.interface";
 
 describe("RollCallComponent", () => {
   let component: RollCallComponent;
   let fixture: ComponentFixture<RollCallComponent>;
 
   const testEvent = Note.create(new Date());
+  let mockConfigService: jasmine.SpyObj<ConfigService>;
 
   beforeEach(async(() => {
+    mockConfigService = jasmine.createSpyObj("mockConfigService", [
+      "getConfig",
+    ]);
+    mockConfigService.getConfig.and.returnValue([]);
+
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
       declarations: [RollCallComponent],
+      providers: [{ provide: ConfigService, useValue: mockConfigService }],
     }).compileComponents();
   }));
 
@@ -26,5 +36,35 @@ describe("RollCallComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should display all available attendance status to select", async () => {
+    const testStatusEnumConfig: ConfigurableEnumConfig = [
+      {
+        id: "PRESENT",
+        shortName: "P",
+        label: "Present",
+        style: "attendance-P",
+        countAs: "PRESENT",
+      },
+      {
+        id: "ABSENT",
+        shortName: "A",
+        label: "Absent",
+        style: "attendance-A",
+        countAs: "ABSENT",
+      },
+    ];
+    mockConfigService.getConfig.and.returnValue(testStatusEnumConfig);
+    component.eventEntity = Note.create(new Date());
+    component.eventEntity.addChild("1");
+    await component.ngOnInit();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const statusOptions = fixture.debugElement.queryAll(
+      By.css(".group-select-option")
+    );
+    expect(statusOptions.length).toBe(testStatusEnumConfig.length);
   });
 });

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -1,12 +1,13 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { animate, style, transition, trigger } from "@angular/animations";
 import {
-  AttendanceStatus,
+  ATTENDANCE_STATUS_CONFIG_ID,
   AttendanceStatusType,
-  DEFAULT_ATTENDANCE_TYPES,
 } from "../../model/attendance-status";
 import { Note } from "../../../notes/model/note";
 import { EventAttendance } from "../../model/event-attendance";
+import { ConfigService } from "../../../../core/config/config.service";
+import { ConfigurableEnumConfig } from "../../../../core/configurable-enum/configurable-enum.interface";
 
 /**
  * Displays the participants of the given event one by one to mark attendance status.
@@ -47,6 +48,8 @@ export class RollCallComponent implements OnInit {
 
   entries: { childId: string; attendance: EventAttendance }[];
 
+  constructor(private configService: ConfigService) {}
+
   async ngOnInit() {
     this.loadAttendanceStatusTypes();
 
@@ -58,11 +61,12 @@ export class RollCallComponent implements OnInit {
   }
 
   private loadAttendanceStatusTypes() {
-    // TODO: move this into config completely
-    this.availableStatus = DEFAULT_ATTENDANCE_TYPES;
+    this.availableStatus = this.configService.getConfig<
+      ConfigurableEnumConfig<AttendanceStatusType>
+    >(ATTENDANCE_STATUS_CONFIG_ID);
   }
 
-  markAttendance(childId: string, status: AttendanceStatus) {
+  markAttendance(childId: string, status: AttendanceStatusType) {
     this.eventEntity.getAttendance(childId).status = status;
 
     // automatically move to next participant after a short delay giving the user visual feedback on the selected status

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.stories.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.stories.ts
@@ -1,7 +1,6 @@
 import { Story, Meta } from "@storybook/angular/types-6-0";
 import { RollCallComponent } from "./roll-call.component";
 import { DemoChildGenerator } from "../../../children/demo-data-generators/demo-child-generator.service";
-import { addDefaultChildPhoto } from "../../../../../../.storybook/utils/addDefaultChildPhoto";
 import { moduleMetadata } from "@storybook/angular";
 import { CommonModule } from "@angular/common";
 import { ChildBlockComponent } from "../../../children/child-block/child-block.component";
@@ -42,7 +41,6 @@ const demoChildren = [
   DemoChildGenerator.generateEntity("2"),
   DemoChildGenerator.generateEntity("3"),
 ];
-demoChildren.forEach((c) => addDefaultChildPhoto(c));
 demoChildren.forEach((c) => demoEvent.addChild(c.getId()));
 
 const Template: Story<RollCallComponent> = (args: RollCallComponent) => ({

--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
@@ -13,16 +13,8 @@
 
   <div *ngIf="selectedEvent && highlightForChild">
     <div>
-      <span class="indicator {{selectedEventAttendance.status.style}}">&nbsp;</span>
-      &nbsp;
-      <mat-form-field>
-        <mat-select [(ngModel)]="selectedEventAttendance.status" (ngModelChange)="save()" #dayStatusSelect>
-          <mat-option *ngFor="let s of statusValues" [value]="s">
-            <span class="indicator {{s.style}}">&nbsp;</span>
-            {{s.label}}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
+      <app-attendance-status-select [(value)]="selectedEventAttendance.status" (valueChange)="save()">
+      </app-attendance-status-select>
     </div>
 
     <div>

--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
@@ -13,13 +13,13 @@
 
   <div *ngIf="selectedEvent && highlightForChild">
     <div>
-      <span class="indicator {{getCssClassForAttendanceStatus(selectedEventAttendance.status)}}">&nbsp;</span>
+      <span class="indicator {{selectedEventAttendance.status.style}}">&nbsp;</span>
       &nbsp;
       <mat-form-field>
         <mat-select [(ngModel)]="selectedEventAttendance.status" (ngModelChange)="save()" #dayStatusSelect>
-          <mat-option *ngFor="let s of statusValues | keys" [value]="s.value">
-            <span class="indicator {{getCssClassForAttendanceStatus(s.value)}}">&nbsp;</span>
-            {{s.key}}
+          <mat-option *ngFor="let s of statusValues" [value]="s">
+            <span class="indicator {{s.style}}">&nbsp;</span>
+            {{s.label}}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.scss
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.scss
@@ -52,11 +52,3 @@ background: linear-gradient(to right, green 0%, green 80%, red 80%, red 100%);
 button {
   margin: 5px;
 }
-
-.indicator {
-  width: 14px;
-  height: 14px;
-  display: inline-block;
-  vertical-align: text-top;
-  border-radius: 50%;
-}

--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.ts
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.ts
@@ -9,17 +9,12 @@ import { Note } from "../../notes/model/note";
 import { MatCalendarCellCssClasses } from "@angular/material/datepicker/calendar-body";
 import moment, { Moment } from "moment";
 import { EventAttendance } from "../model/event-attendance";
-import {
-  ATTENDANCE_STATUS_CONFIG_ID,
-  AttendanceStatusType,
-} from "../model/attendance-status";
+import { AttendanceStatusType } from "../model/attendance-status";
 import { MatCalendar } from "@angular/material/datepicker";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { FormDialogService } from "../../../core/form-dialog/form-dialog.service";
 import { NoteDetailsComponent } from "../../notes/note-details/note-details.component";
 import { calculateAverageAttendance } from "../model/calculate-average-event-attendance";
-import { ConfigService } from "../../../core/config/config.service";
-import { ConfigurableEnumConfig } from "../../../core/configurable-enum/configurable-enum.interface";
 
 @Component({
   selector: "app-attendance-calendar",
@@ -31,7 +26,6 @@ export class AttendanceCalendarComponent implements OnChanges {
   @Input() highlightForChild: string;
 
   @ViewChild(MatCalendar) calendar: MatCalendar<Date>;
-  statusValues: AttendanceStatusType[];
   minDate: Date;
   maxDate: Date;
 
@@ -47,13 +41,8 @@ export class AttendanceCalendarComponent implements OnChanges {
 
   constructor(
     private entityMapper: EntityMapperService,
-    private formDialog: FormDialogService,
-    private configService: ConfigService
-  ) {
-    this.statusValues = this.configService.getConfig<
-      ConfigurableEnumConfig<AttendanceStatusType>
-    >(ATTENDANCE_STATUS_CONFIG_ID);
-  }
+    private formDialog: FormDialogService
+  ) {}
 
   highlightDate = (cellDate: Date): MatCalendarCellCssClasses => {
     const cellMoment = moment(cellDate);

--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.stories.ts
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.stories.ts
@@ -4,7 +4,7 @@ import { AttendanceModule } from "../attendance.module";
 import { FontAwesomeIconsModule } from "../../../core/icons/font-awesome-icons.module";
 import { RouterTestingModule } from "@angular/router/testing";
 import { generateEventWithAttendance } from "../model/activity-attendance";
-import { AttendanceStatus } from "../model/attendance-status";
+import { AttendanceLogicalStatus } from "../model/attendance-status";
 import { AttendanceCalendarComponent } from "./attendance-calendar.component";
 import { MatNativeDateModule } from "@angular/material/core";
 import { Note } from "../../notes/model/note";
@@ -15,31 +15,31 @@ import { FormDialogModule } from "../../../core/form-dialog/form-dialog.module";
 const demoEvents: Note[] = [
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.ABSENT,
-      "2": AttendanceStatus.PRESENT,
-      "3": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.ABSENT,
+      "2": AttendanceLogicalStatus.PRESENT,
+      "3": AttendanceLogicalStatus.ABSENT,
     },
     new Date()
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.PRESENT,
-      "2": AttendanceStatus.ABSENT,
-      "3": AttendanceStatus.UNKNOWN,
+      "1": AttendanceLogicalStatus.PRESENT,
+      "2": AttendanceLogicalStatus.ABSENT,
+      "3": AttendanceLogicalStatus.IGNORE,
     },
     moment().subtract(1, "day").toDate()
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.LATE,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.IGNORE,
+      "2": AttendanceLogicalStatus.ABSENT,
     },
     moment().subtract(2, "day").toDate()
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.HOLIDAY,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.IGNORE,
+      "2": AttendanceLogicalStatus.ABSENT,
     },
     moment().subtract(3, "day").toDate()
   ),

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.html
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.html
@@ -48,15 +48,8 @@
       <div fxFlex>
         <mat-form-field>
           <input matInput type="number" min="0" placeholder='unknown status'
-                 [value]="focusedChild ? entity.countEventsWithStatusForChild(attendanceStatus.UNKNOWN, focusedChild) : entity.countEventsWithUnknownStatus()"
+                 [value]="focusedChild ? entity.countEventsWithStatusForChild(UnknownStatus, focusedChild) : entity.countEventsWithUnknownStatus()"
                  readonly>
-        </mat-form-field>
-      </div>
-
-      <div fxFlex *ngIf="focusedChild">
-        <mat-form-field>
-          <input matInput type="number" min="0" placeholder='days late'
-                 [value]="entity.countEventsWithStatusForChild(attendanceStatus.LATE, focusedChild)" readonly>
         </mat-form-field>
       </div>
     </div>

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.spec.ts
@@ -7,7 +7,7 @@ import {
   ActivityAttendance,
   generateEventWithAttendance,
 } from "../model/activity-attendance";
-import { AttendanceStatus } from "../model/attendance-status";
+import { AttendanceLogicalStatus } from "../model/attendance-status";
 import { RecurringActivity } from "../model/recurring-activity";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { AttendanceModule } from "../attendance.module";
@@ -22,16 +22,16 @@ describe("AttendanceDetailsComponent", () => {
     const entity = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance(
         {
-          "1": AttendanceStatus.PRESENT,
-          "2": AttendanceStatus.PRESENT,
-          "3": AttendanceStatus.ABSENT,
+          "1": AttendanceLogicalStatus.PRESENT,
+          "2": AttendanceLogicalStatus.PRESENT,
+          "3": AttendanceLogicalStatus.ABSENT,
         },
         new Date("2020-01-01")
       ),
       generateEventWithAttendance(
         {
-          "1": AttendanceStatus.LATE,
-          "2": AttendanceStatus.ABSENT,
+          "1": AttendanceLogicalStatus.PRESENT,
+          "2": AttendanceLogicalStatus.ABSENT,
         },
         new Date("2020-01-02")
       ),

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.ts
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.ts
@@ -6,7 +6,7 @@ import { ColumnDescriptionInputType } from "../../../core/entity-components/enti
 import { NoteDetailsComponent } from "../../notes/note-details/note-details.component";
 import { Note } from "../../notes/model/note";
 import { calculateAverageAttendance } from "../model/calculate-average-event-attendance";
-import { AttendanceStatus } from "../model/attendance-status";
+import { NullAttendanceStatusType } from "../model/attendance-status";
 import { OnInitDynamicComponent } from "../../../core/view/dynamic-components/on-init-dynamic-component.interface";
 
 @Component({
@@ -45,7 +45,7 @@ export class AttendanceDetailsComponent
       },
     },
   ];
-  attendanceStatus = AttendanceStatus;
+  UnknownStatus = NullAttendanceStatusType;
 
   constructor() {}
 

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.stories.ts
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.stories.ts
@@ -5,7 +5,7 @@ import {
   ActivityAttendance,
   generateEventWithAttendance,
 } from "../model/activity-attendance";
-import { AttendanceStatus } from "../model/attendance-status";
+import { AttendanceLogicalStatus } from "../model/attendance-status";
 import { AttendanceDetailsComponent } from "./attendance-details.component";
 import { AttendanceModule } from "../attendance.module";
 import { RouterTestingModule } from "@angular/router/testing";
@@ -20,30 +20,30 @@ const demoActivity = RecurringActivity.create("Coaching Batch C");
 const activityAttendance = ActivityAttendance.create(new Date("2020-01-01"), [
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.PRESENT,
-      "2": AttendanceStatus.PRESENT,
-      "3": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.PRESENT,
+      "2": AttendanceLogicalStatus.PRESENT,
+      "3": AttendanceLogicalStatus.ABSENT,
     },
     new Date("2020-01-01")
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.LATE,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.PRESENT,
+      "2": AttendanceLogicalStatus.ABSENT,
     },
     new Date("2020-01-02")
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.ABSENT,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.ABSENT,
+      "2": AttendanceLogicalStatus.ABSENT,
     },
     new Date("2020-01-03")
   ),
   generateEventWithAttendance(
     {
-      "1": AttendanceStatus.PRESENT,
-      "2": AttendanceStatus.ABSENT,
+      "1": AttendanceLogicalStatus.PRESENT,
+      "2": AttendanceLogicalStatus.ABSENT,
     },
     new Date("2020-01-04")
   ),
@@ -88,8 +88,8 @@ const activityAttendanceIndividual = Object.assign(
   new ActivityAttendance(),
   activityAttendance
 );
-activityAttendanceIndividual.focusedChild = "1";
 export const ForIndividualChild = Template.bind({});
 ForIndividualChild.args = {
   entity: activityAttendanceIndividual,
+  focusedChild: "1",
 };

--- a/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.html
+++ b/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.html
@@ -1,0 +1,12 @@
+<div>
+  <span class="indicator {{value.style}}">&nbsp;</span>
+
+  <mat-form-field class="compact-form-field">
+    <mat-select [(ngModel)]="value" (ngModelChange)="valueChange.emit(value)">
+      <mat-option *ngFor="let s of statusValues" [value]="s">
+        <span class="indicator {{s.style}}">&nbsp;</span>
+        {{s.label}}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+</div>

--- a/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.scss
+++ b/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.scss
@@ -1,0 +1,14 @@
+.indicator {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  vertical-align: text-top;
+  border-radius: 50%;
+
+  margin-right: 8px;
+}
+
+.compact-form-field {
+  margin-bottom: -10px;
+  margin-top: -10px;
+}

--- a/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { AttendanceStatusSelectComponent } from "./attendance-status-select.component";
+
+describe("AttendanceStatusSelectComponent", () => {
+  let component: AttendanceStatusSelectComponent;
+  let fixture: ComponentFixture<AttendanceStatusSelectComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AttendanceStatusSelectComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AttendanceStatusSelectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.ts
+++ b/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.component.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { ConfigService } from "../../../core/config/config.service";
+import { ConfigurableEnumConfig } from "../../../core/configurable-enum/configurable-enum.interface";
+import {
+  ATTENDANCE_STATUS_CONFIG_ID,
+  AttendanceStatusType,
+  NullAttendanceStatusType,
+} from "../model/attendance-status";
+
+@Component({
+  selector: "app-attendance-status-select",
+  templateUrl: "./attendance-status-select.component.html",
+  styleUrls: ["./attendance-status-select.component.scss"],
+})
+export class AttendanceStatusSelectComponent {
+  @Input() value: AttendanceStatusType = NullAttendanceStatusType;
+  @Output() valueChange = new EventEmitter<AttendanceStatusType>();
+
+  statusValues: AttendanceStatusType[];
+
+  constructor(private configService: ConfigService) {
+    this.statusValues = this.configService.getConfig<
+      ConfigurableEnumConfig<AttendanceStatusType>
+    >(ATTENDANCE_STATUS_CONFIG_ID);
+  }
+}

--- a/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.stories.ts
+++ b/src/app/child-dev-project/attendance/attendance-status-select/attendance-status-select.stories.ts
@@ -1,0 +1,37 @@
+import { Story, Meta } from "@storybook/angular/types-6-0";
+import { moduleMetadata } from "@storybook/angular";
+import { AttendanceModule } from "../attendance.module";
+import { FontAwesomeIconsModule } from "../../../core/icons/font-awesome-icons.module";
+import { RouterTestingModule } from "@angular/router/testing";
+import { MatNativeDateModule } from "@angular/material/core";
+import { FormDialogModule } from "../../../core/form-dialog/form-dialog.module";
+import { AttendanceStatusSelectComponent } from "./attendance-status-select.component";
+import { ConfigService } from "../../../core/config/config.service";
+
+export default {
+  title: "AttendanceModule/AttendanceStatusSelect",
+  component: AttendanceStatusSelectComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        AttendanceModule,
+        FormDialogModule,
+        FontAwesomeIconsModule,
+        RouterTestingModule,
+        MatNativeDateModule,
+      ],
+      declarations: [],
+      providers: [ConfigService],
+    }),
+  ],
+} as Meta;
+
+const Template: Story<AttendanceStatusSelectComponent> = (
+  args: AttendanceStatusSelectComponent
+) => ({
+  component: AttendanceStatusSelectComponent,
+  props: args,
+});
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/src/app/child-dev-project/attendance/attendance.module.ts
+++ b/src/app/child-dev-project/attendance/attendance.module.ts
@@ -53,6 +53,7 @@ import { ActivityAttendanceSectionComponent } from "./activity-attendance-sectio
 import { AttendanceCalendarComponent } from "./attendance-calendar/attendance-calendar.component";
 import { GroupedChildAttendanceComponent } from "../children/child-details/grouped-child-attendance/grouped-child-attendance.component";
 import { MatTabsModule } from "@angular/material/tabs";
+import { AttendanceStatusSelectComponent } from "./attendance-status-select/attendance-status-select.component";
 
 @NgModule({
   declarations: [
@@ -71,6 +72,7 @@ import { MatTabsModule } from "@angular/material/tabs";
     ActivityAttendanceSectionComponent,
     AttendanceCalendarComponent,
     GroupedChildAttendanceComponent,
+    AttendanceStatusSelectComponent,
   ],
   imports: [
     EntityListModule,
@@ -96,6 +98,10 @@ import { MatTabsModule } from "@angular/material/tabs";
     EntitySubrecordModule,
     MatTabsModule,
   ],
-  exports: [ActivityCardComponent, ActivitySetupComponent],
+  exports: [
+    ActivityCardComponent,
+    ActivitySetupComponent,
+    AttendanceStatusSelectComponent,
+  ],
 })
 export class AttendanceModule {}

--- a/src/app/child-dev-project/attendance/model/activity-attendance.spec.ts
+++ b/src/app/child-dev-project/attendance/model/activity-attendance.spec.ts
@@ -19,7 +19,7 @@ import {
   ActivityAttendance,
   generateEventWithAttendance,
 } from "./activity-attendance";
-import { AttendanceStatus } from "./attendance-status";
+import { AttendanceLogicalStatus } from "./attendance-status";
 
 describe("ActivityAttendance", () => {
   let testInstance: ActivityAttendance;
@@ -27,13 +27,13 @@ describe("ActivityAttendance", () => {
   beforeEach(() => {
     testInstance = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.PRESENT,
-        "3": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.PRESENT,
+        "3": AttendanceLogicalStatus.ABSENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       }),
     ]);
   });
@@ -53,29 +53,29 @@ describe("ActivityAttendance", () => {
   it("calculates average absent", () => {
     const everyoneInOneEventAbsent = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.PRESENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.PRESENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.PRESENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.PRESENT,
       }),
     ]);
     expect(everyoneInOneEventAbsent.countEventsAbsentAverage()).toBe(1);
 
     const allAbsent = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance({
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.ABSENT,
-        "3": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.ABSENT,
+        "3": AttendanceLogicalStatus.ABSENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       }),
     ]);
     expect(allAbsent.countEventsAbsentAverage()).toBe(2);
@@ -85,28 +85,28 @@ describe("ActivityAttendance", () => {
   xit("calculates average present", () => {
     const presentAct = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.PRESENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.PRESENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
-        "2": AttendanceStatus.PRESENT,
+        "1": AttendanceLogicalStatus.PRESENT,
+        "2": AttendanceLogicalStatus.PRESENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.PRESENT,
+        "1": AttendanceLogicalStatus.PRESENT,
       }),
     ]);
     expect(presentAct.countEventsPresentAverage()).toBe(2.5);
 
     const allAbsent = ActivityAttendance.create(new Date(), [
       generateEventWithAttendance({
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.ABSENT,
-        "3": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.ABSENT,
+        "3": AttendanceLogicalStatus.ABSENT,
       }),
       generateEventWithAttendance({
-        "1": AttendanceStatus.ABSENT,
-        "2": AttendanceStatus.ABSENT,
+        "1": AttendanceLogicalStatus.ABSENT,
+        "2": AttendanceLogicalStatus.ABSENT,
       }),
     ]);
     expect(allAbsent.countEventsPresentAverage()).toBe(0);

--- a/src/app/child-dev-project/attendance/model/attendance-status.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-status.ts
@@ -1,3 +1,11 @@
+import {
+  CONFIGURABLE_ENUM_CONFIG_PREFIX,
+  ConfigurableEnumValue,
+} from "../../../core/configurable-enum/configurable-enum.interface";
+
+/**
+ * @deprecated
+ */
 export enum AttendanceStatus {
   UNKNOWN = "?",
   HOLIDAY = "H",
@@ -7,81 +15,51 @@ export enum AttendanceStatus {
   EXCUSED = "E",
 }
 
-export class AttendanceStatusType {
-  static NONE = {
-    status: AttendanceStatus.UNKNOWN,
-    name: "?",
-    shortName: "?",
-    style: "attendance-U",
-  };
+/**
+ * logical type of an attendance status, i.e. how it will be considered for statistics and analysis.
+ */
+export enum AttendanceLogicalStatus {
+  PRESENT = "PRESENT",
+  ABSENT = "ABSENT",
+  IGNORE = "IGNORE",
+}
 
-  /**
-   * match to enum - can probably be removed once completed moved into config?
-   */
-  status: AttendanceStatus;
+/**
+ * the id through which the available attendance status types can be loaded from the ConfigService.
+ */
+export const ATTENDANCE_STATUS_CONFIG_ID =
+  CONFIGURABLE_ENUM_CONFIG_PREFIX + "attendance-status";
 
-  countAs: AttendanceCounting = AttendanceCounting.IGNORE;
+/**
+ * Details of one status option users can assign to a participant's details attending an event.
+ */
+export interface AttendanceStatusType extends ConfigurableEnumValue {
+  /** persistent id that remains unchanged in the config database */
+  id: string;
+
+  /** a clear, spelled out title of the status */
+  label: string;
 
   /** a short (one letter) representation e.g. used in calendar view */
   shortName: string;
 
-  /** a clear, spelled out title of the status */
-  name: string;
+  /**
+   * how this status will be categorized and considered for statistics and analysis
+   */
+  countAs: AttendanceLogicalStatus;
 
   /** a css class with styling related to the status */
   style?: string;
 }
 
-export enum AttendanceCounting {
-  PRESENT,
-  ABSENT,
-  IGNORE,
-}
-
 /**
- * TEMPORARY: standard attendance types; should be moved into config
+ * Null object representing an unknown attendance status.
+ *
+ * This allows easier handling of attendance status logic because exceptional checks for undefined are not necessary.
  */
-export const DEFAULT_ATTENDANCE_TYPES = [
-  {
-    status: AttendanceStatus.PRESENT,
-    shortName: "P",
-    name: "Present",
-    style: "attendance-P",
-    countAs: AttendanceCounting.PRESENT,
-  },
-  {
-    status: AttendanceStatus.ABSENT,
-    shortName: "A",
-    name: "Absent",
-    style: "attendance-A",
-    countAs: AttendanceCounting.ABSENT,
-  },
-  {
-    status: AttendanceStatus.LATE,
-    shortName: "L",
-    name: "Late",
-    style: "attendance-L",
-    countAs: AttendanceCounting.PRESENT,
-  },
-  {
-    status: AttendanceStatus.HOLIDAY,
-    shortName: "H",
-    name: "Holiday",
-    style: "attendance-H",
-    countAs: AttendanceCounting.IGNORE,
-  },
-  {
-    status: AttendanceStatus.EXCUSED,
-    shortName: "E",
-    name: "Excused",
-    style: "attendance-E",
-    countAs: AttendanceCounting.IGNORE,
-  },
-  {
-    status: AttendanceStatus.UNKNOWN,
-    shortName: "?",
-    name: "Skip",
-    style: "attendance-U",
-    countAs: AttendanceCounting.IGNORE,
-  },
-];
+export const NullAttendanceStatusType: AttendanceStatusType = {
+  id: "",
+  label: "",
+  shortName: "",
+  countAs: AttendanceLogicalStatus.IGNORE,
+};

--- a/src/app/child-dev-project/attendance/model/calculate-average-event-attendance.ts
+++ b/src/app/child-dev-project/attendance/model/calculate-average-event-attendance.ts
@@ -1,41 +1,40 @@
 import { Note } from "../../notes/model/note";
 import {
-  AttendanceCounting,
-  AttendanceStatus,
+  AttendanceLogicalStatus,
   AttendanceStatusType,
+  NullAttendanceStatusType,
 } from "./attendance-status";
-import { getAttendanceType } from "./activity-attendance";
 
 export function calculateAverageAttendance(
   event: Note
 ): {
   average: number;
   unknownStatus: number;
-  statusCounts: Map<AttendanceStatus, number>;
+  statusCounts: Map<AttendanceStatusType, number>;
 } {
-  const stats = new Map<AttendanceCounting, number>();
-  stats.set(AttendanceCounting.PRESENT, 0);
-  stats.set(AttendanceCounting.ABSENT, 0);
-  stats.set(AttendanceCounting.IGNORE, 0);
+  const stats = new Map<AttendanceLogicalStatus, number>();
+  stats.set(AttendanceLogicalStatus.PRESENT, 0);
+  stats.set(AttendanceLogicalStatus.ABSENT, 0);
+  stats.set(AttendanceLogicalStatus.IGNORE, 0);
 
-  const statusCounts = new Map<AttendanceStatus, number>();
+  const statusCounts = new Map<AttendanceStatusType, number>();
 
   for (const childId of event.children) {
     const status = event.getAttendance(childId).status;
     const countStatus = statusCounts.get(status) ?? 0;
     statusCounts.set(status, countStatus + 1);
 
-    const attendanceType = getAttendanceType(status).countAs;
+    const attendanceType = status.countAs;
     const countType = stats.get(attendanceType) ?? 0;
     stats.set(attendanceType, countType + 1);
   }
 
   return {
     average:
-      stats.get(AttendanceCounting.PRESENT) /
-      (stats.get(AttendanceCounting.PRESENT) +
-        stats.get(AttendanceCounting.ABSENT)),
-    unknownStatus: statusCounts.get(AttendanceStatusType.NONE.status) ?? 0,
+      stats.get(AttendanceLogicalStatus.PRESENT) /
+      (stats.get(AttendanceLogicalStatus.PRESENT) +
+        stats.get(AttendanceLogicalStatus.ABSENT)),
+    unknownStatus: statusCounts.get(NullAttendanceStatusType.status) ?? 0,
     statusCounts: statusCounts,
   };
 }

--- a/src/app/child-dev-project/attendance/model/event-attendance.ts
+++ b/src/app/child-dev-project/attendance/model/event-attendance.ts
@@ -1,11 +1,27 @@
-import { AttendanceStatus } from "./attendance-status";
+import {
+  ATTENDANCE_STATUS_CONFIG_ID,
+  AttendanceStatusType,
+  NullAttendanceStatusType,
+} from "./attendance-status";
+import { DatabaseField } from "../../../core/entity/database-field.decorator";
 
 /**
  * Simple relationship object to represent an individual child's status at an event including context information.
  */
 export class EventAttendance {
+  @DatabaseField({
+    dataType: "configurable-enum",
+    innerDataType: ATTENDANCE_STATUS_CONFIG_ID,
+  })
+  status: AttendanceStatusType;
+
+  @DatabaseField() remarks: string;
+
   constructor(
-    public status: AttendanceStatus = AttendanceStatus.UNKNOWN,
-    public remarks: string = ""
-  ) {}
+    status: AttendanceStatusType = NullAttendanceStatusType,
+    remarks: string = ""
+  ) {
+    this.status = status;
+    this.remarks = remarks;
+  }
 }

--- a/src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.ts
+++ b/src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from "@angular/core";
 import { DemoDataGenerator } from "../../../core/demo-data/demo-data-generator";
 import { faker } from "../../../core/demo-data/faker";
 import { centersWithProbability } from "./fixtures/centers";
+import { addDefaultChildPhoto } from "../../../../../.storybook/utils/addDefaultChildPhoto";
 
 export class DemoChildConfig {
   count: number;
@@ -43,6 +44,9 @@ export class DemoChildGenerator extends DemoDataGenerator<Child> {
     if (faker.random.number(100) > 80) {
       DemoChildGenerator.makeChildDropout(child);
     }
+
+    // add default photo for easier use in storybook stories
+    addDefaultChildPhoto(child);
 
     return child;
   }

--- a/src/app/child-dev-project/notes/demo-data/demo-note-generator.service.ts
+++ b/src/app/child-dev-project/notes/demo-data/demo-note-generator.service.ts
@@ -11,7 +11,13 @@ import { centersUnique } from "../../children/demo-data-generators/fixtures/cent
 import { absenceRemarks } from "./remarks";
 import moment from "moment";
 import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
-import { AttendanceStatus } from "../../attendance/model/attendance-status";
+import {
+  ATTENDANCE_STATUS_CONFIG_ID,
+  AttendanceLogicalStatus,
+  AttendanceStatusType,
+} from "../../attendance/model/attendance-status";
+import { ConfigService } from "../../../core/config/config.service";
+import { ConfigurableEnumConfig } from "../../../core/configurable-enum/configurable-enum.interface";
 
 export class DemoNoteConfig {
   minNotesPerChild: number;
@@ -54,12 +60,19 @@ export class DemoNoteGeneratorService extends DemoDataGenerator<Note> {
     return this._teamMembers;
   }
 
+  private availableStatusTypes: AttendanceStatusType[];
+
   constructor(
     private config: DemoNoteConfig,
     private demoChildren: DemoChildGenerator,
-    private schemaService: EntitySchemaService
+    private schemaService: EntitySchemaService,
+    private configService: ConfigService
   ) {
     super();
+
+    this.availableStatusTypes = this.configService.getConfig<
+      ConfigurableEnumConfig<AttendanceStatusType>
+    >(ATTENDANCE_STATUS_CONFIG_ID);
   }
 
   public generateEntities(): Note[] {
@@ -156,7 +169,9 @@ export class DemoNoteGeneratorService extends DemoDataGenerator<Note> {
       const attendance = note.getAttendance(child.getId());
       // get an approximate presence of 85%
       if (faker.random.number(100) <= 15) {
-        attendance.status = AttendanceStatus.ABSENT;
+        attendance.status = this.availableStatusTypes.find(
+          (t) => t.countAs === AttendanceLogicalStatus.ABSENT
+        );
         attendance.remarks = faker.random.arrayElement(absenceRemarks);
       }
     });

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.html
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.html
@@ -1,6 +1,5 @@
 
-<div fxLayout="col" fxLayoutGap="4px">
-
+<div fxLayout="col" fxLayoutGap="4px" fxLayoutAlign="start baseline">
   <div class="actions" fxFlex="40px">
     <!-- deactivated to keep the UI simple and understandable
     <span class="fa fa-window-maximize" *ngIf="!showRemarks" (click)="showRemarks=true"></span>
@@ -11,18 +10,9 @@
     </button>
   </div>
 
-  <div fxFlex="125px">
-    <mat-button-toggle-group name="present" class="presence-toggle"
-                             [value]="attendance.status.id !== 'ABSENT'" (change)='setStatus($event.value)'>
-      <mat-button-toggle [value]="true" class="presence-toggle-button"
-                         [ngClass]="{'button-present': attendance.status.id !== 'ABSENT'}">
-        Present
-      </mat-button-toggle>
-      <mat-button-toggle [value]="false" class="presence-toggle-button"
-                         [ngClass]="{'button-absent': attendance.status.id === 'ABSENT'}">
-        Absent
-      </mat-button-toggle>
-    </mat-button-toggle-group>
+  <div fxFlex="250px">
+    <app-attendance-status-select [(value)]="attendance.status" (valueChange)="change.emit(attendance)">
+    </app-attendance-status-select>
   </div>
 
   <app-child-block [entityId]="childId" fxFlex>

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.html
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.html
@@ -13,13 +13,13 @@
 
   <div fxFlex="125px">
     <mat-button-toggle-group name="present" class="presence-toggle"
-                             [value]="attendance.status !== ATTENDANCE_STATUS.ABSENT" (change)='setStatus($event.value)'>
+                             [value]="attendance.status.id !== 'ABSENT'" (change)='setStatus($event.value)'>
       <mat-button-toggle [value]="true" class="presence-toggle-button"
-                         [ngClass]="{'button-present': attendance.status !== ATTENDANCE_STATUS.ABSENT}">
+                         [ngClass]="{'button-present': attendance.status.id !== 'ABSENT'}">
         Present
       </mat-button-toggle>
       <mat-button-toggle [value]="false" class="presence-toggle-button"
-                         [ngClass]="{'button-absent': attendance.status === ATTENDANCE_STATUS.ABSENT}">
+                         [ngClass]="{'button-absent': attendance.status.id === 'ABSENT'}">
         Absent
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.scss
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.scss
@@ -6,18 +6,3 @@
 .actions {
 
 }
-
-.presence-toggle {
-  margin: 4px;
-  font-size: 0.8em;
-}
-.presence-toggle-button {
-  margin: -10px -5px -10px -5px;
-}
-
-.button-present {
-  background-color: #90ee9040;
-}
-.button-absent {
-  background-color: #fd727280;
-}

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { EventAttendance } from "../../../attendance/model/event-attendance";
 
+/**
+ * Display a single participant's attendance status in a compact row.
+ */
 @Component({
   selector: "app-child-meeting-note-attendance",
   templateUrl: "./child-meeting-note-attendance.component.html",

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { EventAttendance } from "../../../attendance/model/event-attendance";
-import { AttendanceLogicalStatus } from "../../../attendance/model/attendance-status";
 
 @Component({
   selector: "app-child-meeting-note-attendance",
@@ -13,11 +12,4 @@ export class ChildMeetingNoteAttendanceComponent {
   @Output() change = new EventEmitter();
   @Output() remove = new EventEmitter();
   showRemarks: boolean = false;
-
-  ATTENDANCE_STATUS = AttendanceLogicalStatus;
-
-  setStatus(present: boolean) {
-    // TODO this.attendance.status = AttendanceStatus.ABSENT;
-    this.change.emit(this.attendance);
-  }
 }

--- a/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
+++ b/src/app/child-dev-project/notes/note-details/child-meeting-attendance/child-meeting-note-attendance.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { EventAttendance } from "../../../attendance/model/event-attendance";
-import { AttendanceStatus } from "../../../attendance/model/attendance-status";
+import { AttendanceLogicalStatus } from "../../../attendance/model/attendance-status";
 
 @Component({
   selector: "app-child-meeting-note-attendance",
@@ -14,14 +14,10 @@ export class ChildMeetingNoteAttendanceComponent {
   @Output() remove = new EventEmitter();
   showRemarks: boolean = false;
 
-  ATTENDANCE_STATUS = AttendanceStatus;
+  ATTENDANCE_STATUS = AttendanceLogicalStatus;
 
   setStatus(present: boolean) {
-    if (present) {
-      this.attendance.status = AttendanceStatus.PRESENT;
-    } else {
-      this.attendance.status = AttendanceStatus.ABSENT;
-    }
+    // TODO this.attendance.status = AttendanceStatus.ABSENT;
     this.change.emit(this.attendance);
   }
 }

--- a/src/app/child-dev-project/notes/note-details/note-details.stories.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.stories.ts
@@ -9,6 +9,9 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { MatNativeDateModule } from "@angular/material/core";
 import { Angulartics2Module } from "angulartics2";
+import { Child } from "../../children/model/child";
+
+const demoChildren: Child[] = [Child.create("Joe"), Child.create("Jane")];
 
 export default {
   title: "Child Dev Project/NoteDetails",
@@ -36,4 +39,14 @@ const Template: Story<NoteDetailsComponent> = (args: NoteDetailsComponent) => ({
 export const Primary = Template.bind({});
 Primary.args = {
   entity: new Note(),
+};
+
+const eventNote = Note.create(new Date(), "Coaching today");
+eventNote.category = { id: "COACHING", label: "Coaching", isMeeting: true };
+eventNote.addChild(demoChildren[0].getId());
+eventNote.addChild(demoChildren[1].getId());
+
+export const EventWithAttendance = Template.bind({});
+Primary.args = {
+  entity: eventNote,
 };

--- a/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.component.ts
@@ -8,7 +8,7 @@ import {
 import { Note } from "../../model/note";
 import { NgForm } from "@angular/forms";
 import { ChildSelectComponent } from "../../../children/child-select/child-select.component";
-import { AttendanceStatus } from "../../../attendance/model/attendance-status";
+import { AttendanceLogicalStatus } from "../../../attendance/model/attendance-status";
 
 @Component({
   selector: "app-note-presence-list",
@@ -44,7 +44,7 @@ export class NotePresenceListComponent implements OnChanges {
       if (statusA === statusB) {
         return 0;
       }
-      if (statusA === AttendanceStatus.PRESENT) {
+      if (statusA.countAs === AttendanceLogicalStatus.PRESENT) {
         return -1;
       }
       return statusA.localeCompare(statusB);

--- a/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.component.ts
@@ -10,6 +10,9 @@ import { NgForm } from "@angular/forms";
 import { ChildSelectComponent } from "../../../children/child-select/child-select.component";
 import { AttendanceLogicalStatus } from "../../../attendance/model/attendance-status";
 
+/**
+ * Display the participants' of an event in a list allowing each attendance status to be edited.
+ */
 @Component({
   selector: "app-note-presence-list",
   templateUrl: "./note-presence-list.component.html",

--- a/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.stories.ts
+++ b/src/app/child-dev-project/notes/note-details/note-presence-list/note-presence-list.stories.ts
@@ -1,0 +1,60 @@
+import { Story, Meta } from "@storybook/angular/types-6-0";
+import { moduleMetadata } from "@storybook/angular";
+import { CommonModule } from "@angular/common";
+import { ConfigurableEnumModule } from "../../../../core/configurable-enum/configurable-enum.module";
+import { NotesModule } from "../../notes.module";
+import { NotePresenceListComponent } from "./note-presence-list.component";
+import { Note } from "../../model/note";
+import { ChildrenService } from "../../../children/children.service";
+import { of } from "rxjs";
+import { RouterTestingModule } from "@angular/router/testing";
+import { FontAwesomeIconsModule } from "../../../../core/icons/font-awesome-icons.module";
+import { DemoChildGenerator } from "../../../children/demo-data-generators/demo-child-generator.service";
+
+const demoChildren = [
+  DemoChildGenerator.generateEntity("1"),
+  DemoChildGenerator.generateEntity("2"),
+  DemoChildGenerator.generateEntity("3"),
+];
+
+export default {
+  title: "Child Dev Project/NotePresenceList",
+  component: NotePresenceListComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CommonModule,
+        RouterTestingModule,
+        FontAwesomeIconsModule,
+        ConfigurableEnumModule,
+        NotesModule,
+      ],
+      providers: [
+        {
+          provide: ChildrenService,
+          useValue: {
+            getChild: (id) => of(demoChildren.find((c) => c.getId() === id)),
+            getChildren: () => of(demoChildren),
+          },
+        },
+      ],
+    }),
+  ],
+} as Meta;
+
+const Template: Story<NotePresenceListComponent> = (
+  args: NotePresenceListComponent
+) => ({
+  component: NotePresenceListComponent,
+  props: args,
+});
+
+const eventNote = Note.create(new Date(), "Coaching today");
+eventNote.category = { id: "COACHING", label: "Coaching", isMeeting: true };
+eventNote.addChild(demoChildren[0].getId());
+eventNote.addChild(demoChildren[1].getId());
+
+export const Primary = Template.bind({});
+Primary.args = {
+  entity: eventNote,
+};

--- a/src/app/child-dev-project/notes/notes.module.ts
+++ b/src/app/child-dev-project/notes/notes.module.ts
@@ -40,6 +40,7 @@ import { Angulartics2Module } from "angulartics2";
 import { EntitySubrecordModule } from "../../core/entity-components/entity-subrecord/entity-subrecord.module";
 import { EntityListModule } from "../../core/entity-components/entity-list/entity-list.module";
 import { ConfigurableEnumModule } from "../../core/configurable-enum/configurable-enum.module";
+import { AttendanceModule } from "../attendance/attendance.module";
 
 @NgModule({
   declarations: [
@@ -90,6 +91,7 @@ import { ConfigurableEnumModule } from "../../core/configurable-enum/configurabl
     EntitySubrecordModule,
     EntityListModule,
     ConfigurableEnumModule,
+    AttendanceModule,
   ],
   providers: [],
 })

--- a/src/app/core/config/config-fix.json
+++ b/src/app/core/config/config-fix.json
@@ -58,6 +58,8 @@
       }
     ]
   },
+
+
   "enum:interaction-type": [
     {
       "id": "",
@@ -161,6 +163,53 @@
       "isMeeting": true
     }
   ],
+
+  "enum:attendance-status": [
+    {
+      "id": "PRESENT",
+      "shortlabel": "P",
+      "label": "Present",
+      "style": "attendance-P",
+      "countAs": "PRESENT"
+    },
+    {
+      "id": "ABSENT",
+      "shortlabel": "A",
+      "label": "Absent",
+      "style": "attendance-A",
+      "countAs": "ABSENT"
+    },
+    {
+      "id": "LATE",
+      "shortlabel": "L",
+      "label": "Late",
+      "style": "attendance-L",
+      "countAs": "PRESENT"
+    },
+    {
+      "id": "HOLIDAY",
+      "shortlabel": "H",
+      "label": "Holiday",
+      "style": "attendance-H",
+      "countAs": "IGNORE"
+    },
+    {
+      "id": "EXCUSED",
+      "shortlabel": "E",
+      "label": "Excused",
+      "style": "attendance-E",
+      "countAs": "IGNORE"
+    },
+    {
+      "id": "UNKNOWN",
+      "shortlabel": "?",
+      "label": "Skip",
+      "style": "attendance-U",
+      "countAs": "IGNORE"
+    }
+  ],
+
+
   "view:": {
     "component": "Dashboard",
     "config": {

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -65,3 +65,10 @@ export class ConfigService {
     return matchingConfigs;
   }
 }
+
+export function createTestingConfigService(configsObject: any): ConfigService {
+  const configService = new ConfigService(null);
+  // @ts-ignore
+  configService.config.data = configsObject;
+  return configService;
+}

--- a/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
+++ b/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
@@ -31,11 +31,13 @@ export class ConfigurableEnumDatatype
     schemaField: EntitySchemaField
   ): ConfigurableEnumValue {
     if (value) {
+      let configId = schemaField.innerDataType;
+      if (!configId.startsWith(CONFIGURABLE_ENUM_CONFIG_PREFIX)) {
+        configId = CONFIGURABLE_ENUM_CONFIG_PREFIX + configId;
+      }
       return this.configService
-        .getConfig<ConfigurableEnumConfig>(
-          CONFIGURABLE_ENUM_CONFIG_PREFIX + schemaField.innerDataType
-        )
-        .find((option) => option.id === value);
+        .getConfig<ConfigurableEnumConfig>(configId)
+        ?.find((option) => option.id === value);
     } else {
       return undefined;
     }

--- a/src/app/core/session/session-service/online-session.service.ts
+++ b/src/app/core/session/session-service/online-session.service.ts
@@ -48,7 +48,6 @@ export class OnlineSessionService extends SessionService {
     this.remoteSession = new RemoteSession();
     this.database = new PouchDatabase(
       this.remoteSession.database,
-      this.alertService,
       this.loggingService
     );
   }


### PR DESCRIPTION
- replace hard-coded attendance status options with a configurable enum loaded from config
- update children attendance list in NoteDetails with proper selectable version that is offering all options

the code overall is becoming bloated with too many components and files and complicated demo setups. I will try to simplify this once all the basic functionality is implemented for the epic.