### PR TITLE
Fix Reloading Config

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,7 @@ import { EntityConfigService } from "./core/entity/entity-config.service";
 import { Child } from "./child-dev-project/children/model/child";
 import { SessionService } from "./core/session/session-service/session.service";
 import { SyncState } from "./core/session/session-states/sync-state.enum";
+import { ActivatedRoute, Router } from "@angular/router";
 
 /**
  * Component as the main entry point for the app.
@@ -45,7 +46,9 @@ export class AppComponent implements OnInit {
     private entityMapper: EntityMapperService,
     private routerService: RouterService,
     private entityConfigService: EntityConfigService,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private activatedRoute: ActivatedRoute,
+    private router: Router
   ) {
     // If loading the config earlier (in a module constructor or through APP_INITIALIZER) a runtime error occurs.
     // The EntityMapperService needs the SessionServiceProvider which needs the AppConfig to be set up.
@@ -56,7 +59,8 @@ export class AppComponent implements OnInit {
     sessionService
       .getSyncState()
       .waitForChangeTo(SyncState.COMPLETED)
-      .then(() => configService.loadConfig(entityMapper));
+      .then(() => configService.loadConfig(entityMapper))
+      .then(() => router.navigate([], { relativeTo: this.activatedRoute }));
     // These functions will be executed whenever a new config is available
     configService.configUpdated.subscribe(() => routerService.initRouting());
     configService.configUpdated.subscribe(() =>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,6 +25,8 @@ import { ConfigService } from "./core/config/config.service";
 import { RouterService } from "./core/view/dynamic-routing/router.service";
 import { EntityConfigService } from "./core/entity/entity-config.service";
 import { Child } from "./child-dev-project/children/model/child";
+import { SessionService } from "./core/session/session-service/session.service";
+import { SyncState } from "./core/session/session-states/sync-state.enum";
 
 /**
  * Component as the main entry point for the app.
@@ -42,13 +44,19 @@ export class AppComponent implements OnInit {
     private configService: ConfigService,
     private entityMapper: EntityMapperService,
     private routerService: RouterService,
-    private entityConfigService: EntityConfigService
+    private entityConfigService: EntityConfigService,
+    private sessionService: SessionService
   ) {
     // If loading the config earlier (in a module constructor or through APP_INITIALIZER) a runtime error occurs.
     // The EntityMapperService needs the SessionServiceProvider which needs the AppConfig to be set up.
     // If the EntityMapperService is requested to early (through DI), the AppConfig is not ready yet.
     // TODO fix this with https://github.com/Aam-Digital/ndb-core/issues/595
     configService.loadConfig(entityMapper);
+    // Reload config once the database is synced
+    sessionService
+      .getSyncState()
+      .waitForChangeTo(SyncState.COMPLETED)
+      .then(() => configService.loadConfig(entityMapper));
     // These functions will be executed whenever a new config is available
     configService.configUpdated.subscribe(() => routerService.initRouting());
     configService.configUpdated.subscribe(() =>

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -15,12 +15,11 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Optional } from "@angular/core";
+import { Component } from "@angular/core";
 import { SyncState } from "../session-states/sync-state.enum";
 import { SessionService } from "../session-service/session.service";
 import { LoginState } from "../session-states/login-state.enum";
 import { ConnectionState } from "../session-states/connection-state.enum";
-import { ActivatedRoute, Router } from "@angular/router";
 
 /**
  * Form to allow users to enter their credentials and log in.
@@ -43,11 +42,7 @@ export class LoginComponent {
   /** errorMessage displayed in form */
   errorMessage: string;
 
-  constructor(
-    private _sessionService: SessionService,
-    @Optional() private router: Router,
-    @Optional() private route: ActivatedRoute
-  ) {}
+  constructor(private _sessionService: SessionService) {}
 
   /**
    * Do a login with the SessionService.
@@ -92,12 +87,6 @@ export class LoginComponent {
   }
 
   private onLoginSuccess() {
-    // New routes are added at runtime,
-    if (this.router && this.route) {
-      this.router.navigate([], {
-        relativeTo: this.route,
-      });
-    }
     this.reset();
     // login component is automatically hidden based on _sessionService.isLoggedIn()
   }

--- a/src/app/core/ui/ui/ui.component.html
+++ b/src/app/core/ui/ui/ui.component.html
@@ -59,7 +59,6 @@
     <button
       mat-icon-button
       (click)="logout()"
-      [routerLink]="['']"
       *ngIf="isLoggedIn()"
     >
       <mat-icon class="header-icon" fontIcon="fa-sign-out"></mat-icon>

--- a/src/app/core/view/dynamic-routing/router.service.ts
+++ b/src/app/core/view/dynamic-routing/router.service.ts
@@ -46,7 +46,7 @@ export class RouterService {
     additionalRoutes: Route[] = [],
     overwriteExistingRoutes = false
   ) {
-    const routes = [];
+    const routes: Route[] = [];
 
     for (const view of viewConfigs) {
       const route = this.generateRouteFromConfig(view);
@@ -70,7 +70,10 @@ export class RouterService {
     }
 
     // add routes from other sources (e.g. pre-existing  hard-coded routes)
-    routes.push(...additionalRoutes);
+    const noDuplicates = additionalRoutes.filter(
+      (r) => !routes.find((o) => o.path === r.path)
+    );
+    routes.push(...noDuplicates);
 
     this.router.resetConfig(routes);
   }


### PR DESCRIPTION
see issue: #615 

### Visible/Frontend Changes
- The config is applied at the initial sync 
- The current route is not lost when logging in/out

### Architectural/Backend Changes
- The config is reloaded, once the sync status changes to `COMPLETED`
- After the config is loaded, a routing to the same location is started, to apply config that affects the first page that is already loaded

