### PR TITLE
Creating coverage report inside the docker image

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -21,8 +21,6 @@ jobs:
           destination_dir: documentation
   run-tests:
     runs-on: ubuntu-latest
-      env:
-        TIME: 0
     steps:
       - uses: actions/checkout@v1
       - name: Login to DockerHub

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -21,6 +21,8 @@ jobs:
           destination_dir: documentation
   run-tests:
     runs-on: ubuntu-latest
+      env:
+        TIME: 0
     steps:
       - uses: actions/checkout@v1
       - name: Login to DockerHub
@@ -31,24 +33,24 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
-      - name: Build and push prod image
+      - name: Get time of commit
+        run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
+      - name: Run tests and upload coverage
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./build/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          tags: test-image
           target: builder
-          build-args: RUN_TESTS=${{ true }}
-          outputs: type=local,dest=./img
+          tags: test-image
+          build-args: |
+            UPLOAD_COVERAGE=${{ true }}
+            GIT_COMMIT_SHA=${{ GITHUB_SHA }}
+            GIT_BRANCH=${{ github.head_ref }}
+            GIT_COMMITTED_AT=${{ env.TIME }}
+            CC_TEST_REPORTER_ID=${{ secrets.CODE_CLIMATE_ID }}
           cache-from: type=registry,ref=aamdigital/ndb-server:cache
           cache-to: type=registry,ref=aamdigital/ndb-server:cache,mode=max
-      - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
-        with:
-          coverageLocations: img/app/coverage/lcov.info:lcov
   run-semantic-release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Get time of commit
         id: commit-time
         run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
-      - name: debug
-        run: |
-          echo ${{ github.event.pull_request.head.sha }}
-          echo ${{ github.head_ref }}
-          echo ${{ env.TIME }}
       - name: Build dev image and save it locally
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Get time of commit
         id: commit-time
         run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
+      - name: debug
+        run: |
+          echo ${{ github.event.pull_request.sha }}
+          echo ${{ github.head_ref }}
+          echo ${{ env.TIME }}
       - name: Build dev image and save it locally
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -4,8 +4,6 @@ on: pull_request
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    env:
-      TIME: 0
     steps:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -4,11 +4,16 @@ on: pull_request
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      TIME: 0
     steps:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+      - name: Get time of commit
+        id: commit-time
+        run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
       - name: Build dev image and save it locally
         uses: docker/build-push-action@v2
         with:
@@ -17,15 +22,14 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           target: builder
           tags: test-image
-          outputs: type=local,dest=./img
-          build-args: RUN_TESTS=${{ true }}
+          build-args: |
+            RUN_TESTS=${{ true }}
+            UPLOAD_COVERAGE=${{ true }}
+            GIT_COMMIT_SHA=${{ github.event.pull_request.sha }}
+            GIT_BRANCH=${{ github.head_ref }}
+            GIT_COMMITTED_AT=${{ env.TIME }}
+            CC_TEST_REPORTER_ID=${{ secrets.CODE_CLIMATE_ID }}
           cache-from: type=registry,ref=aamdigital/ndb-server:cache
-      - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
-        with:
-          coverageLocations: ${{github.workspace}}/img/app/coverage/lcov.info:lcov
   deploy-prod-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -12,7 +12,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@master
       - name: Get time of commit
-        id: commit-time
         run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
       - name: Build dev image and save it locally
         uses: docker/build-push-action@v2

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo "TIME=$(git log -1 --pretty=format:%ct)" >> $GITHUB_ENV
       - name: debug
         run: |
-          echo ${{ github.event.pull_request.sha }}
+          echo ${{ github.event.pull_request.head.sha }}
           echo ${{ github.head_ref }}
           echo ${{ env.TIME }}
       - name: Build dev image and save it locally
@@ -30,7 +30,7 @@ jobs:
           build-args: |
             RUN_TESTS=${{ true }}
             UPLOAD_COVERAGE=${{ true }}
-            GIT_COMMIT_SHA=${{ github.event.pull_request.sha }}
+            GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha }}
             GIT_BRANCH=${{ github.head_ref }}
             GIT_COMMITTED_AT=${{ env.TIME }}
             CC_TEST_REPORTER_ID=${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -23,7 +23,6 @@ jobs:
           target: builder
           tags: test-image
           build-args: |
-            RUN_TESTS=${{ true }}
             UPLOAD_COVERAGE=${{ true }}
             GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha }}
             GIT_BRANCH=${{ github.head_ref }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,6 +19,13 @@ COPY . .
 RUN $(npm bin)/ng build --prod
 
 # When set to true, chromium is installed an tests are executed
+ARG UPLOAD_COVERAGE=false
+RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
+    apk --no-cache add curl git &&\
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter &&\
+    chmod +x ./cc-test-reporter &&\
+    ./cc-test-reporter before-build ; fi
+
 ARG RUN_TESTS=false
 ARG CHROME_BIN=/usr/bin/chromium-browser
 # In the pipeline we run the tests and report the results
@@ -26,6 +33,13 @@ RUN if [ "$RUN_TESTS" = true ] ; then \
     apk --no-cache add chromium &&\
     npm run lint &&\
     npm run test-ci ; fi
+
+
+ARG GIT_COMMIT_SHA
+ARG GIT_BRANCH
+ARG GIT_COMMITTED_AT
+ARG CC_TEST_REPORTER_ID
+RUN if [ "$UPLOAD_COVERAGE" = true ] ; then ./cc-test-reporter after-build --debug ; fi
 
 
 ### PROD image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,7 +21,7 @@ RUN $(npm bin)/ng build --prod
 # When set to true, chromium is installed an tests are executed
 ARG UPLOAD_COVERAGE=false
 RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
-    apk --no-cache add curl git &&\
+    apk --no-cache add curl &&\
     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter &&\
     chmod +x ./cc-test-reporter &&\
     ./cc-test-reporter before-build ; fi

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN $(npm bin)/ng version
 COPY . .
 RUN $(npm bin)/ng build --prod
 
-# When set to true, chromium is installed an tests are executed
+# When set to true, tests are run and coverage will be uploaded to CodeClimate
 ARG UPLOAD_COVERAGE=false
 RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
     apk --no-cache add curl &&\
@@ -26,18 +26,23 @@ RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
     chmod +x ./cc-test-reporter &&\
     ./cc-test-reporter before-build ; fi
 
+# When set to true, chromium is installed an tests are executed
 ARG RUN_TESTS=false
 ARG CHROME_BIN=/usr/bin/chromium-browser
-# In the pipeline we run the tests and report the results
-RUN if [ "$RUN_TESTS" = true ] ; then \
+# Install chromium for karma, lint code and run tests
+RUN if [ "$RUN_TESTS" = true ] || [ "$UPLOAD_COVERAGE" = true ] ; then \
     apk --no-cache add chromium &&\
     npm run lint &&\
     npm run test-ci ; fi
 
-
+# The following arguments need to be provided for the code climate test reporter to work correctly
+# The commit sha
 ARG GIT_COMMIT_SHA
+# The branch
 ARG GIT_BRANCH
+# The time of the commit, can be extracted with `git log -1 --pretty=format:%ct`
 ARG GIT_COMMITTED_AT
+# The ID for the test reporter, can be found on CodeCoverage
 ARG CC_TEST_REPORTER_ID
 RUN if [ "$UPLOAD_COVERAGE" = true ] ; then ./cc-test-reporter after-build --debug ; fi
 


### PR DESCRIPTION
see issue: #610
Due to recent problems with the test stage, this image directly uploads the coverage results instead of copying them to the GitHub runner

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- Docker image has additional flag for uploading the coverage report
- GitHub workflow for uploading test coverage was removed
