### PR TITLE
Remove skip ci message on release message by semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -31,7 +31,8 @@
       "npmPublish": false
     }],
     ["@semantic-release/git", {
-      "assets": ["src/environments/environment.ts", "src/environments/environment.prod.ts", "package.json", "package-lock.json"]
+      "assets": ["src/environments/environment.ts", "src/environments/environment.prod.ts", "package.json", "package-lock.json"],
+      "message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
     }],
     ["semantic-release-slack-bot", {
       "packageName": "ndb-server",


### PR DESCRIPTION
Currently releases do not trigger the `new tag`  workflow due to [recent changes at GitHub](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)

The default message is:
> "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

### Architectural/Backend Changes
- Changed message created by Semantic Release