### PR TITLE
Initializing new school relations correctly

### DIFF
--- a/src/app/child-dev-project/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/previous-schools/previous-schools.component.ts
@@ -138,7 +138,6 @@ export class PreviousSchoolsComponent
       newPreviousSchool.start = new Date(
         lastToDate.setDate(lastToDate.getDate() + 1)
       ); // one day after last to-date
-      newPreviousSchool.end = null; // void date
       newPreviousSchool.result = Number.NaN; // NaN represents no data available
       return newPreviousSchool;
     };


### PR DESCRIPTION
### Architectural/Backend Changes
- New `ChildSchoolRelations` are not initialized with null any more
