### PR TITLE
Fix importing backup files

### DIFF
--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -60,19 +60,17 @@ export class AdminComponent implements OnInit {
   /**
    * Download a full backup of the database as (json) file.
    */
-  saveBackup() {
-    this.backupService
-      .getJsonExport()
-      .then((bac) => this.startDownload(bac, "text/json", "backup.json"));
+  async saveBackup() {
+    const backup = await this.backupService.getJsonExport();
+    this.startDownload(backup, "text/json", "backup.json");
   }
 
   /**
    * Download a full export of the database as csv file.
    */
-  saveCsvExport() {
-    this.backupService
-      .getCsvExport()
-      .then((csv) => this.startDownload(csv, "text/csv", "export.csv"));
+  async saveCsvExport() {
+    const csv = await this.backupService.getCsvExport();
+    this.startDownload(csv, "text/csv", "export.csv");
   }
 
   downloadConfigClick() {
@@ -80,12 +78,13 @@ export class AdminComponent implements OnInit {
     this.startDownload(jsonString, "text/json", "config.json");
   }
 
-  uploadConfigFile(file: Blob) {
-    this.readFile(file)
-      .then((res) =>
-        this.configService.saveConfig(this.entityMapper, JSON.parse(res))
-      )
-      .then(() => this.configService.loadConfig(this.entityMapper));
+  async uploadConfigFile(file: Blob) {
+    const loadedFile = await this.readFile(file);
+    await this.configService.saveConfig(
+      this.entityMapper,
+      JSON.parse(loadedFile)
+    );
+    await this.configService.loadConfig(this.entityMapper);
   }
 
   private startDownload(data: string, type: string, name: string) {
@@ -111,39 +110,35 @@ export class AdminComponent implements OnInit {
    * Reset the database to the state from the loaded backup file.
    * @param file The file object of the backup to be restored
    */
-  loadBackup(file) {
-    const pRestorePoint = this.backupService.getJsonExport();
-    const pLoadedData = this.readFile(file);
-    Promise.all([pLoadedData, pRestorePoint]).then((r) => {
-      const newData = r[0];
-      const restorePoint = r[1];
+  async loadBackup(file) {
+    const restorePoint = await this.backupService.getJsonExport();
+    const newData = await this.readFile(file);
 
-      const dialogRef = this.confirmationDialog.openDialog(
-        "Overwrite complete database?",
-        "Are you sure you want to restore this backup? " +
-          "This will delete all " +
-          restorePoint.split("\n").length +
-          " existing records in the database, " +
-          "restoring " +
-          newData.split("\n").length +
-          " records from the loaded file."
-      );
+    const dialogRef = this.confirmationDialog.openDialog(
+      "Overwrite complete database?",
+      "Are you sure you want to restore this backup? " +
+        "This will delete all " +
+        restorePoint.split("\n").length +
+        " existing records in the database, " +
+        "restoring " +
+        newData.split("\n").length +
+        " records from the loaded file."
+    );
 
-      dialogRef.afterClosed().subscribe((confirmed) => {
-        if (confirmed) {
-          this.backupService
-            .clearDatabase()
-            .then(() => this.backupService.importJson(newData, true));
+    dialogRef.afterClosed().subscribe(async (confirmed) => {
+      if (!confirmed) {
+        return;
+      }
 
-          const snackBarRef = this.snackBar.open("Backup restored", "Undo", {
-            duration: 8000,
-          });
-          snackBarRef.onAction().subscribe(() => {
-            this.backupService
-              .clearDatabase()
-              .then(() => this.backupService.importJson(restorePoint, true));
-          });
-        }
+      await this.backupService.clearDatabase();
+      await this.backupService.importJson(newData, true);
+
+      const snackBarRef = this.snackBar.open("Backup restored", "Undo", {
+        duration: 8000,
+      });
+      snackBarRef.onAction().subscribe(async () => {
+        await this.backupService.clearDatabase();
+        await this.backupService.importJson(restorePoint, true);
       });
     });
   }
@@ -152,34 +147,32 @@ export class AdminComponent implements OnInit {
    * Add the data from the loaded file to the database, inserting and updating records.
    * @param file The file object of the csv data to be loaded
    */
-  loadCsv(file: Blob) {
-    const pRestorePoint = this.backupService.getJsonExport();
-    const pLoadedData = this.readFile(file);
-    Promise.all([pLoadedData, pRestorePoint]).then((r) => {
-      const newData = r[0];
-      const restorePoint = r[1];
+  async loadCsv(file: Blob) {
+    const restorePoint = await this.backupService.getJsonExport();
+    const newData = await this.readFile(file);
 
-      const dialogRef = this.confirmationDialog.openDialog(
-        "Import new data?",
-        "Are you sure you want to import this file? " +
-          "This will add or update " +
-          (newData.trim().split("\n").length - 1) +
-          " records from the loaded file. " +
-          'Existing records with same "_id" in the database will be overwritten!'
-      );
+    const dialogRef = this.confirmationDialog.openDialog(
+      "Import new data?",
+      "Are you sure you want to import this file? " +
+        "This will add or update " +
+        (newData.trim().split("\n").length - 1) +
+        " records from the loaded file. " +
+        'Existing records with same "_id" in the database will be overwritten!'
+    );
 
-      dialogRef.afterClosed().subscribe((confirmed) => {
-        if (confirmed) {
-          this.backupService.importCsv(newData, true);
+    dialogRef.afterClosed().subscribe(async (confirmed) => {
+      if (!confirmed) {
+        return;
+      }
 
-          const snackBarRef = this.snackBar.open("Import completed", "Undo", {
-            duration: 8000,
-          });
-          snackBarRef.onAction().subscribe(() => {
-            this.backupService.clearDatabase();
-            this.backupService.importJson(restorePoint, true);
-          });
-        }
+      await this.backupService.importCsv(newData, true);
+
+      const snackBarRef = this.snackBar.open("Import completed", "Undo", {
+        duration: 8000,
+      });
+      snackBarRef.onAction().subscribe(async () => {
+        await this.backupService.clearDatabase();
+        await this.backupService.importJson(restorePoint, true);
       });
     });
   }
@@ -187,27 +180,29 @@ export class AdminComponent implements OnInit {
   /**
    * Reset the database removing all entities except user accounts.
    */
-  clearDatabase() {
-    this.backupService.getJsonExport().then((restorePoint) => {
-      const dialogRef = this.confirmationDialog.openDialog(
-        "Empty complete database?",
-        "Are you sure you want to clear the database? " +
-          "This will delete all " +
-          restorePoint.split("\n").length +
-          " existing records in the database!"
-      );
+  async clearDatabase() {
+    const restorePoint = await this.backupService.getJsonExport();
 
-      dialogRef.afterClosed().subscribe((confirmed) => {
-        if (confirmed) {
-          this.backupService.clearDatabase();
+    const dialogRef = this.confirmationDialog.openDialog(
+      "Empty complete database?",
+      "Are you sure you want to clear the database? " +
+        "This will delete all " +
+        restorePoint.split("\n").length +
+        " existing records in the database!"
+    );
 
-          const snackBarRef = this.snackBar.open("Import completed", "Undo", {
-            duration: 8000,
-          });
-          snackBarRef.onAction().subscribe(() => {
-            this.backupService.importJson(restorePoint, true);
-          });
-        }
+    dialogRef.afterClosed().subscribe(async (confirmed) => {
+      if (!confirmed) {
+        return;
+      }
+
+      await this.backupService.clearDatabase();
+
+      const snackBarRef = this.snackBar.open("Import completed", "Undo", {
+        duration: 8000,
+      });
+      snackBarRef.onAction().subscribe(async () => {
+        await this.backupService.importJson(restorePoint, true);
       });
     });
   }

--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -131,15 +131,17 @@ export class AdminComponent implements OnInit {
 
       dialogRef.afterClosed().subscribe((confirmed) => {
         if (confirmed) {
-          this.backupService.clearDatabase();
-          this.backupService.importJson(newData, true);
+          this.backupService
+            .clearDatabase()
+            .then(() => this.backupService.importJson(newData, true));
 
           const snackBarRef = this.snackBar.open("Backup restored", "Undo", {
             duration: 8000,
           });
           snackBarRef.onAction().subscribe(() => {
-            this.backupService.clearDatabase();
-            this.backupService.importJson(restorePoint, true);
+            this.backupService
+              .clearDatabase()
+              .then(() => this.backupService.importJson(restorePoint, true));
           });
         }
       });

--- a/src/app/core/admin/services/backup.service.ts
+++ b/src/app/core/admin/services/backup.service.ts
@@ -100,8 +100,11 @@ export class BackupService {
    */
   importJson(json, forceUpdate = false) {
     const promises = [];
-    json.split(BackupService.SEPARATOR_ROW).forEach((record) => {
-      promises.push(this.db.put(JSON.parse(record), forceUpdate));
+    json.split(BackupService.SEPARATOR_ROW).forEach((stringRecord) => {
+      const record = JSON.parse(stringRecord);
+      // Remove _rev so CouchDB treats it as a new rather than a updated document
+      delete record._rev;
+      promises.push(this.db.put(record, forceUpdate));
     });
     return Promise.all(promises);
   }
@@ -125,7 +128,7 @@ export class BackupService {
     parsedCsv.data.forEach((record) => {
       // remove undefined properties
       for (const propertyName in record) {
-        if (record[propertyName] === null) {
+        if (record[propertyName] === null || propertyName === "_rev") {
           delete record[propertyName];
         }
       }

--- a/src/app/core/admin/services/backup.service.ts
+++ b/src/app/core/admin/services/backup.service.ts
@@ -23,8 +23,9 @@ export class BackupService {
    *
    * @returns Promise<string> a string containing all elements of the database separated by SEPARATOR_ROW
    */
-  getJsonExport(): Promise<string> {
-    return this.db.getAll().then((results) => this.createJson(results));
+  async getJsonExport(): Promise<string> {
+    const results = await this.db.getAll();
+    return this.createJson(results);
   }
 
   /**
@@ -47,8 +48,9 @@ export class BackupService {
    *
    * @returns string a valid CSV string
    */
-  getCsvExport(): Promise<string> {
-    return this.db.getAll().then((results) => this.createCsv(results));
+  async getCsvExport(): Promise<string> {
+    const results = await this.db.getAll();
+    return this.createCsv(results);
   }
 
   /**
@@ -74,19 +76,14 @@ export class BackupService {
    *
    * @returns Promise<any> a promise that resolves after all remove operations are done
    */
-  clearDatabase(): Promise<any> {
-    const userEntityPrefix = new User("").getType() + ":";
-
-    return this.db.getAll().then((allDocs) => {
-      const p = [];
-      allDocs.forEach((row) => {
-        if (!row._id.startsWith(userEntityPrefix)) {
-          // skip User entities in order to not break login!
-          p.push(this.db.remove(row));
-        }
-      });
-      return Promise.all(p);
-    });
+  async clearDatabase(): Promise<void> {
+    const allDocs = await this.db.getAll();
+    for (const row of allDocs) {
+      if (!row._id.startsWith(User.ENTITY_TYPE + ":")) {
+        // skip User entities in order to not break login!
+        await this.db.remove(row);
+      }
+    }
   }
 
   /**
@@ -95,18 +92,14 @@ export class BackupService {
    *
    * @param json An array of entities to be written to the database
    * @param forceUpdate should existing objects be overridden? Default false
-   *
-   * @returns Promise<any> a promise that resolves after all save operations are done
    */
-  importJson(json, forceUpdate = false) {
-    const promises = [];
-    json.split(BackupService.SEPARATOR_ROW).forEach((stringRecord) => {
+  async importJson(json, forceUpdate = false): Promise<void> {
+    for (const stringRecord of json.split(BackupService.SEPARATOR_ROW)) {
       const record = JSON.parse(stringRecord);
       // Remove _rev so CouchDB treats it as a new rather than a updated document
       delete record._rev;
-      promises.push(this.db.put(record, forceUpdate));
-    });
-    return Promise.all(promises);
+      await this.db.put(record, forceUpdate);
+    }
   }
 
   /**
@@ -117,15 +110,14 @@ export class BackupService {
    *
    * @returns Promise<any> a promise that resolves after all save operations are done
    */
-  importCsv(csv, forceUpdate = false): Promise<any> {
-    const promises = [];
-
+  async importCsv(csv, forceUpdate = false): Promise<void> {
     const parsedCsv = this.papa.parse(csv, {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
     });
-    parsedCsv.data.forEach((record) => {
+
+    for (const record of parsedCsv.data) {
       // remove undefined properties
       for (const propertyName in record) {
         if (record[propertyName] === null || propertyName === "_rev") {
@@ -133,9 +125,7 @@ export class BackupService {
         }
       }
 
-      promises.push(this.db.put(record, forceUpdate));
-    });
-
-    return Promise.all(promises);
+      await this.db.put(record, forceUpdate);
+    }
   }
 }


### PR DESCRIPTION
When importing a backup file where documents have the `_rev` field, CouchDB thinks the document is updated rather than created and throws document conflicts. Because the document should be overwritten anyways, the `_rev` field is now removed before saving the document to the database.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- Removing the `_rev` field of documents before saving it to database
