### PR TITLE
Index Implementation for MockDB

### DIFF
--- a/src/app/core/database/mock-database.ts
+++ b/src/app/core/database/mock-database.ts
@@ -139,8 +139,6 @@ export class MockDatabase extends Database {
   }
 
   /**
-   * A "simulation" of queries as the PouchDatabase implementation would handle them.
-   *
    * This has hard-coded response logic for some individual indices that are used in the app
    * and at the moment cannot handle generic creating and executing real queries.
    * You can add a mock implementation here for your specific query/index if necessary.
@@ -176,8 +174,6 @@ export class MockDatabase extends Database {
   }
 
   /**
-   * Currently not implemented for MockDatabase!
-   *
    * Check (and extend) the `query` method for hard-coded mocks of some specific queries.
    *
    * @param designDoc

--- a/src/app/core/entity/database-indexing/database-indexing.service.ts
+++ b/src/app/core/entity/database-indexing/database-indexing.service.ts
@@ -22,6 +22,11 @@ import { BackgroundProcessState } from "../../sync-status/background-process-sta
 import { Entity, EntityConstructor } from "../entity";
 import { EntitySchemaService } from "../schema/entity-schema.service";
 
+export interface DesignDoc {
+  _id: string;
+  views: { [key: string]: { map: string; reduce?: string } };
+}
+
 /**
  * Manage database query index creation and use, working as a facade in front of the Database service.
  * This allows to track pending indexing processes and also show them to users in the UI.


### PR DESCRIPTION
Implemented the functionality to create and query indices for the mock database.

Currently `reduce` is not supported and the performance for the demo data is very bad due to the many usages of the index (`childBlockComponent`).

The performance could be improved by exchanging the sorting of the documents with a more sophisticated data structure that already sorts the elements when inserted.

### Architectural/Backend Changes
- [x] `saveDatabaseIndex` and `query` implemented for the `MockDatabase`