### PR TITLE
Changed descriptions to a more suitable format

### DIFF
--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.html
@@ -37,7 +37,10 @@
   </div>
 
   <div *ngIf="selectedEvent && !highlightForChild">
-    <div>
+    <div *ngIf="!selectedEventStats.average">
+      All excused (out of {{selectedEvent.children.length}} participants)
+    </div>
+    <div *ngIf="selectedEventStats.average">
       {{ selectedEventStats.average | percent: "1.0-0" }} attended (of
       {{ selectedEvent.children.length }} participants)
     </div>

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.html
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.html
@@ -26,9 +26,9 @@
       <div class="summary">
         Attendance:
         {{
-          focusedChild
+        (focusedChild
             ? entity?.getAttendancePercentage(focusedChild)
-            : (entity?.getAttendancePercentageAverage() | percent: "1.0-0")
+            : entity?.getAttendancePercentageAverage()) | percent: "1.0-0"
         }}
       </div>
     </div>

--- a/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.ts
+++ b/src/app/child-dev-project/attendance/attendance-details/attendance-details.component.ts
@@ -40,7 +40,10 @@ export class AttendanceDetailsComponent
         if (this.focusedChild) {
           return note.getAttendance(this.focusedChild).status.label;
         } else {
-          return Math.round(calculateAverageAttendance(note).average * 10) / 10;
+          return (
+            Math.round(calculateAverageAttendance(note).average * 10) / 10 ||
+            "N/A"
+          );
         }
       },
     },


### PR DESCRIPTION
see issue: #729 

### Visible/Frontend Changes
These texts have been updated to a more readable format:
- [x] 'N/A' instead of 'NaN' in the activity details-component
- [x] 'All excused (out of x participants)' instead of 'attended (out of x participants)'
- [x] The attendance of a single child was in a format that was badly readable 

### Architectural/Backend Changes
None
