### PR TITLE
Orphan Commits for gh-pages

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -19,6 +19,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: doc/compodoc
           destination_dir: documentation
+          force_orhpan: true
   run-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With this change, the `gh-pages` branch will only hold the latest commit and therefore drastically reduce the branch size