### PR TITLE
Marking childSchoolRelations as active that start today

### DIFF
--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -195,11 +195,17 @@ export class ChildrenService {
         by_school: {
           map: `(doc) => {
             if ( (!doc._id.startsWith("${ChildSchoolRelation.ENTITY_TYPE}")) ||
-                (doc.start && (new Date(doc.start) > new Date().setHours(0, 0, 0, 0))) ||
-                (doc.end && (new Date(doc.end) < new Date().setHours(0, 0, 0, 0))) ) {
+                (doc.start && isAfterToday(new Date(doc.start))) ||
+                (doc.end && !isAfterToday(new Date(doc.end))) ) {
               return;
             }
             emit(doc.schoolId);
+            function isAfterToday(date) {
+              const tomorrow = new Date();
+              tomorrow.setHours(0, 0, 0, 0);
+              tomorrow.setDate(tomorrow.getDate() + 1);
+              return date >= tomorrow;
+            }
             }`,
         },
         by_date: {


### PR DESCRIPTION
A problem occurred (maybe just because of the time zone) where children were not correctly marked as attending a given school, when the starting date was same as today.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- Overworked function to calculate whether a child currently attends this school
- Added tests for the indices of the `ChildrenService`
