### PR TITLE
Preventing transfomation of null values

### DIFF
--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -190,4 +190,31 @@ describe("EntitySchemaService", () => {
     expect(rawData.details.month).toEqual("2020-01");
     expect(rawData.details.otherStuff).toBeUndefined();
   });
+
+  it("should not transform null values", () => {
+    class Test extends Entity {
+      @DatabaseField({ dataType: "date-only" }) normalDate: Date;
+      @DatabaseField({ dataType: "date-only" }) nullDate: Date;
+    }
+    const testObject = new Test();
+    testObject.normalDate = new Date();
+    testObject.nullDate = null;
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(
+      testObject
+    );
+    expect(rawData.normalDate).toBeDefined();
+    expect(rawData.nullDate).toBeUndefined();
+  });
+
+  it("should not load null values", () => {
+    class Test extends Entity {
+      @DatabaseField({ dataType: "date-only" }) normalDate: Date;
+      @DatabaseField({ dataType: "date-only" }) nullDate: Date;
+    }
+    const rawData = { normalDate: "2021-05-04", nullDate: null };
+    const testEntity = new Test();
+    entitySchemaService.loadDataIntoEntity(testEntity, rawData);
+    expect(testEntity.normalDate).toBeDefined();
+    expect(testEntity.nullDate).toBeNull();
+  });
 });

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -97,7 +97,7 @@ export class EntitySchemaService {
     for (const key of schema.keys()) {
       const schemaField: EntitySchemaField = schema.get(key);
 
-      if (data[key] === undefined) {
+      if (data[key] === undefined || data[key] === null) {
         if (schemaField.defaultValue !== undefined) {
           data[key] = schemaField.defaultValue;
         } else {
@@ -153,7 +153,7 @@ export class EntitySchemaService {
       let value = entity[key];
       const schemaField: EntitySchemaField = schema.get(key);
 
-      if (value === undefined) {
+      if (value === undefined || value === null) {
         if (schemaField.defaultValue !== undefined) {
           value = schemaField.defaultValue;
         } else {


### PR DESCRIPTION
Currently setting a value to `null` can break the code because the schema transformation does not further check if the value is null. 
This is now prevented by explicitly not transforming `null` values of attributes.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- Now transformation functions are not called with `null` values any more
