### PR TITLE
Event on wrong day bug

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -52,12 +52,12 @@ export class RollCallSetupComponent implements OnInit {
         a.assignedTo === ""
     );
 
-    for (const activity of this.visibleActivities) {
-      const newEvent = await this.createEventForActivity(activity);
-      if (newEvent) {
-        this.existingEvents.push(newEvent);
-      }
-    }
+    const eventPromises = this.visibleActivities.map((activity) =>
+      this.createEventForActivity(activity)
+    );
+    let events = await Promise.all(eventPromises);
+    events = events.filter((event) => !!event);
+    this.existingEvents.push(...events);
   }
 
   async showMore() {

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -52,12 +52,12 @@ export class RollCallSetupComponent implements OnInit {
         a.assignedTo === ""
     );
 
-    const eventPromises = this.visibleActivities.map((activity) =>
-      this.createEventForActivity(activity)
-    );
-    let events = await Promise.all(eventPromises);
-    events = events.filter((event) => !!event);
-    this.existingEvents.push(...events);
+    for (const activity of this.visibleActivities) {
+      const newEvent = await this.createEventForActivity(activity);
+      if (newEvent) {
+        this.existingEvents.push(newEvent);
+      }
+    }
   }
 
   async showMore() {

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -298,4 +298,19 @@ describe("AttendanceService", () => {
     expect(event.children).toContain(duplicateChild.getId());
     expect(event.children).toContain(anotherRelation.childId);
   });
+
+  it("should load the events which took place today for datepicker date format", async () => {
+    const datePickerDate = new Date(
+      "Mon Apr 05 2021 00:00:00 GMT+0200 (Central European Summer Time)"
+    );
+    const sameDayEvent = EventNote.create(
+      new Date("2021-04-05"),
+      "Same Day Event"
+    );
+    sameDayEvent.category = defaultInteractionTypes.find((it) => it.isMeeting);
+    await entityMapper.save(sameDayEvent);
+    const events = await service.getEventsOnDate(datePickerDate);
+    expect(events).toHaveSize(1);
+    expect(events[0].subject).toBe(sameDayEvent.subject);
+  });
 });

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -299,7 +299,7 @@ describe("AttendanceService", () => {
     expect(event.children).toContain(anotherRelation.childId);
   });
 
-  it("should load the events which took place today for datepicker date format", async () => {
+  it("should load the events which took place on a date with datepicker format", async () => {
     const datePickerDate = new Date(
       "Mon Apr 05 2021 00:00:00 GMT+0200 (Central European Summer Time)"
     );

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -299,7 +299,7 @@ describe("AttendanceService", () => {
     expect(event.children).toContain(anotherRelation.childId);
   });
 
-  it("should load the events which took place today for datepicker date format", async () => {
+  it("should load the events for a date with date-picker format", async () => {
     const datePickerDate = new Date(
       new Date("2021-04-05").setHours(0, 0, 0, 0)
     );

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -301,7 +301,7 @@ describe("AttendanceService", () => {
 
   it("should load the events which took place on a date with datepicker format", async () => {
     const datePickerDate = new Date(
-      "Mon Apr 05 2021 00:00:00 GMT+0200 (Central European Summer Time)"
+      new Date("2021-04-05").setHours(0, 0, 0, 0)
     );
     const sameDayEvent = EventNote.create(
       new Date("2021-04-05"),

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -299,7 +299,7 @@ describe("AttendanceService", () => {
     expect(event.children).toContain(anotherRelation.childId);
   });
 
-  it("should load the events which took place on a date with datepicker format", async () => {
+  it("should load the events which took place today for datepicker date format", async () => {
     const datePickerDate = new Date(
       new Date("2021-04-05").setHours(0, 0, 0, 0)
     );

--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -107,8 +107,8 @@ export class AttendanceService {
     return await this.dbIndexing.queryIndexDocsRange(
       EventNote,
       "events_index/by_date",
-      startDate.toISOString().substr(0, 10),
-      endDate.toISOString().substr(0, 10)
+      moment(startDate).format("YYYY-MM-DD"),
+      moment(endDate).format("YYYY-MM-DD")
     );
   }
 


### PR DESCRIPTION
The datepicker creates dates like `Mon Apr 05 2021 00:00:00 GMT+0200 (Central European Summer Time)`. The problem is, that currently `.getISOString()` is used to get the date in format `YYYY-MM-DD` but this will transform the datepicker date to `2021-04-04` (the day before) because of the timezone. This results in the wrong events being displayed in the record attendance section.

### Visible/Frontend Changes
- Correct events are displayed in the `Recurring Activities`

### Architectural/Backend Changes
- Using `moment` to format the date correctly
