### PR TITLE
Removed deprecated async done combination

### DIFF
--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -77,14 +77,14 @@ describe("ChildrenService", () => {
 
   // TODO: test getAttendances
 
-  it("should find latest ChildSchoolRelation of a child", async (done: DoneFn) => {
+  it("should find latest ChildSchoolRelation of a child", async () => {
     const children = await service.getChildren().toPromise();
     const promises: Promise<any>[] = [];
     expect(children.length).toBeGreaterThan(0);
     children.forEach((child) =>
       promises.push(verifyLatestChildRelations(child, service))
     );
-    Promise.all(promises).then(() => done());
+    await Promise.all(promises);
   });
 
   it("should return ChildSchoolRelations of child in correct order", (done: DoneFn) => {

--- a/src/app/core/entity/entity-mapper.service.spec.ts
+++ b/src/app/core/entity/entity-mapper.service.spec.ts
@@ -179,24 +179,20 @@ describe("EntityMapperService", () => {
     entityMapper.remove(testEntity);
   });
 
-  it("publishes when an existing entity is updated", async (done) => {
+  it("publishes when an existing entity is updated", (done) => {
     receiveUpdatesAndTestTypeAndId(done, "update", existingEntity.entityId);
 
-    const loadedEntity = await entityMapper.load<Entity>(
-      Entity,
-      existingEntity.entityId
-    );
-    await entityMapper.save<Entity>(loadedEntity);
+    entityMapper
+      .load<Entity>(Entity, existingEntity.entityId)
+      .then((loadedEntity) => entityMapper.save<Entity>(loadedEntity));
   });
 
-  it("publishes when an existing entity is deleted", async (done) => {
+  it("publishes when an existing entity is deleted", (done) => {
     receiveUpdatesAndTestTypeAndId(done, "remove", existingEntity.entityId);
 
-    const loadedEntity = await entityMapper.load<Entity>(
-      Entity,
-      existingEntity.entityId
-    );
-    await entityMapper.remove<Entity>(loadedEntity);
+    entityMapper
+      .load<Entity>(Entity, existingEntity.entityId)
+      .then((loadedEntity) => entityMapper.remove<Entity>(loadedEntity));
   });
 
   it("publishes when a new entity is being saved", (done) => {


### PR DESCRIPTION
Recently Karma showed a deprecation note that `async` and `done()` should not be used in the same test and will not be supported in the future.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- changed tests where `async` and `done()` was used
