### PR TITLE
refactor: remove duplicate color assignment in notes-manager

### DIFF
--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.spec.ts
@@ -17,7 +17,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { of } from "rxjs";
 import { User } from "../../../core/user/user";
 import { Note } from "../model/note";
-import { WarningLevel, WarningLevelColor } from "../../warning-level";
 import { Angulartics2Module } from "angulartics2";
 import { NoteDetailsComponent } from "../note-details/note-details.component";
 import {
@@ -127,31 +126,6 @@ describe("NotesManagerComponent", () => {
     expect(component.config.filters[0].hasOwnProperty("options")).toBeTrue();
     expect(component.config.filters[1].hasOwnProperty("options")).toBeTrue();
     expect(component.config.filters[2].hasOwnProperty("options")).toBeFalse();
-  }));
-
-  it("should set the color for the notes", fakeAsync(() => {
-    const note1 = new Note("n1");
-    note1.warningLevel = WarningLevel.URGENT;
-    const note2 = new Note("n2");
-    const note3 = new Note("n3");
-    note3.category = { id: "TEST", label: "test", color: "CategoryColor" };
-    const note4 = new Note("n4");
-    note4.warningLevel = WarningLevel.WARNING;
-    const entityMapper = fixture.debugElement.injector.get(EntityMapperService);
-    spyOn(entityMapper, "loadType").and.returnValue(
-      Promise.resolve([note1, note2, note3, note4])
-    );
-    component.ngOnInit();
-    tick();
-    expect(component.notes.length).toEqual(4);
-    expect(component.notes[0]["color"]).toEqual(
-      WarningLevelColor(note1.warningLevel)
-    );
-    expect(component.notes[1]["color"]).toEqual("");
-    expect(component.notes[2]["color"]).toEqual("CategoryColor");
-    expect(component.notes[3]["color"]).toEqual(
-      WarningLevelColor(note4.warningLevel)
-    );
   }));
 
   it("should open the dialog when clicking details", () => {

--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
@@ -3,7 +3,7 @@ import { Note } from "../model/note";
 import { MediaObserver } from "@angular/flex-layout";
 import { NoteDetailsComponent } from "../note-details/note-details.component";
 import { ActivatedRoute } from "@angular/router";
-import { WarningLevel, WarningLevelColor } from "../../warning-level";
+import { WarningLevel } from "../../warning-level";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { FilterSelectionOption } from "../../../core/filter/filter-selection/filter-selection";
 import { SessionService } from "../../../core/session/session-service/session.service";
@@ -11,7 +11,6 @@ import { FormDialogService } from "../../../core/form-dialog/form-dialog.service
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { LoggingService } from "../../../core/logging/logging.service";
 import { EntityListComponent } from "../../../core/entity-components/entity-list/entity-list.component";
-import { tap } from "rxjs/operators";
 import { applyUpdate } from "../../../core/entity/entity-update";
 import { EntityListConfig } from "../../../core/entity-components/entity-list/EntityListConfig";
 
@@ -81,7 +80,6 @@ export class NotesManagerComponent implements OnInit {
       this.addPrebuiltFilters();
     });
     this.entityMapperService.loadType<Note>(Note).then((notes) => {
-      notes.forEach((note) => (note["color"] = this.getColor(note)));
       // This prevents edge-cases where updates are received
       // before this is
       this.notes = notes.concat(this.notes);
@@ -89,10 +87,7 @@ export class NotesManagerComponent implements OnInit {
 
     this.entityMapperService
       .receiveUpdates<Note>(Note)
-      .pipe(
-        untilDestroyed(this),
-        tap((note) => (note.entity["color"] = this.getColor(note.entity)))
-      )
+      .pipe(untilDestroyed(this))
       .subscribe((updatedNote) => {
         this.notes = applyUpdate(this.notes, updatedNote);
       });
@@ -140,17 +135,5 @@ export class NotesManagerComponent implements OnInit {
 
   showDetails(entity: Note) {
     this.formDialog.openDialog(NoteDetailsComponent, entity.copy());
-  }
-
-  private getColor(entity: Note): string {
-    if (entity.warningLevel === WarningLevel.URGENT) {
-      return WarningLevelColor(WarningLevel.URGENT);
-    }
-    if (entity.warningLevel === WarningLevel.WARNING) {
-      return WarningLevelColor(WarningLevel.WARNING);
-    }
-
-    const color = entity.category?.color;
-    return color ? color : "";
   }
 }

--- a/src/app/core/entity-components/entity-list/entity-list.component.html
+++ b/src/app/core/entity-components/entity-list/entity-list.component.html
@@ -129,7 +129,7 @@
     <tr
       mat-row
       *matRowDef="let entity; columns: columnsToDisplay"
-      [ngStyle]="{ 'background-color': entity.color }"
+      [ngStyle]="{ 'background-color': entity?.getColor() }"
       (click)="elementClick.emit(entity)"
       style="cursor: pointer"
       class="table-list-item"

--- a/src/app/core/entity-components/entity-list/entity-list.component.html
+++ b/src/app/core/entity-components/entity-list/entity-list.component.html
@@ -129,7 +129,7 @@
     <tr
       mat-row
       *matRowDef="let entity; columns: columnsToDisplay"
-      [ngStyle]="{ 'background-color': entity?.getColor() }"
+      [ngStyle]="{ 'background-color': entity.getColor() }"
       (click)="elementClick.emit(entity)"
       style="cursor: pointer"
       class="table-list-item"


### PR DESCRIPTION
assigning the correct color is already in-built in the `Entity` class, which `Note` correctly overrides to add the custom logic that was duplicated here.