### PR TITLE
Implemented default value from config

### DIFF
--- a/src/app/child-dev-project/aser/model/aser.spec.ts
+++ b/src/app/child-dev-project/aser/model/aser.spec.ts
@@ -19,11 +19,11 @@ import { Aser } from "./aser";
 import { WarningLevel } from "../../warning-level";
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
 
 describe("Aser", () => {
   const ENTITY_TYPE = "Aser";
-  const entitySchemaService = new EntitySchemaService();
+  const entitySchemaService = createTestingEntitySchemaService();
 
   beforeEach(waitForAsync(() => {}));
 

--- a/src/app/child-dev-project/attendance/model/attendance-day.spec.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-day.spec.ts
@@ -17,7 +17,10 @@
 
 import { AttendanceDay } from "./attendance-day";
 import { waitForAsync } from "@angular/core/testing";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 import { AttendanceMonth } from "./attendance-month";
 
 describe("AttendanceDay", () => {
@@ -25,7 +28,7 @@ describe("AttendanceDay", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
+++ b/src/app/child-dev-project/attendance/model/attendance-month.spec.ts
@@ -19,7 +19,10 @@ import { AttendanceMonth, daysInMonth } from "./attendance-month";
 import { WarningLevel } from "../../warning-level";
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 
 describe("AttendanceMonth", () => {
   const ENTITY_TYPE = "AttendanceMonth";
@@ -27,7 +30,7 @@ describe("AttendanceMonth", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/attendance/model/recurring-activity.spec.ts
+++ b/src/app/child-dev-project/attendance/model/recurring-activity.spec.ts
@@ -15,7 +15,10 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 import { waitForAsync } from "@angular/core/testing";
 import { RecurringActivity } from "./recurring-activity";
 import { Entity } from "../../../core/entity/entity";
@@ -43,7 +46,7 @@ describe("RecurringActivity", () => {
       ]);
       mockConfigService.getConfig.and.returnValue(testInteractionTypes);
 
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
       entitySchemaService.registerSchemaDatatype(
         new ConfigurableEnumDatatype(mockConfigService)
       );

--- a/src/app/child-dev-project/children/model/child.spec.ts
+++ b/src/app/child-dev-project/children/model/child.spec.ts
@@ -19,7 +19,10 @@ import { Child } from "./child";
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
 import { Gender } from "./Gender";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 import { LoadChildPhotoEntitySchemaDatatype } from "../child-photo-service/datatype-load-child-photo";
 
 describe("Child", () => {
@@ -28,7 +31,7 @@ describe("Child", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
       entitySchemaService.registerSchemaDatatype(
         new LoadChildPhotoEntitySchemaDatatype(null)
       );

--- a/src/app/child-dev-project/children/model/childSchoolRelation.spec.ts
+++ b/src/app/child-dev-project/children/model/childSchoolRelation.spec.ts
@@ -18,7 +18,10 @@
 import { waitForAsync } from "@angular/core/testing";
 import { ChildSchoolRelation } from "./childSchoolRelation";
 import { Entity } from "../../../core/entity/entity";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 import moment from "moment";
 
 describe("ChildSchoolRelation Entity", () => {
@@ -27,7 +30,7 @@ describe("ChildSchoolRelation Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/educational-material/model/educational-material.spec.ts
+++ b/src/app/child-dev-project/educational-material/model/educational-material.spec.ts
@@ -18,7 +18,10 @@
 import { waitForAsync } from "@angular/core/testing";
 import { EducationalMaterial } from "./educational-material";
 import { Entity } from "../../../core/entity/entity";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 
 describe("EducationalMaterial Entity", () => {
   const ENTITY_TYPE = "EducationalMaterial";
@@ -26,7 +29,7 @@ describe("EducationalMaterial Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/health-checkup/model/health-check.spec.ts
+++ b/src/app/child-dev-project/health-checkup/model/health-check.spec.ts
@@ -18,7 +18,10 @@
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
 import { HealthCheck } from "./health-check";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 
 describe("HealthCheck Entity", () => {
   const ENTITY_TYPE = "HealthCheck";
@@ -26,7 +29,7 @@ describe("HealthCheck Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/notes/model/note.spec.ts
+++ b/src/app/child-dev-project/notes/model/note.spec.ts
@@ -1,6 +1,9 @@
 import { Note } from "./note";
 import { WarningLevel, WarningLevelColor } from "../../warning-level";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
 import {
@@ -78,7 +81,7 @@ describe("Note", () => {
       ] = testInteractionTypes;
       testConfigs[ATTENDANCE_STATUS_CONFIG_ID] = testStatusTypes;
 
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
       entitySchemaService.registerSchemaDatatype(
         new ConfigurableEnumDatatype(createTestingConfigService(testConfigs))
       );

--- a/src/app/child-dev-project/progress-dashboard-widget/progress-dashboard/progress-dashboard-config.spec.ts
+++ b/src/app/child-dev-project/progress-dashboard-widget/progress-dashboard/progress-dashboard-config.spec.ts
@@ -18,7 +18,10 @@
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../../../core/entity/entity";
 import { ProgressDashboardConfig } from "./progress-dashboard-config";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 
 describe("ProgressDashboardConfig Entity", () => {
   const ENTITY_TYPE = "ProgressDashboardConfig";
@@ -26,7 +29,7 @@ describe("ProgressDashboardConfig Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/child-dev-project/schools/model/school.spec.ts
+++ b/src/app/child-dev-project/schools/model/school.spec.ts
@@ -18,7 +18,10 @@
 import { waitForAsync } from "@angular/core/testing";
 import { School } from "./school";
 import { Entity } from "../../../core/entity/entity";
-import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../../../core/entity/schema/entity-schema.service";
 
 describe("School Entity", () => {
   const ENTITY_TYPE = "School";
@@ -26,7 +29,7 @@ describe("School Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/core/entity/database-indexing/database-indexing.service.spec.ts
+++ b/src/app/core/entity/database-indexing/database-indexing.service.spec.ts
@@ -18,7 +18,7 @@
 import { DatabaseIndexingService } from "./database-indexing.service";
 import { Database } from "../../database/database";
 import { take } from "rxjs/operators";
-import { EntitySchemaService } from "../schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../schema/entity-schema.service";
 
 describe("DatabaseIndexingService", () => {
   let service: DatabaseIndexingService;
@@ -26,7 +26,10 @@ describe("DatabaseIndexingService", () => {
 
   beforeEach(() => {
     mockDb = jasmine.createSpyObj("mockDb", ["saveDatabaseIndex", "query"]);
-    service = new DatabaseIndexingService(mockDb, new EntitySchemaService());
+    service = new DatabaseIndexingService(
+      mockDb,
+      createTestingEntitySchemaService()
+    );
   });
 
   it("should pass through any query to the database", async () => {

--- a/src/app/core/entity/entity-mapper.service.spec.ts
+++ b/src/app/core/entity/entity-mapper.service.spec.ts
@@ -19,7 +19,7 @@ import { EntityMapperService } from "./entity-mapper.service";
 import { Entity } from "./entity";
 import { MockDatabase } from "../database/mock-database";
 import { Database } from "../database/database";
-import { EntitySchemaService } from "./schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "./schema/entity-schema.service";
 
 describe("EntityMapperService", () => {
   let entityMapper: EntityMapperService;
@@ -41,7 +41,7 @@ describe("EntityMapperService", () => {
     testDatabase = new MockDatabase();
     entityMapper = new EntityMapperService(
       testDatabase,
-      new EntitySchemaService()
+      createTestingEntitySchemaService()
     );
 
     return Promise.all([

--- a/src/app/core/entity/entity.spec.ts
+++ b/src/app/core/entity/entity.spec.ts
@@ -17,7 +17,10 @@
 
 import { Entity } from "./entity";
 import { waitForAsync } from "@angular/core/testing";
-import { EntitySchemaService } from "./schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "./schema/entity-schema.service";
 import { DatabaseField } from "./database-field.decorator";
 
 describe("Entity", () => {
@@ -25,7 +28,7 @@ describe("Entity", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-map.spec.ts
@@ -18,7 +18,10 @@
 import { Entity } from "../entity";
 import { waitForAsync } from "@angular/core/testing";
 import { DatabaseField } from "../database-field.decorator";
-import { EntitySchemaService } from "../schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../schema/entity-schema.service";
 
 describe("Schema data type: map", () => {
   class TestEntity extends Entity {
@@ -32,7 +35,7 @@ describe("Schema data type: map", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 

--- a/src/app/core/entity/schema/entity-schema-field.ts
+++ b/src/app/core/entity/schema/entity-schema-field.ts
@@ -52,6 +52,16 @@ export interface EntitySchemaField {
   defaultValue?: any;
 
   /**
+   * same as {@link defaultValue}, but the default value is defined in the app-config.
+   * In a case where both this value as well as the <code>defaultValue</code> are set,
+   * the "winning" default-value will be the one from the config.
+   * If the config also doesn't contain anything, the regular default-value will be used.
+   * <br>Note that the default value has to be present in the config as the field that it represents.
+   * It will undergo any mapping
+   */
+  defaultValueFromConfig?: string;
+
+  /**
    * (Optional) Assign any custom "extension" configuration you need for a specific datatype extension.
    *
    * You can pass any kind of value here to allow complex custom datytypes' transformations

--- a/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -27,7 +27,7 @@ import { MatListModule } from "@angular/material/list";
 import { RouterService } from "../../view/dynamic-routing/router.service";
 import { ConfigService } from "../../config/config.service";
 import { SessionService } from "../../session/session-service/session.service";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { BehaviorSubject } from "rxjs";
 import { Config } from "../../config/config";
 
@@ -45,7 +45,9 @@ describe("NavigationComponent", () => {
       mockConfigService = jasmine.createSpyObj(["getConfig"]);
       mockConfigService.getConfig.and.returnValue({ items: [] });
       mockConfigService.configUpdated = mockConfigUpdated;
-      sessionService = new MockSessionService(new EntitySchemaService());
+      sessionService = new MockSessionService(
+        createTestingEntitySchemaService()
+      );
 
       TestBed.configureTestingModule({
         imports: [

--- a/src/app/core/session/logged-in-guard/logged-in.guard.spec.ts
+++ b/src/app/core/session/logged-in-guard/logged-in.guard.spec.ts
@@ -20,13 +20,13 @@ import { TestBed, inject } from "@angular/core/testing";
 import { LoggedInGuard } from "./logged-in.guard";
 import { MockSessionService } from "../session-service/mock-session.service";
 import { SessionService } from "../session-service/session.service";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 
 describe("LoggedInGuard", () => {
   let sessionService: SessionService;
 
   beforeEach(() => {
-    sessionService = new MockSessionService(new EntitySchemaService());
+    sessionService = new MockSessionService(createTestingEntitySchemaService());
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/core/session/session-service/local-session.spec.ts
+++ b/src/app/core/session/session-service/local-session.spec.ts
@@ -15,7 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { AppConfig } from "../../app-config/app-config";
 import { LocalSession } from "./local-session";
 import { SessionType } from "../session-type";
@@ -33,7 +33,7 @@ describe("LocalSessionService", () => {
       },
     };
 
-    localSession = new LocalSession(new EntitySchemaService());
+    localSession = new LocalSession(createTestingEntitySchemaService());
   });
 
   it("should be created", async () => {

--- a/src/app/core/session/session-service/new-local-session.service.spec.ts
+++ b/src/app/core/session/session-service/new-local-session.service.spec.ts
@@ -15,7 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { NewLocalSessionService } from "./new-local-session.service";
 import { testSessionServiceImplementation } from "./session.service.spec";
 
@@ -23,7 +23,7 @@ describe("NewLocalSessionService", async () => {
   testSessionServiceImplementation(async () => {
     return new NewLocalSessionService(
       jasmine.createSpyObj(["warn"]),
-      new EntitySchemaService()
+      createTestingEntitySchemaService()
     );
   });
 });

--- a/src/app/core/session/session-service/synced-session.service.spec.ts
+++ b/src/app/core/session/session-service/synced-session.service.spec.ts
@@ -23,14 +23,14 @@ import { ConnectionState } from "../session-states/connection-state.enum";
 import { AppConfig } from "../../app-config/app-config";
 import { LocalSession } from "./local-session";
 import { RemoteSession } from "./remote-session";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { SessionType } from "../session-type";
 import { fakeAsync, tick } from "@angular/core/testing";
 
 describe("SyncedSessionService", () => {
   const snackBarMock = { openFromComponent: () => {} } as any;
   const alertService = new AlertService(snackBarMock);
-  const entitySchemaService = new EntitySchemaService();
+  const entitySchemaService = createTestingEntitySchemaService();
   let sessionService: SyncedSessionService;
 
   xdescribe("Integration Tests", () => {

--- a/src/app/core/sync-status/sync-status/sync-status.component.spec.ts
+++ b/src/app/core/sync-status/sync-status/sync-status.component.spec.ts
@@ -27,7 +27,7 @@ import { InitialSyncDialogComponent } from "./initial-sync-dialog.component";
 import { SessionService } from "../../session/session-service/session.service";
 import { SyncState } from "../../session/session-states/sync-state.enum";
 import { AlertsModule } from "../../alerts/alerts.module";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { DatabaseIndexingService } from "../../entity/database-indexing/database-indexing.service";
 import { BehaviorSubject } from "rxjs";
 import { take } from "rxjs/operators";
@@ -51,7 +51,9 @@ describe("SyncStatusComponent", () => {
 
   beforeEach(
     waitForAsync(() => {
-      sessionService = new MockSessionService(new EntitySchemaService());
+      sessionService = new MockSessionService(
+        createTestingEntitySchemaService()
+      );
       mockIndexingService = { indicesRegistered: new BehaviorSubject([]) };
 
       TestBed.configureTestingModule({

--- a/src/app/core/ui/ui/ui.component.spec.ts
+++ b/src/app/core/ui/ui/ui.component.spec.ts
@@ -42,7 +42,7 @@ import { MockSessionService } from "../../session/session-service/mock-session.s
 import { FlexLayoutModule } from "@angular/flex-layout";
 import { SwUpdate } from "@angular/service-worker";
 import { of } from "rxjs";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { createTestingEntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { EntitySubrecordModule } from "../../entity-components/entity-subrecord/entity-subrecord.module";
 import { ApplicationInitStatus } from "@angular/core";
 
@@ -53,7 +53,9 @@ describe("UiComponent", () => {
   beforeEach(
     waitForAsync(() => {
       const mockSwUpdate = { available: of(), checkForUpdate: () => {} };
-      const mockSession = new MockSessionService(new EntitySchemaService());
+      const mockSession = new MockSessionService(
+        createTestingEntitySchemaService()
+      );
       TestBed.configureTestingModule({
         declarations: [SearchComponent, PrimaryActionComponent, UiComponent],
         imports: [

--- a/src/app/core/user/user.spec.ts
+++ b/src/app/core/user/user.spec.ts
@@ -18,7 +18,10 @@
 import { User } from "./user";
 import { waitForAsync } from "@angular/core/testing";
 import { Entity } from "../entity/entity";
-import { EntitySchemaService } from "../entity/schema/entity-schema.service";
+import {
+  createTestingEntitySchemaService,
+  EntitySchemaService,
+} from "../entity/schema/entity-schema.service";
 
 describe("User", () => {
   const ENTITY_TYPE = "User";
@@ -26,7 +29,7 @@ describe("User", () => {
 
   beforeEach(
     waitForAsync(() => {
-      entitySchemaService = new EntitySchemaService();
+      entitySchemaService = createTestingEntitySchemaService();
     })
   );
 


### PR DESCRIPTION
### Architectural/Backend Changes
- [x] Allows an `EntitySchemaField` to get default-values from the config

This pull request itself does not change anything about the behavior of the app. Instead, it implements the feature to allow default values for an entity schema field to come from the config.

*Use-case*
In some cases, it might be useful to get a defined, default value that is not consistent throughout the app, but consistent for different configurations. Examples include units; for example size units (cm vs inches for some regions) or weight units (kg vs lbs).

