### PR TITLE
Improved performance for roll call

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -52,12 +52,12 @@ export class RollCallSetupComponent implements OnInit {
         a.assignedTo === ""
     );
 
-    for (const activity of this.visibleActivities) {
-      const newEvent = await this.createEventForActivity(activity);
-      if (newEvent) {
-        this.existingEvents.push(newEvent);
-      }
-    }
+    const eventPromises = this.visibleActivities.map((activity) =>
+      this.createEventForActivity(activity)
+    );
+    let events = await Promise.all(eventPromises);
+    events = events.filter((event) => !!event);
+    this.existingEvents.push(...events);
   }
 
   async showMore() {


### PR DESCRIPTION
This change will show all the activities at once instead of appearing one by one.
I made some performance comparisons and for my test setup, the previous method took around 4600ms and this method takes around 2600ms. The drawback is that the user does not get feedback about the loading of activities.

### Visible/Frontend Changes
- Activities on Roll Call load faster

### Architectural/Backend Changes
- Loading all activities at once instead of one by one
