### PR TITLE
Fix null value is passed to date-only transformation

### DIFF
--- a/src/app/child-dev-project/children/model/childSchoolRelation.spec.ts
+++ b/src/app/child-dev-project/children/model/childSchoolRelation.spec.ts
@@ -20,6 +20,7 @@ import { ChildSchoolRelation } from "./childSchoolRelation";
 import { Entity } from "../../../core/entity/entity";
 import { EntitySchemaService } from "../../../core/entity/schema/entity-schema.service";
 import moment from "moment";
+import { DatabaseField } from "../../../core/entity/database-field.decorator";
 
 describe("ChildSchoolRelation Entity", () => {
   const ENTITY_TYPE = "ChildSchoolRelation";
@@ -97,5 +98,20 @@ describe("ChildSchoolRelation Entity", () => {
     relation.start = moment().subtract(1, "week").toDate();
     relation.end = moment().add(1, "day").toDate();
     expect(relation.isActive()).toBeTrue();
+  });
+
+  it("should not fail on null values", () => {
+    class Test extends Entity {
+      @DatabaseField({ dataType: "date-only" }) normalDate: Date;
+      @DatabaseField({ dataType: "date-only" }) nullDate: Date;
+    }
+    const testObject = new Test();
+    testObject.normalDate = new Date();
+    testObject.nullDate = null;
+    const rawData = entitySchemaService.transformEntityToDatabaseFormat(
+      testObject
+    );
+    expect(rawData.normalDate).toBeDefined();
+    expect(rawData.nullDate).toBeUndefined();
   });
 });

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -30,6 +30,9 @@ export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
   name: "date-only",
 
   transformToDatabaseFormat: (value: Date) => {
+    if (!(value instanceof Date)) {
+      value = new Date(value);
+    }
     return (
       value.getFullYear() +
       "-" +

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -31,7 +31,7 @@ export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
 
   transformToDatabaseFormat: (value: Date) => {
     if (!(value instanceof Date)) {
-      value = new Date(value);
+      return undefined;
     }
     return (
       value.getFullYear() +


### PR DESCRIPTION
When removing a existing date in the `Schools History` section, the application will throw an error and the change will not be saved. This is due to the datepicker setting a null value as the date and the transformation not checking if the value is null.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- Saving undefined if a null value is set to a date-only property
