### PR TITLE
Fix not existing children in roll call

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
@@ -1,5 +1,5 @@
 <!-- Individual Student's Page -->
-<div *ngIf="!isFinished()">
+<div *ngIf="!isFinished() && entries?.length > 0">
   <app-child-block [entity]="entries[currentIndex].child"></app-child-block>
 
   <div

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.html
@@ -1,6 +1,6 @@
 <!-- Individual Student's Page -->
 <div *ngIf="!isFinished()">
-  <app-child-block [entityId]="entries[currentIndex].childId"></app-child-block>
+  <app-child-block [entity]="entries[currentIndex].child"></app-child-block>
 
   <div
     fxLayout="column"
@@ -10,7 +10,7 @@
     <div
       class="group-select-option"
       *ngFor="let option of availableStatus"
-      (click)="markAttendance(entries[currentIndex].childId, option)"
+      (click)="markAttendance(entries[currentIndex].attendance, option)"
       [ngClass]="
         entries[currentIndex].attendance.status.id === option.id
           ? option.style

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -1,4 +1,10 @@
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from "@angular/core/testing";
 
 import { RollCallComponent } from "./roll-call.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -6,6 +12,9 @@ import { Note } from "../../../notes/model/note";
 import { By } from "@angular/platform-browser";
 import { ConfigService } from "../../../../core/config/config.service";
 import { ConfigurableEnumConfig } from "../../../../core/configurable-enum/configurable-enum.interface";
+import { Child } from "../../../children/model/child";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+import { LoggingService } from "../../../../core/logging/logging.service";
 
 describe("RollCallComponent", () => {
   let component: RollCallComponent;
@@ -13,6 +22,8 @@ describe("RollCallComponent", () => {
 
   const testEvent = Note.create(new Date());
   let mockConfigService: jasmine.SpyObj<ConfigService>;
+  let mockEntityMapper: jasmine.SpyObj<EntityMapperService>;
+  let mockLoggingService: jasmine.SpyObj<LoggingService>;
 
   beforeEach(
     waitForAsync(() => {
@@ -20,11 +31,18 @@ describe("RollCallComponent", () => {
         "getConfig",
       ]);
       mockConfigService.getConfig.and.returnValue([]);
+      mockEntityMapper = jasmine.createSpyObj(["load"]);
+      mockEntityMapper.load.and.resolveTo();
+      mockLoggingService = jasmine.createSpyObj(["warn"]);
 
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
         declarations: [RollCallComponent],
-        providers: [{ provide: ConfigService, useValue: mockConfigService }],
+        providers: [
+          { provide: ConfigService, useValue: mockConfigService },
+          { provide: EntityMapperService, useValue: mockEntityMapper },
+          { provide: LoggingService, useValue: mockLoggingService },
+        ],
       }).compileComponents();
     })
   );
@@ -69,4 +87,24 @@ describe("RollCallComponent", () => {
     );
     expect(statusOptions.length).toBe(testStatusEnumConfig.length);
   });
+
+  it("should not record attendance if childId does not exist", fakeAsync(() => {
+    const existingChild = new Child("existingChild");
+    const noteWithNonExistingChild = new Note();
+    noteWithNonExistingChild.addChild(existingChild.getId());
+    noteWithNonExistingChild.addChild("notExistingChild");
+    component.eventEntity = noteWithNonExistingChild;
+
+    mockEntityMapper.load.and.callFake((con, id) =>
+      id === existingChild.getId()
+        ? Promise.resolve(existingChild as any)
+        : Promise.reject()
+    );
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.entries.map((e) => e.child)).toEqual([existingChild]);
+    expect(mockLoggingService.warn).toHaveBeenCalled();
+  }));
 });

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -148,4 +148,27 @@ describe("RollCallComponent", () => {
     );
     flush();
   }));
+
+  it("should mark roll call as done when all existing children are finished", fakeAsync(() => {
+    const existingChild1 = new Child("existingChild1");
+    const existingChild2 = new Child("existingChild2");
+    const note = new Note();
+    note.addChild(existingChild1.getId());
+    note.addChild("notExistingChild");
+    note.addChild(existingChild2.getId());
+    mockEntityMapper.load.and.returnValues(
+      Promise.resolve(existingChild2),
+      Promise.reject(),
+      Promise.resolve(existingChild1)
+    );
+    spyOn(component.complete, "emit");
+    component.eventEntity = note;
+    component.ngOnInit();
+    tick();
+
+    component.goToNextParticipant();
+    component.goToNextParticipant();
+
+    expect(component.complete.emit).toHaveBeenCalledWith(note);
+  }));
 });

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -66,7 +66,7 @@ export class RollCallComponent implements OnInit {
         child = await this.entityMapper.load(Child, childId);
       } catch (e) {
         this.loggingService.warn(
-          "Could not child " +
+          "Could not find child " +
             childId +
             " for event " +
             this.eventEntity.getId()

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -107,6 +107,6 @@ export class RollCallComponent implements OnInit {
   }
 
   isFinished(): boolean {
-    return this.currentIndex >= this.entries.length;
+    return this.currentIndex >= this.entries?.length;
   }
 }

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -8,6 +8,9 @@ import { Note } from "../../../notes/model/note";
 import { EventAttendance } from "../../model/event-attendance";
 import { ConfigService } from "../../../../core/config/config.service";
 import { ConfigurableEnumConfig } from "../../../../core/configurable-enum/configurable-enum.interface";
+import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
+import { Child } from "../../../children/model/child";
+import { LoggingService } from "../../../../core/logging/logging.service";
 
 /**
  * Displays the participants of the given event one by one to mark attendance status.
@@ -46,17 +49,35 @@ export class RollCallComponent implements OnInit {
   /** options available for selecting an attendance status */
   availableStatus: AttendanceStatusType[];
 
-  entries: { childId: string; attendance: EventAttendance }[];
+  entries: { child: Child; attendance: EventAttendance }[];
 
-  constructor(private configService: ConfigService) {}
+  constructor(
+    private configService: ConfigService,
+    private entityMapper: EntityMapperService,
+    private loggingService: LoggingService
+  ) {}
 
   async ngOnInit() {
+    this.entries = [];
     this.loadAttendanceStatusTypes();
-
-    this.entries = this.eventEntity.children.map((childId) => ({
-      childId: childId,
-      attendance: this.eventEntity.getAttendance(childId),
-    }));
+    for (const childId of this.eventEntity.children) {
+      let child;
+      try {
+        child = await this.entityMapper.load(Child, childId);
+      } catch (e) {
+        this.loggingService.warn(
+          "Could not child " +
+            childId +
+            " for event " +
+            this.eventEntity.getId()
+        );
+        continue;
+      }
+      this.entries.push({
+        child: child,
+        attendance: this.eventEntity.getAttendance(childId),
+      });
+    }
     this.goToNextParticipant(0);
   }
 
@@ -66,8 +87,8 @@ export class RollCallComponent implements OnInit {
     >(ATTENDANCE_STATUS_CONFIG_ID);
   }
 
-  markAttendance(childId: string, status: AttendanceStatusType) {
-    this.eventEntity.getAttendance(childId).status = status;
+  markAttendance(attendance: EventAttendance, status: AttendanceStatusType) {
+    attendance.status = status;
 
     // automatically move to next participant after a short delay giving the user visual feedback on the selected status
     setTimeout(() => this.goToNextParticipant(), 750);

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -107,6 +107,6 @@ export class RollCallComponent implements OnInit {
   }
 
   isFinished(): boolean {
-    return this.currentIndex >= this.eventEntity.children.length;
+    return this.currentIndex >= this.entries.length;
   }
 }


### PR DESCRIPTION
When a child is deleted but still part of a recurring activity or event, the roll call is in a inconsistent state.
This bug is now fixed.

### Visible/Frontend Changes
- [x] only existing children are shown in the roll call

### Architectural/Backend Changes
- [x] Loading all children initially and skipping not existing ones
