### PR TITLE
Prebuilt filter fix

### DIFF
--- a/src/app/child-dev-project/children/children-list/children-list.component.ts
+++ b/src/app/child-dev-project/children/children-list/children-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ViewChild } from "@angular/core";
 import { Child } from "../model/child";
 import { ActivatedRoute, Router } from "@angular/router";
 import { UntilDestroy } from "@ngneat/until-destroy";
@@ -11,6 +11,7 @@ import {
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { School } from "../../schools/model/school";
 import { LoggingService } from "../../../core/logging/logging.service";
+import { EntityListComponent } from "../../../core/entity-components/entity-list/entity-list.component";
 
 @UntilDestroy()
 @Component({
@@ -29,6 +30,8 @@ export class ChildrenListComponent implements OnInit {
   childrenList: Child[] = [];
   listConfig: EntityListConfig;
   childConstructor = Child;
+  @ViewChild(EntityListComponent)
+  entityListComponent: EntityListComponent<Child>;
 
   constructor(
     private childrenService: ChildrenService,
@@ -53,41 +56,45 @@ export class ChildrenListComponent implements OnInit {
     this.router.navigate([path, route]);
   }
 
-  private addPrebuiltFilters() {
-    this.listConfig.filters
-      .filter((filter) => filter.type === "prebuilt")
-      .forEach(async (filter) => {
-        switch (filter.id) {
-          case "school": {
-            (filter as PrebuiltFilterConfig<Child>).options = await this.buildSchoolFilter();
-            (filter as PrebuiltFilterConfig<Child>).default = "";
-            return;
-          }
-          default: {
-            this.log.warn(
-              "[ChildrenListComponent] No filter options available for prebuilt filter: " +
-                filter.id
-            );
-            (filter as PrebuiltFilterConfig<Child>).options = [];
-          }
+  private async addPrebuiltFilters() {
+    for (const filter of this.listConfig.filters.filter(
+      (filter) => filter.type === "prebuilt"
+    )) {
+      switch (filter.id) {
+        case "school": {
+          (filter as PrebuiltFilterConfig<Child>).options = await this.buildSchoolFilter();
+          (filter as PrebuiltFilterConfig<Child>).default = "";
+          break;
         }
-      });
+        default: {
+          this.log.warn(
+            "[ChildrenListComponent] No filter options available for prebuilt filter: " +
+              filter.id
+          );
+          (filter as PrebuiltFilterConfig<Child>).options = [];
+        }
+      }
+    }
+    // Triggering the initialization of the filter selections
+    this.entityListComponent.ngOnChanges({
+      entityList: null,
+    });
   }
 
   private async buildSchoolFilter(): Promise<FilterSelectionOption<Child>[]> {
     const schools: School[] = await this.entityMapper.loadType(School);
-    const filters: FilterSelectionOption<Child>[] = [
+    const options: FilterSelectionOption<Child>[] = [
       { key: "", label: "All", filterFun: () => true },
     ];
     schools
       .sort((s1, s2) => s1.name.localeCompare(s2.name))
       .forEach((school) =>
-        filters.push({
+        options.push({
           key: school.getId(),
           label: school.name,
           filterFun: (c) => c.schoolId === school.getId(),
         })
       );
-    return filters;
+    return options;
   }
 }

--- a/src/app/child-dev-project/children/children-list/children-list.component.ts
+++ b/src/app/child-dev-project/children/children-list/children-list.component.ts
@@ -57,21 +57,21 @@ export class ChildrenListComponent implements OnInit {
   }
 
   private async addPrebuiltFilters() {
-    for (const filter of this.listConfig.filters.filter(
+    for (const prebuiltFilter of this.listConfig.filters.filter(
       (filter) => filter.type === "prebuilt"
     )) {
-      switch (filter.id) {
+      switch (prebuiltFilter.id) {
         case "school": {
-          (filter as PrebuiltFilterConfig<Child>).options = await this.buildSchoolFilter();
-          (filter as PrebuiltFilterConfig<Child>).default = "";
+          (prebuiltFilter as PrebuiltFilterConfig<Child>).options = await this.buildSchoolFilter();
+          (prebuiltFilter as PrebuiltFilterConfig<Child>).default = "";
           break;
         }
         default: {
           this.log.warn(
             "[ChildrenListComponent] No filter options available for prebuilt filter: " +
-              filter.id
+              prebuiltFilter.id
           );
-          (filter as PrebuiltFilterConfig<Child>).options = [];
+          (prebuiltFilter as PrebuiltFilterConfig<Child>).options = [];
         }
       }
     }

--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
@@ -131,26 +131,26 @@ export class NotesManagerComponent implements OnInit {
   }
 
   private addPrebuiltFilters() {
-    for (const filter of this.config.filters.filter(
+    for (const prebuiltFilter of this.config.filters.filter(
       (filter) => filter.type === "prebuilt"
     )) {
-      switch (filter.id) {
+      switch (prebuiltFilter.id) {
         case "status": {
-          filter["options"] = this.statusFS;
-          filter["default"] = "";
+          prebuiltFilter["options"] = this.statusFS;
+          prebuiltFilter["default"] = "";
           break;
         }
         case "date": {
-          filter["options"] = this.dateFS;
-          filter["default"] = "current-week";
+          prebuiltFilter["options"] = this.dateFS;
+          prebuiltFilter["default"] = "current-week";
           break;
         }
         default: {
           this.log.warn(
             "[NoteManagerComponent] No filter options available for prebuilt filter: " +
-              filter.id
+              prebuiltFilter.id
           );
-          filter["options"] = [];
+          prebuiltFilter["options"] = [];
         }
       }
     }

--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.ts
@@ -131,29 +131,29 @@ export class NotesManagerComponent implements OnInit {
   }
 
   private addPrebuiltFilters() {
-    this.config.filters.forEach((f) => {
-      if (f.type === "prebuilt") {
-        switch (f.id) {
-          case "status": {
-            f["options"] = this.statusFS;
-            f["default"] = "";
-            return;
-          }
-          case "date": {
-            f["options"] = this.dateFS;
-            f["default"] = "current-week";
-            return;
-          }
-          default: {
-            this.log.warn(
-              "[NoteManagerComponent] No filter options available for prebuilt filter: " +
-                f.id
-            );
-            return (f["options"] = []);
-          }
+    for (const filter of this.config.filters.filter(
+      (filter) => filter.type === "prebuilt"
+    )) {
+      switch (filter.id) {
+        case "status": {
+          filter["options"] = this.statusFS;
+          filter["default"] = "";
+          break;
+        }
+        case "date": {
+          filter["options"] = this.dateFS;
+          filter["default"] = "current-week";
+          break;
+        }
+        default: {
+          this.log.warn(
+            "[NoteManagerComponent] No filter options available for prebuilt filter: " +
+              filter.id
+          );
+          filter["options"] = [];
         }
       }
-    });
+    }
   }
 
   private getPreviousSunday(weeksBack: number) {

--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -77,9 +77,11 @@ export class AdminComponent implements OnInit {
     this.startDownload(csv, "text/csv", "export.csv");
   }
 
-  downloadConfigClick() {
-    const jsonString = this.configService.exportConfig();
-    this.startDownload(jsonString, "text/json", "config.json");
+  async downloadConfigClick() {
+    const configString = await this.configService.exportConfig(
+      this.entityMapper
+    );
+    this.startDownload(configString, "text/json", "config.json");
   }
 
   async uploadConfigFile(file: Blob) {

--- a/src/app/core/config/config-fix.ts
+++ b/src/app/core/config/config-fix.ts
@@ -3,7 +3,7 @@ import { defaultInteractionTypes } from "./default-config/default-interaction-ty
 import { ColumnDescriptionInputType } from "../entity-components/entity-subrecord/column-description-input-type.enum";
 
 // prettier-ignore
-export const defaultConfig = {
+export const defaultJsonConfig = {
   "navigationMenu": {
     "items": [
       {

--- a/src/app/core/config/config.service.spec.ts
+++ b/src/app/core/config/config.service.spec.ts
@@ -2,6 +2,7 @@ import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { ConfigService } from "./config.service";
 import { EntityMapperService } from "../entity/entity-mapper.service";
 import { Config } from "./config";
+import { defaultJsonConfig } from "./config-fix";
 
 describe("ConfigService", () => {
   let service: ConfigService;
@@ -30,13 +31,15 @@ describe("ConfigService", () => {
   }));
 
   it("should use the default config when none is loaded", fakeAsync(() => {
-    const configBefore = service.getAllConfigs("");
+    const defaultConfig = Object.keys(defaultJsonConfig).map((key) => {
+      defaultJsonConfig[key]._id = key;
+      return defaultJsonConfig[key];
+    });
     entityMapper.load.and.rejectWith("No config found");
     service.loadConfig(entityMapper);
     tick();
     const configAfter = service.getAllConfigs("");
-    expect(configAfter).toEqual(configBefore);
-    expect(configAfter).not.toBeNull();
+    expect(configAfter).toEqual(defaultConfig);
   }));
 
   it("should correctly return prefixed fields", fakeAsync(() => {

--- a/src/app/core/config/config.service.spec.ts
+++ b/src/app/core/config/config.service.spec.ts
@@ -31,7 +31,7 @@ describe("ConfigService", () => {
 
   it("should use the default config when none is loaded", fakeAsync(() => {
     const configBefore = service.getAllConfigs("");
-    entityMapper.load.and.throwError("No config found");
+    entityMapper.load.and.rejectWith("No config found");
     service.loadConfig(entityMapper);
     tick();
     const configAfter = service.getAllConfigs("");
@@ -88,16 +88,14 @@ describe("ConfigService", () => {
     );
   }));
 
-  it("should create export config string", fakeAsync(() => {
+  it("should create export config string", async () => {
     const config = new Config();
     config.data = { first: "foo", second: "bar" };
     const expected = JSON.stringify(config.data);
     entityMapper.load.and.returnValue(Promise.resolve(config));
-    service.loadConfig(entityMapper);
-    tick();
-    const result = service.exportConfig();
+    const result = await service.exportConfig(entityMapper);
     expect(result).toEqual(expected);
-  }));
+  });
 
   it("should emit new value", fakeAsync(() => {
     spyOn(service.configUpdated, "next");

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -52,7 +52,7 @@ export class ConfigService {
   public async exportConfig(
     entityMapper: EntityMapperService
   ): Promise<string> {
-    let config = await this.getConfigOrDefault(entityMapper);
+    const config = await this.getConfigOrDefault(entityMapper);
     return JSON.stringify(config.data);
   }
 

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -3,7 +3,7 @@ import { EntityMapperService } from "../entity/entity-mapper.service";
 import { Config } from "./config";
 import { LoggingService } from "../logging/logging.service";
 import { BehaviorSubject } from "rxjs";
-import { defaultConfig } from "./config-fix";
+import { defaultJsonConfig } from "./config-fix";
 
 @Injectable({
   providedIn: "root",
@@ -18,16 +18,13 @@ export class ConfigService {
   public configUpdated: BehaviorSubject<Config>;
 
   constructor(@Optional() private loggingService: LoggingService) {
-    this.config.data = defaultConfig;
+    this.config.data = defaultJsonConfig;
     this.configUpdated = new BehaviorSubject<Config>(this.config);
   }
 
   public async loadConfig(entityMapper: EntityMapperService): Promise<Config> {
-    const newConfig = await this.getConfigOrDefault(entityMapper);
-    if (newConfig !== this.config) {
-      this.config = newConfig;
-      this.configUpdated.next(this.config);
-    }
+    this.config = await this.getConfigOrDefault(entityMapper);
+    this.configUpdated.next(this.config);
     return this.config;
   }
 
@@ -38,7 +35,9 @@ export class ConfigService {
       this.loggingService.info(
         "No configuration found in the database, using default one"
       );
-      return this.config;
+      const defaultConfig = new Config(ConfigService.CONFIG_KEY);
+      defaultConfig.data = defaultJsonConfig;
+      return defaultConfig;
     });
   }
 


### PR DESCRIPTION
The prebuilt filters directly work on the config and currently this changes are also exported when downloading the config. This has some bad sideeffects when using this config again. Instead the exported config is now directly taken from the database.

### Visible/Frontend Changes
- [x] Prebuilt schools-filter is always present (not only after second entry of the page #761

### Architectural/Backend Changes
- [x] Loading config from database before exporting
- [x] Retrigger `ngOnChanges` of entity list component after schools-filter is built
