### PR TITLE
Remove falsy attributes from DB

### DIFF
--- a/src/app/core/entity-components/entity-details/form/form.component.ts
+++ b/src/app/core/entity-components/entity-details/form/form.component.ts
@@ -128,8 +128,10 @@ export class FormComponent implements OnInitDynamicComponent, OnInit {
   private assignFormValuesToEntity(entity: Entity, form: FormGroup) {
     Object.keys(form.controls).forEach((key) => {
       const value = form.get(key).value;
-      if (value !== null) {
+      if (value || value === 0) {
         entity[key] = value;
+      } else {
+        delete entity[key];
       }
     });
   }

--- a/src/app/core/entity-components/entity-details/form/form.component.ts
+++ b/src/app/core/entity-components/entity-details/form/form.component.ts
@@ -128,11 +128,7 @@ export class FormComponent implements OnInitDynamicComponent, OnInit {
   private assignFormValuesToEntity(entity: Entity, form: FormGroup) {
     Object.keys(form.controls).forEach((key) => {
       const value = form.get(key).value;
-      if (value || value === 0) {
-        entity[key] = value;
-      } else {
-        delete entity[key];
-      }
+      entity[key] = value;
     });
   }
 

--- a/src/app/core/entity/schema-datatypes/datatype-array.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-array.ts
@@ -40,13 +40,13 @@ export const arrayEntitySchemaDatatype: EntitySchemaDatatype = {
     schemaService: EntitySchemaService,
     parent
   ) => {
-    if (!Array.isArray(value)) {
+    if (!Array.isArray(value)  || !value.length) {
       console.warn(
-        `property to be transformed with "array" EntitySchema is not an array`,
+        `property to be transformed with "array" EntitySchema is not an array or empty`,
         value,
         parent
       );
-      return value;
+      return undefined;
     }
 
     const arrayElementDatatype: EntitySchemaDatatype = schemaService.getDatatypeOrDefault(

--- a/src/app/core/entity/schema-datatypes/datatype-number.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-number.ts
@@ -33,6 +33,14 @@ export const numberEntitySchemaDatatype: EntitySchemaDatatype = {
   name: "number",
 
   transformToDatabaseFormat: (value) => {
+    // check if falsy except for 0
+    if(value !== 0 && !value){
+      console.warn(
+        `property to be transformed with "number" EntitySchema is falsy`,
+        value
+      );
+      return undefined;
+    }
     return Number(value);
   },
 

--- a/src/app/core/entity/schema-datatypes/datatype-string.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-string.ts
@@ -33,7 +33,16 @@ export const stringEntitySchemaDatatype: EntitySchemaDatatype = {
   name: "string",
 
   transformToDatabaseFormat: (value) => {
-    return String(value);
+    const retString: String = String(value);
+    // don't save empty strings
+    if (retString){
+      return retString;
+    }
+    console.warn(
+      `property to be transformed with "string" EntitySchema is empty`,
+      value
+    );
+    return undefined;
   },
 
   transformToObjectFormat: (value) => {


### PR DESCRIPTION
see issue: #818

I suspect, that the null check was originally implemented to stop the creation of empty/null valued properties in the DB-json-files. As far as I can tell the easiest way to accomplish this would be by checking if a given value is falsy (keep 0 in case this makes sense somewhere) and remove them in that case.

### Architectural/Backend Changes
- [x] remove checks from form component
- [x] add checks to entity schema