### PR TITLE
Implement entity block component

### DIFF
--- a/src/app/core/entity-components/entity-block/entity-block.component.html
+++ b/src/app/core/entity-components/entity-block/entity-block.component.html
@@ -1,0 +1,14 @@
+<ng-container
+  *ngIf="blockName"
+  [appDynamicComponent]="{
+      component: blockName,
+      config: {
+        entity: entity,
+        linkDisabled: true,
+        tooltipDisabled: true
+      }
+    }">
+</ng-container>
+<ng-container *ngIf="!blockName">
+  {{entity["name"] || entity.getId()}}
+</ng-container>

--- a/src/app/core/entity-components/entity-block/entity-block.component.spec.ts
+++ b/src/app/core/entity-components/entity-block/entity-block.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { EntityBlockComponent } from "./entity-block.component";
+import { Entity } from "../../entity/entity";
+
+describe("EntityBlockComponent", () => {
+  let component: EntityBlockComponent<any>;
+  let fixture: ComponentFixture<EntityBlockComponent<any>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EntityBlockComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EntityBlockComponent);
+    component = fixture.componentInstance;
+    component.entity = new Entity();
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/entity-components/entity-block/entity-block.component.ts
+++ b/src/app/core/entity-components/entity-block/entity-block.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { Entity } from "../../entity/entity";
+import { DYNAMIC_COMPONENTS_MAP } from "../../view/dynamic-components-map";
+
+@Component({
+  selector: "app-entity-block",
+  templateUrl: "./entity-block.component.html",
+})
+export class EntityBlockComponent<E extends Entity> implements OnInit {
+  blockName?: string;
+  @Input() entity: E;
+
+  ngOnInit() {
+    const type = this.entity.getType();
+    if (DYNAMIC_COMPONENTS_MAP.has(type + "Block")) {
+      this.blockName = type + "Block";
+    } else {
+      this.blockName = undefined;
+    }
+  }
+}

--- a/src/app/core/entity-components/entity-block/entity-block.module.ts
+++ b/src/app/core/entity-components/entity-block/entity-block.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { EntityBlockComponent } from "./entity-block.component";
+import { ViewModule } from "../../view/view.module";
+
+@NgModule({
+  declarations: [EntityBlockComponent],
+  imports: [CommonModule, ViewModule],
+  exports: [EntityBlockComponent],
+})
+export class EntityBlockModule {}

--- a/src/app/core/entity-components/entity-select/entity-select.module.ts
+++ b/src/app/core/entity-components/entity-select/entity-select.module.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatChipsModule } from "@angular/material/chips";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
-import { MatInputModule } from "@angular/material/input";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { ViewModule } from "../../view/view.module";
+import { EntityBlockModule } from "../entity-block/entity-block.module";
 
 @NgModule({
   declarations: [EntitySelectComponent],
@@ -17,9 +17,9 @@ import { ViewModule } from "../../view/view.module";
     MatChipsModule,
     ReactiveFormsModule,
     MatAutocompleteModule,
-    MatInputModule,
     MatTooltipModule,
     ViewModule,
+    EntityBlockModule,
   ],
   exports: [EntitySelectComponent],
 })

--- a/src/app/core/entity-components/entity-select/entity-select/entity-select.component.html
+++ b/src/app/core/entity-components/entity-select/entity-select/entity-select.component.html
@@ -22,7 +22,7 @@
         *ngFor="let entity of selection_"
         class="chip">
         <!-- This is going to be replaced with the dynamic content -->
-        <ng-container *ngTemplateOutlet="block; context: {entity: entity}"></ng-container>
+        <app-entity-block [entity]="entity"></app-entity-block>
         <div
           *ngIf="removable && !disabled"
           matTooltip="remove"
@@ -40,27 +40,7 @@
     <ng-content select="mat-option"></ng-content>
     <mat-option *ngFor='let res of filteredEntities | async' [value]="res">
       <!-- This is going to be replaced with the dynamic content -->
-      <ng-container *ngTemplateOutlet="block; context: {entity: res}"></ng-container>
+      <app-entity-block [entity]="res"></app-entity-block>
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>
-
-<ng-template
-  #block
-  let-entity="entity"
->
-  <ng-container
-    *ngIf="entityBlockComponent"
-    [appDynamicComponent]="{
-      component: entityBlockComponent,
-      config: {
-        entity: entity,
-        linkDisabled: true,
-        tooltipDisabled: true
-      }
-    }">
-  </ng-container>
-  <ng-container *ngIf="!entityBlockComponent">
-    {{entity["name"] || entity.getId()}}
-  </ng-container>
-</ng-template>

--- a/src/app/core/entity-components/entity-select/entity-select/entity-select.component.spec.ts
+++ b/src/app/core/entity-components/entity-select/entity-select/entity-select.component.spec.ts
@@ -13,6 +13,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Entity } from "../../../entity/entity";
 import { ReactiveFormsModule } from "@angular/forms";
 import { mockEntityMapper } from "../../../entity/mock-entity-mapper-service";
+import { Subscription } from "rxjs";
 
 class TestEntity extends Entity {
   static create(name: string): TestEntity {
@@ -30,9 +31,10 @@ class TestEntity extends Entity {
 describe("EntitySelectComponent", () => {
   let component: EntitySelectComponent<any>;
   let fixture: ComponentFixture<EntitySelectComponent<any>>;
+  let subscription: Subscription;
 
-  const mockEntitiesA: Entity[] = ["Abc", "Bcd", "Abd", "Aba"].map((s) =>
-    TestEntity.create(s)
+  const mockEntitiesA: Entity[] = ["Abc", "Bcd", "Abd", "Aba"].map(
+    TestEntity.create
   );
   const mockEntitiesB: Entity[] = [new Entity(), new Entity()];
 
@@ -79,9 +81,10 @@ describe("EntitySelectComponent", () => {
   }));
 
   it("should suggest all entities after an initial load", (done) => {
-    component.filteredEntities.subscribe((next) => {
+    subscription = component.filteredEntities.subscribe((next) => {
       expect(next.length).toBe(mockEntitiesA.length);
       done();
+      subscription.unsubscribe();
     });
     component.setEntityType(TestEntity);
     fixture.detectChanges();
@@ -155,11 +158,12 @@ describe("EntitySelectComponent", () => {
     component.loading.next(false);
     let iterations = 0;
     let expectedLength = 4;
-    component.filteredEntities.subscribe((next) => {
+    subscription = component.filteredEntities.subscribe((next) => {
       iterations++;
       expect(next.length).toEqual(expectedLength);
       if (iterations === 4) {
         done();
+        subscription.unsubscribe();
       }
     });
     expectedLength = 4;


### PR DESCRIPTION
### Architectural/Backend Changes
- [x] Implement a standalone generic `EntityBlockComponent`

The `EntityBlockComponent` looks like a registered block component when one is available (currently only the school block or child block). If none is available, the block component will display the entity's name, or its ID, if it has no name.
