### PR TITLE
Datatype photo does not throw error

### DIFF
--- a/src/app/child-dev-project/children/child-photo-service/datatype-photo.spec.ts
+++ b/src/app/child-dev-project/children/child-photo-service/datatype-photo.spec.ts
@@ -91,4 +91,15 @@ describe("dataType photo", () => {
 
     expect(result.photo).toBeUndefined();
   });
+
+  it("should not throw an error if deprecated value is null", () => {
+    const oldChild = {
+      _id: "oldChild",
+      photoFile: null,
+    };
+
+    expect(() =>
+      entitySchemaService.loadDataIntoEntity(new Child(), oldChild)
+    ).not.toThrowError();
+  });
 });

--- a/src/app/child-dev-project/children/child-photo-service/datatype-photo.ts
+++ b/src/app/child-dev-project/children/child-photo-service/datatype-photo.ts
@@ -47,7 +47,7 @@ export class PhotoDatatype implements EntitySchemaDatatype {
   ): Photo {
     // Using of old photoFile values
     if (
-      parent.hasOwnProperty("photoFile") &&
+      typeof parent["photoFile"] === "string" &&
       parent["photoFile"].trim() !== ""
     ) {
       value = parent["photoFile"];


### PR DESCRIPTION
Old photo format currently throws an error if the old value is `null`.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Photo datatype checks for correct instance before applying trim function
