### PR TITLE
Fix paginator all issue

### DIFF
--- a/src/app/core/entity-components/entity-list/entity-list.stories.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.stories.ts
@@ -14,6 +14,9 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ConfigurableEnumModule } from "../../configurable-enum/configurable-enum.module";
 import { DatePipe } from "@angular/common";
 
+const user = new User();
+user.paginatorSettingsPageSize["ageprojectNumbernamegendercenterstatus"] = 13;
+
 export default {
   title: "Core/Entity List",
   component: EntityListComponent,
@@ -30,10 +33,13 @@ export default {
         DatePipe,
         {
           provide: SessionService,
-          useValue: { getCurrentUser: () => new User() },
+          useValue: { getCurrentUser: () => user },
         },
         { provide: BackupService, useValue: {} },
-        { provide: EntityMapperService, useValue: {} },
+        {
+          provide: EntityMapperService,
+          useValue: { save: () => Promise.resolve() },
+        },
       ],
     }),
   ],
@@ -46,7 +52,7 @@ const Template: Story<EntityListComponent<Child>> = (
   props: args,
 });
 
-const children = new DemoChildGenerator({ count: 20 }).generateEntities();
+const children = new DemoChildGenerator({ count: 25 }).generateEntities();
 
 export const Primary = Template.bind({});
 Primary.args = {

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.stories.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.stories.ts
@@ -20,6 +20,8 @@ import { ChildrenService } from "../../../../child-dev-project/children/children
 import { of } from "rxjs";
 import * as faker from "faker";
 import { EntityPermissionsService } from "../../../permissions/entity-permissions.service";
+import { SessionService } from "../../../session/session-service/session.service";
+import { User } from "../../../user/user";
 
 const configService = new ConfigService();
 const schemaService = new EntitySchemaService();
@@ -74,6 +76,10 @@ export default {
         {
           provide: EntityPermissionsService,
           useValue: { userIsPermitted: () => true },
+        },
+        {
+          provide: SessionService,
+          useValue: { getCurrentUser: () => new User() },
         },
       ],
     }),

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.html
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.html
@@ -7,9 +7,9 @@
   >
   <mat-paginator
     (page)="onPaginateChange($event)"
-    [pageSize]="paginatorPageSize"
-    [pageIndex]="paginatorPageIndex"
-    [pageSizeOptions]="paginatorPageSizeOptions"
+    [pageSize]="pageSize"
+    [pageIndex]="currentPageIndex"
+    [pageSizeOptions]="sizeOptions"
     [showFirstLastButtons]="true"
   ></mat-paginator>
 </mat-toolbar>

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.html
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.html
@@ -1,6 +1,5 @@
 <mat-toolbar>
   <mat-slide-toggle
-    [disabled]="allToggleDisabled"
     [checked]="showingAll"
     (change)="changeAllToggle()"
     >Show All</mat-slide-toggle
@@ -9,7 +8,7 @@
     (page)="onPaginateChange($event)"
     [pageSize]="pageSize"
     [pageIndex]="currentPageIndex"
-    [pageSizeOptions]="sizeOptions"
+    [pageSizeOptions]="pageSizeOptions"
     [showFirstLastButtons]="true"
   ></mat-paginator>
 </mat-toolbar>

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
@@ -60,14 +60,6 @@ describe("ListPaginatorComponent", () => {
     expect(component.user.paginatorSettingsPageIndex["table-id"]).toEqual(1);
   }));
 
-  it("should disable the all toggle when too little entries are available", () => {
-    component.dataSource.data = new Array(2);
-
-    component.ngOnChanges({ dataSource: null });
-
-    expect(component.allToggleDisabled).toBeTrue();
-  });
-
   it("should reset the pagination size when clicking the all toggle twice", () => {
     component.pageSize = 20;
     component.dataSource.data = new Array(100);
@@ -97,7 +89,7 @@ describe("ListPaginatorComponent", () => {
 
     component.changeAllToggle();
 
-    const po = component.sizeOptions;
+    const po = component.pageSizeOptions;
     expect(component.pageSize).toBe(po[po.length - 2]);
   }));
 });

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
@@ -69,35 +69,35 @@ describe("ListPaginatorComponent", () => {
   });
 
   it("should reset the pagination size when clicking the all toggle twice", () => {
-    component.paginatorPageSize = 20;
+    component.pageSize = 20;
     component.dataSource.data = new Array(100);
     component.showingAll = false;
     component.ngOnChanges({ dataSource: null });
 
     component.changeAllToggle();
 
-    expect(component.paginatorPageSize).toBe(100);
+    expect(component.pageSize).toBe(100);
     expect(component.showingAll).toBeTrue();
 
     component.changeAllToggle();
 
-    expect(component.paginatorPageSize).toBe(20);
+    expect(component.pageSize).toBe(20);
     expect(component.showingAll).toBeFalse();
   });
 
   it("should toggle back to second biggest size if the previous size is too big", fakeAsync(() => {
     component.dataSource.data = new Array(100);
     component.paginator._changePageSize(100);
-    component.paginatorPageSizeBeforeToggle = 200;
+    component.sizeBeforeToggling = 200;
 
     component.ngOnChanges({ dataSource: null });
 
     expect(component.showingAll).toBeTrue();
-    expect(component.paginatorPageSize).toBe(100);
+    expect(component.pageSize).toBe(100);
 
     component.changeAllToggle();
 
-    const po = component.paginatorPageSizeOptions;
-    expect(component.paginatorPageSize).toBe(po[po.length - 2]);
+    const po = component.sizeOptions;
+    expect(component.pageSize).toBe(po[po.length - 2]);
   }));
 });

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
@@ -76,20 +76,4 @@ describe("ListPaginatorComponent", () => {
     expect(component.pageSize).toBe(20);
     expect(component.showingAll).toBeFalse();
   });
-
-  it("should toggle back to second biggest size if the previous size is too big", fakeAsync(() => {
-    component.dataSource.data = new Array(100);
-    component.paginator._changePageSize(100);
-    component.sizeBeforeToggling = 200;
-
-    component.ngOnChanges({ dataSource: null });
-
-    expect(component.showingAll).toBeTrue();
-    expect(component.pageSize).toBe(100);
-
-    component.changeAllToggle();
-
-    const po = component.pageSizeOptions;
-    expect(component.pageSize).toBe(po[po.length - 2]);
-  }));
 });

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
@@ -53,7 +53,8 @@ export class ListPaginatorComponent<E extends Entity>
         .connect()
         .pipe(
           untilDestroyed(this),
-          filter((updatedDataSource) => this.showingAll && !!this.paginator), // why?
+          // When showingAll is false, nothing needs to be done -> filtered out
+          filter((updatedDataSource) => this.showingAll && !!this.paginator),
           filter((updatedDataSource) => updatedDataSource.length > 0)
         )
         .subscribe(() => {


### PR DESCRIPTION
see issue: #868 

The paginator now works as follows:

- The all button is always enabled
- Enabling the all button will keep the all option enabled for all views on this table
- The other options (10, 20 50) are always available and call always be selected and will be maintained throughout the views of a table
- The all option is not automatically enabled once a page size is selected that is bigger than the amount of items.

### Visible/Frontend Changes
- [x] The paginator defaults to bigger page-sizes if available, instead of keeping the smallest one that was visited

### Architectural/Backend Changes
--
