### PR TITLE
Fixing "Include inactive" not being set correctly

### DIFF
--- a/src/app/child-dev-project/notes/note-details/note-details.component.html
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.html
@@ -131,9 +131,10 @@
         label="Participants"
         placeholder="Add participant ...">
         <!-- Header for autocomplete -->
-        <mat-option (click)="toggleIncludeInactiveChildren()">
+        <mat-option>
           <mat-checkbox
             labelPosition="before"
+            (change)="toggleIncludeInactiveChildren()"
             [checked]="includeInactiveChildren">
             Include Inactive Children
           </mat-checkbox>


### PR DESCRIPTION
see issue: #892

In the HTML of note-details.component.html instead of `(clicked)` we should rather use `(change)` and we should do this in the `mat-checkbox` and not the `mat-option` tag.
