### PR TITLE
ci: new gitflow-like release process

### DIFF
--- a/.github/workflows/tagged-commit.yml
+++ b/.github/workflows/tagged-commit.yml
@@ -29,3 +29,5 @@ jobs:
           tags: aamdigital/ndb-server:${{ env.TAG }}
           cache-from: type=registry,ref=aamdigital/ndb-server:cache
           cache-to: type=registry,ref=aamdigital/ndb-server:cache,mode=max
+          build-args: |
+            APP_VERSION=${{ env.TAG }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,9 @@
 {
   "tagFormat": "${version}",
+  "branches": [
+    "official-release",
+    {"name": "master", "prerelease": true}
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
@@ -29,10 +33,6 @@
     }],
     ["@semantic-release/npm", {
       "npmPublish": false
-    }],
-    ["@semantic-release/git", {
-      "assets": ["src/environments/environment.ts", "src/environments/environment.prod.ts", "package.json", "package-lock.json"],
-      "message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {
       "assets": []

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,6 +14,10 @@ RUN npm ci --no-progress
 RUN $(npm bin)/ng version
 
 COPY . .
+
+ARG APP_VERSION="UNKNOWN"
+RUN sed -i "s/appVersion: \".*\"/appVersion: \"$APP_VERSION\"/g" src/environments/environment*.ts
+
 RUN npm run build-localized
 
 # When set to true, tests are run and coverage will be uploaded to CodeClimate

--- a/build/README.md
+++ b/build/README.md
@@ -6,3 +6,14 @@ Builds are triggered through GitHub Actions CI (see /.github/workflows).
 
 The deployable server (nginx) image is published to [Docker Hub](https://hub.docker.com/r/aamdigital/ndb-server)
 for every official (tagged) build.
+
+## How to build & publish a new image
+You can simply create a new git tag and the CI setup will build and publish a docker image for that version.
+
+## How does the official release process work?
+We use [semantic-release](https://github.com/semantic-release/semantic-release) to automatically create new versions.
+Our process roughly follows the [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) process,
+where our development branch is `master` and our "main" branch holding stable releases is `official-release`. 
+1. Commits on the `master` branch are analyzed and a pre-release version is automatically tagged.
+2. To create an "official" release, merge the `master` into the `official-release` branch. This will trigger a regular new version.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ndb-core",
-  "version": "2.54.0",
+  "version": "0.0.0",
   "license": "GPL-3.0",
   "scripts": {
     "ng": "ng",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -25,7 +25,7 @@
  */
 export const environment = {
   production: true,
-  appVersion: "2.54.0", // replaced automatically by semantic-release
+  appVersion: "0.0.0", // replaced automatically during docker build
   repositoryId: "Aam-Digital/ndb-core",
   remoteLoggingDsn:
     "https://bd6aba79ca514d35bb06a4b4e0c2a21e@sentry.io/1242399",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -25,7 +25,7 @@
  */
 export const environment = {
   production: false,
-  appVersion: "2.54.0", // replaced automatically by semantic-release
+  appVersion: "0.0.0", // replaced automatically during docker build
   repositoryId: "Aam-Digital/ndb-core",
   remoteLoggingDsn: undefined, // only set for production mode in environment.prod.ts
 };


### PR DESCRIPTION
switching to a new release process where stable releases are explicitly released onto the `official-release` branch