### PR TITLE
fix: better logging for document update conflicts in database

### DIFF
--- a/src/app/core/database/pouch-database.ts
+++ b/src/app/core/database/pouch-database.ts
@@ -242,6 +242,7 @@ export class PouchDatabase extends Database {
       return this.put(newObject);
     } else {
       existingError.message = existingError.message + " (unable to resolve)";
+      existingError.affectedDocument = newObject._id;
       throw existingError;
     }
   }


### PR DESCRIPTION
add logging information in case of document update conflicts to make sense of sentry errors