### PR TITLE
Fix: Filter selections are considered when reloading the page

### DIFF
--- a/src/app/child-dev-project/attendance/activity-list/activity-list.component.spec.ts
+++ b/src/app/child-dev-project/attendance/activity-list/activity-list.component.spec.ts
@@ -35,6 +35,7 @@ describe("ActivityListComponent", () => {
             useValue: {
               data: of({ config: mockConfig }),
               queryParams: of({}),
+              snapshot: { queryParams: {} },
             },
           },
         ],

--- a/src/app/child-dev-project/children/children-list/children-list.component.spec.ts
+++ b/src/app/child-dev-project/children/children-list/children-list.component.spec.ts
@@ -77,6 +77,7 @@ describe("ChildrenListComponent", () => {
   const routeMock = {
     data: of({ config: routeData }),
     queryParams: of({}),
+    snapshot: { queryParams: {} },
   };
   const mockChildrenService: jasmine.SpyObj<ChildrenService> = jasmine.createSpyObj(
     ["getChildren"]

--- a/src/app/child-dev-project/notes/notes-manager/notes-manager.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-manager/notes-manager.component.spec.ts
@@ -77,6 +77,7 @@ describe("NotesManagerComponent", () => {
   const routeMock = {
     data: new BehaviorSubject({ config: routeData }),
     queryParams: of({}),
+    snapshot: { queryParams: {} },
   };
 
   const testInteractionTypes: InteractionType[] = [

--- a/src/app/child-dev-project/schools/schools-list/schools-list.component.spec.ts
+++ b/src/app/child-dev-project/schools/schools-list/schools-list.component.spec.ts
@@ -40,6 +40,7 @@ describe("SchoolsListComponent", () => {
   const routeMock = {
     data: of({ config: routeData }),
     queryParams: of({}),
+    snapshot: { queryParams: {} },
   };
 
   beforeEach(

--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -217,7 +217,6 @@ export class EntityListComponent<T extends Entity>
       this.entityConstructor,
       this.allEntities
     );
-    this.loadUrlParams();
   }
 
   private displayColumnGroup(columnGroupName: string) {

--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -115,6 +115,7 @@ export class EntityListComponent<T extends Entity>
       await this.initFilterSelections();
       this.applyFilterSelections();
     }
+    this.loadUrlParams();
   }
 
   private addColumnsFromColumnGroups() {
@@ -152,7 +153,8 @@ export class EntityListComponent<T extends Entity>
     }
   }
 
-  private loadUrlParams(params: Params) {
+  private loadUrlParams(parameters?: Params) {
+    const params = parameters || this.activatedRoute.snapshot.queryParams;
     if (params["view"]) {
       this.displayColumnGroup(params["view"]);
     }
@@ -215,7 +217,7 @@ export class EntityListComponent<T extends Entity>
       this.entityConstructor,
       this.allEntities
     );
-    this.loadUrlParams(this.activatedRoute.snapshot.queryParams);
+    this.loadUrlParams();
   }
 
   private displayColumnGroup(columnGroupName: string) {

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.spec.ts
@@ -42,7 +42,7 @@ describe("EntitySubrecordComponent", () => {
       TestBed.configureTestingModule({
         imports: [
           EntitySubrecordModule,
-          RouterTestingModule,
+          RouterTestingModule.withRoutes([]),
           MatNativeDateModule,
           NoopAnimationsModule,
           MockSessionModule.withState(),

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
@@ -16,10 +16,12 @@ import { mockEntityMapper } from "../../../entity/mock-entity-mapper-service";
 import { User } from "../../../user/user";
 import { Child } from "../../../../child-dev-project/children/model/child";
 import { FlexLayoutModule } from "@angular/flex-layout";
+import { Subscription } from "rxjs";
 
 describe("EntitySelectComponent", () => {
   let component: EntitySelectComponent<any>;
   let fixture: ComponentFixture<EntitySelectComponent<any>>;
+  let subscription: Subscription = null;
 
   const testUsers: Entity[] = ["Abc", "Bcd", "Abd", "Aba"].map((s) => {
     const user = new User();
@@ -54,6 +56,10 @@ describe("EntitySelectComponent", () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    subscription?.unsubscribe();
+  });
+
   it("should create", () => {
     expect(component).toBeTruthy();
   });
@@ -72,9 +78,8 @@ describe("EntitySelectComponent", () => {
   }));
 
   it("should suggest all entities after an initial load", (done) => {
-    const subscription = component.filteredEntities.subscribe((next) => {
+    subscription = component.filteredEntities.subscribe((next) => {
       expect(next.length).toBe(testUsers.length);
-      subscription.unsubscribe();
       done();
     });
     component.entityType = User.ENTITY_TYPE;
@@ -143,16 +148,14 @@ describe("EntitySelectComponent", () => {
   });
 
   it("autocompletes with the default accessor", (done) => {
-    // TODO sometimes this tests fails with `ObjectUnsubscribedError: object unsubscribed`
     component.allEntities = testUsers;
     component.loading.next(false);
     let iterations = 0;
     let expectedLength = 4;
-    const subscription = component.filteredEntities.subscribe((next) => {
+    subscription = component.filteredEntities.subscribe((next) => {
       iterations++;
       expect(next.length).toEqual(expectedLength);
       if (iterations === 4) {
-        subscription.unsubscribe();
         done();
       }
     });
@@ -171,14 +174,13 @@ describe("EntitySelectComponent", () => {
     const selectedUser = testUsers[1];
     let iteration = 0;
 
-    const subscription = component.filteredEntities.subscribe(
+    subscription = component.filteredEntities.subscribe(
       (autocompleteEntities) => {
         iteration++;
         if (iteration === 1) {
           expect(autocompleteEntities).not.toContain(selectedUser);
         } else if (iteration === 2) {
           expect(autocompleteEntities).toContain(selectedUser);
-          subscription.unsubscribe();
           done();
         }
       }


### PR DESCRIPTION
See issue #896

**Backend changes / Fix**
When the filters are initialized, the activated route is being used to initialize any filter selections.
Additionally, the (filtered) data is only shown after the filter are properly initialized