### PR TITLE
Empty entries 972

### DIFF
--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -405,16 +405,11 @@ export class ChildrenService {
     return this.dbIndexing.createIndex(designDoc);
   }
 
-  getEducationalMaterialsOfChild(
+  async getEducationalMaterialsOfChild(
     childId: string
-  ): Observable<EducationalMaterial[]> {
-    return from(
-      this.entityMapper
-        .loadType<EducationalMaterial>(EducationalMaterial)
-        .then((loadedEntities) => {
-          return loadedEntities.filter((o) => o.child === childId);
-        })
-    );
+  ): Promise<EducationalMaterial[]> {
+    const allMaterials = await this.entityMapper.loadType(EducationalMaterial);
+    return allMaterials.filter((mat) => mat.child === childId);
   }
 
   /**

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.html
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.html
@@ -1,7 +1,7 @@
 <app-entity-subrecord
   [records]="records"
   [columns]="columns"
-  [newRecordFactory]="generateNewRecordFactory"
+  [newRecordFactory]="newRecordFactory"
 >
 </app-entity-subrecord>
 

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.html
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.html
@@ -1,7 +1,7 @@
 <app-entity-subrecord
   [records]="records"
   [columns]="columns"
-  [newRecordFactory]="generateNewRecordFactory()"
+  [newRecordFactory]="generateNewRecordFactory"
 >
 </app-entity-subrecord>
 

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
@@ -8,12 +8,22 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { of } from "rxjs";
 import { ChildrenModule } from "../../children/children.module";
 import { MockSessionModule } from "../../../core/session/mock-session.module";
+import { EducationalMaterial } from "../model/educational-material";
+import { ConfigurableEnumValue } from "../../../core/configurable-enum/configurable-enum.interface";
 
 describe("EducationalMaterialComponent", () => {
   let component: EducationalMaterialComponent;
   let fixture: ComponentFixture<EducationalMaterialComponent>;
   let mockChildrenService: jasmine.SpyObj<ChildrenService>;
   const child = new Child("22");
+  const PENCIL: ConfigurableEnumValue = {
+    id: "pencil",
+    label: "Pencil",
+  };
+  const RULER: ConfigurableEnumValue = {
+    id: "ruler",
+    label: "Ruler",
+  };
 
   beforeEach(
     waitForAsync(() => {
@@ -47,5 +57,59 @@ describe("EducationalMaterialComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("produces an empty summary when there are no records", () => {
+    component.records = [];
+    component.updateSummary();
+    expect(component.summary).toHaveSize(0);
+  });
+
+  function setRecordsAndGenerateSummary(
+    ...records: Partial<EducationalMaterial>[]
+  ) {
+    component.records = records.map(EducationalMaterial.create);
+    component.updateSummary();
+  }
+
+  it("produces a singleton summary when there is a single record", () => {
+    setRecordsAndGenerateSummary({ materialType: PENCIL, materialAmount: 1 });
+    expect(component.summary).toEqual(`${PENCIL.label}: 1`);
+  });
+
+  it("produces a summary of all records when they are all different", () => {
+    setRecordsAndGenerateSummary(
+      { materialType: PENCIL, materialAmount: 2 },
+      { materialType: RULER, materialAmount: 1 }
+    );
+    expect(component.summary).toEqual(`${PENCIL.label}: 2, ${RULER.label}: 1`);
+  });
+
+  it("produces a summary of all records when there are duplicates", () => {
+    setRecordsAndGenerateSummary(
+      { materialType: PENCIL, materialAmount: 1 },
+      { materialType: RULER, materialAmount: 1 },
+      { materialType: PENCIL, materialAmount: 3 }
+    );
+    expect(component.summary).toEqual(`${PENCIL.label}: 4, ${RULER.label}: 1`);
+  });
+
+  it("loads all education data associated with a child and updates the summary", async () => {
+    const educationalData = [
+      { materialType: PENCIL, materialAmount: 1 },
+      { materialType: RULER, materialAmount: 2 },
+    ].map(EducationalMaterial.create);
+    mockChildrenService.getEducationalMaterialsOfChild.and.resolveTo(
+      educationalData
+    );
+    await component.loadData("22");
+    expect(component.summary).toEqual(`${PENCIL.label}: 1, ${RULER.label}: 2`);
+    expect(component.records).toEqual(educationalData);
+  });
+
+  it("associates a new record with the current child", () => {
+    component.child = child;
+    const newRecord = component.generateNewRecordFactory();
+    expect(newRecord.child).toBe(child.getId());
   });
 });

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
@@ -22,9 +22,7 @@ describe("EducationalMaterialComponent", () => {
         "getEducationalMaterialsOfChild",
       ]);
       mockChildrenService.getChild.and.returnValue(of(child));
-      mockChildrenService.getEducationalMaterialsOfChild.and.returnValue(
-        of([])
-      );
+      mockChildrenService.getEducationalMaterialsOfChild.and.resolveTo([]);
       TestBed.configureTestingModule({
         declarations: [EducationalMaterialComponent],
         imports: [

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
@@ -105,7 +105,7 @@ describe("EducationalMaterialComponent", () => {
 
   it("associates a new record with the current child", () => {
     component.child = child;
-    const newRecord = component.generateNewRecordFactory();
+    const newRecord = component.newRecordFactory();
     expect(newRecord.child).toBe(child.getId());
   });
 });

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.spec.ts
@@ -5,7 +5,6 @@ import { ChildrenService } from "../../children/children.service";
 import { Child } from "../../children/model/child";
 import { DatePipe } from "@angular/common";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { of } from "rxjs";
 import { ChildrenModule } from "../../children/children.module";
 import { MockSessionModule } from "../../../core/session/mock-session.module";
 import { EducationalMaterial } from "../model/educational-material";
@@ -28,11 +27,8 @@ describe("EducationalMaterialComponent", () => {
   beforeEach(
     waitForAsync(() => {
       mockChildrenService = jasmine.createSpyObj([
-        "getChild",
         "getEducationalMaterialsOfChild",
       ]);
-      mockChildrenService.getChild.and.returnValue(of(child));
-      mockChildrenService.getEducationalMaterialsOfChild.and.resolveTo([]);
       TestBed.configureTestingModule({
         declarations: [EducationalMaterialComponent],
         imports: [

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -6,6 +6,10 @@ import { OnInitDynamicComponent } from "../../../core/view/dynamic-components/on
 import { PanelConfig } from "../../../core/entity-components/entity-details/EntityDetailsConfig";
 import { FormFieldConfig } from "../../../core/entity-components/entity-form/entity-form/FormConfig";
 
+/**
+ * Displays educational materials of a child, such as a pencil, rulers, e.t.c
+ * as well as a summary
+ */
 @Component({
   selector: "app-educational-material",
   templateUrl: "./educational-material.component.html",
@@ -40,30 +44,33 @@ export class EducationalMaterialComponent
     await this.loadData(this.child.getId());
   }
 
+  /**
+   * Loads the data for a given child and updates the summary
+   * @param id The id of the child to load the data for
+   */
   async loadData(id: string) {
-    const results = await this.childrenService.getEducationalMaterialsOfChild(
+    this.records = await this.childrenService.getEducationalMaterialsOfChild(
       id
-    );
-    this.records = results.sort(
-      (a, b) =>
-        (b.date ? b.date.valueOf() : 0) - (a.date ? a.date.valueOf() : 0)
     );
     this.updateSummary();
   }
 
-  generateNewRecordFactory() {
-    return () => {
-      const newAtt = new EducationalMaterial(Date.now().toString());
+  generateNewRecordFactory = () => {
+    const newAtt = new EducationalMaterial(Date.now().toString());
 
-      // use last entered date as default, otherwise today's date
-      newAtt.date = this.records.length > 0 ? this.records[0].date : new Date();
-      newAtt.child = this.child.getId();
-      newAtt.materialAmount = 1;
+    // use last entered date as default, otherwise today's date
+    newAtt.date = this.records.length > 0 ? this.records[0].date : new Date();
+    newAtt.child = this.child.getId();
+    newAtt.materialAmount = 1;
 
-      return newAtt;
-    };
-  }
+    return newAtt;
+  };
 
+  /**
+   * update the summary or generate a new one.
+   * The summary contains no duplicates and is in a
+   * human-readable format
+   */
   updateSummary() {
     const summary = new Map<string, number>();
     this.records.forEach((m) => {
@@ -72,11 +79,8 @@ export class EducationalMaterialComponent
         : 0;
       summary.set(m.materialType.label, previousValue + m.materialAmount);
     });
-
-    let summaryText = "";
-    summary.forEach(
-      (v, k) => (summaryText = summaryText + k + ": " + v + ", ")
-    );
-    this.summary = summaryText;
+    this.summary = [...summary]
+      .map(([key, value]) => key + ": " + value)
+      .join(", ");
   }
 }

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -20,8 +20,8 @@ export class EducationalMaterialComponent
 
   columns: FormFieldConfig[] = [
     { id: "date", visibleFrom: "xs" },
-    { id: "materialType", visibleFrom: "xs" },
-    { id: "materialAmount", visibleFrom: "md" },
+    { id: "materialType", visibleFrom: "xs", required: true },
+    { id: "materialAmount", visibleFrom: "md", required: true },
     { id: "description", visibleFrom: "md" },
   ];
 
@@ -62,6 +62,7 @@ export class EducationalMaterialComponent
       // use last entered date as default, otherwise today's date
       newAtt.date = this.records.length > 0 ? this.records[0].date : new Date();
       newAtt.child = this.child.getId();
+      newAtt.materialAmount = 1;
 
       return newAtt;
     };

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -22,8 +22,8 @@ export class EducationalMaterialComponent
 
   columns: FormFieldConfig[] = [
     { id: "date", visibleFrom: "xs" },
-    { id: "materialType", visibleFrom: "xs", required: true },
-    { id: "materialAmount", visibleFrom: "md", required: true },
+    { id: "materialType", visibleFrom: "xs" },
+    { id: "materialAmount", visibleFrom: "md" },
     { id: "description", visibleFrom: "md" },
   ];
 

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -55,7 +55,7 @@ export class EducationalMaterialComponent
     this.updateSummary();
   }
 
-  generateNewRecordFactory = () => {
+  newRecordFactory = () => {
     const newAtt = new EducationalMaterial(Date.now().toString());
 
     // use last entered date as default, otherwise today's date

--- a/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
+++ b/src/app/child-dev-project/educational-material/educational-material-component/educational-material.component.ts
@@ -1,13 +1,11 @@
 import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { EducationalMaterial } from "../model/educational-material";
 import { ChildrenService } from "../../children/children.service";
-import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Child } from "../../children/model/child";
 import { OnInitDynamicComponent } from "../../../core/view/dynamic-components/on-init-dynamic-component.interface";
 import { PanelConfig } from "../../../core/entity-components/entity-details/EntityDetailsConfig";
 import { FormFieldConfig } from "../../../core/entity-components/entity-form/entity-form/FormConfig";
 
-@UntilDestroy()
 @Component({
   selector: "app-educational-material",
   templateUrl: "./educational-material.component.html",
@@ -15,7 +13,7 @@ import { FormFieldConfig } from "../../../core/entity-components/entity-form/ent
 export class EducationalMaterialComponent
   implements OnChanges, OnInitDynamicComponent {
   @Input() child: Child;
-  records = new Array<EducationalMaterial>();
+  records: EducationalMaterial[] = [];
   summary = "";
 
   columns: FormFieldConfig[] = [
@@ -27,32 +25,30 @@ export class EducationalMaterialComponent
 
   constructor(private childrenService: ChildrenService) {}
 
-  ngOnChanges(changes: SimpleChanges): void {
+  async ngOnChanges(changes: SimpleChanges): Promise<void> {
     if (changes.hasOwnProperty("child")) {
-      this.loadData(this.child.getId());
+      await this.loadData(this.child.getId());
     }
   }
 
-  onInitFromDynamicConfig(config: PanelConfig) {
+  async onInitFromDynamicConfig(config: PanelConfig) {
     if (config?.config?.columns) {
       this.columns = config.config.columns;
     }
 
     this.child = config.entity as Child;
-    this.loadData(this.child.getId());
+    await this.loadData(this.child.getId());
   }
 
-  loadData(id: string) {
-    this.childrenService
-      .getEducationalMaterialsOfChild(id)
-      .pipe(untilDestroyed(this))
-      .subscribe((results) => {
-        this.records = results.sort(
-          (a, b) =>
-            (b.date ? b.date.valueOf() : 0) - (a.date ? a.date.valueOf() : 0)
-        );
-        this.updateSummary();
-      });
+  async loadData(id: string) {
+    const results = await this.childrenService.getEducationalMaterialsOfChild(
+      id
+    );
+    this.records = results.sort(
+      (a, b) =>
+        (b.date ? b.date.valueOf() : 0) - (a.date ? a.date.valueOf() : 0)
+    );
+    this.updateSummary();
   }
 
   generateNewRecordFactory() {

--- a/src/app/child-dev-project/educational-material/model/educational-material.ts
+++ b/src/app/child-dev-project/educational-material/model/educational-material.ts
@@ -22,6 +22,12 @@ import { ConfigurableEnumValue } from "../../../core/configurable-enum/configura
 
 @DatabaseEntity("EducationalMaterial")
 export class EducationalMaterial extends Entity {
+  static create(params: Partial<EducationalMaterial>): EducationalMaterial {
+    const educationalMaterial = new EducationalMaterial();
+    Object.assign(educationalMaterial, params);
+    return educationalMaterial;
+  }
+
   @DatabaseField() child: string; // id of Child entity
   @DatabaseField({
     label: $localize`:Date on which the material has been borrowed:Date`,

--- a/src/app/child-dev-project/educational-material/model/educational-material.ts
+++ b/src/app/child-dev-project/educational-material/model/educational-material.ts
@@ -23,9 +23,7 @@ import { ConfigurableEnumValue } from "../../../core/configurable-enum/configura
 @DatabaseEntity("EducationalMaterial")
 export class EducationalMaterial extends Entity {
   static create(params: Partial<EducationalMaterial>): EducationalMaterial {
-    const educationalMaterial = new EducationalMaterial();
-    Object.assign(educationalMaterial, params);
-    return educationalMaterial;
+    return Object.assign(new EducationalMaterial(), params);
   }
 
   @DatabaseField() child: string; // id of Child entity
@@ -37,10 +35,12 @@ export class EducationalMaterial extends Entity {
     label: $localize`:The material which has been borrowed:Material`,
     dataType: "configurable-enum",
     innerDataType: "materials",
+    required: true,
   })
   materialType: ConfigurableEnumValue;
   @DatabaseField({
     label: $localize`:The amount of the material which has been borrowed:Amount`,
+    required: true,
   })
   materialAmount: number;
   @DatabaseField({

--- a/src/app/child-dev-project/health-checkup/health-checkup-component/health-checkup.component.spec.ts
+++ b/src/app/child-dev-project/health-checkup/health-checkup-component/health-checkup.component.spec.ts
@@ -24,9 +24,7 @@ describe("HealthCheckupComponent", () => {
         "getHealthChecksOfChild",
       ]);
       mockChildrenService.getChild.and.returnValue(of(child));
-      mockChildrenService.getEducationalMaterialsOfChild.and.returnValue(
-        of([])
-      );
+      mockChildrenService.getEducationalMaterialsOfChild.and.resolveTo([]);
       mockChildrenService.getHealthChecksOfChild.and.returnValue(of([]));
 
       TestBed.configureTestingModule({

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
@@ -7,5 +7,8 @@
       {{ o.label }}
     </mat-option>
   </mat-select>
+  <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">
+    This field is required
+  </mat-error>
 </mat-form-field>
 


### PR DESCRIPTION
see issue: #972

To solve this issue, `materialType` and `materialAmount` are required and `materialAmount` defaults to `1`. In my opinion, there is no point in storing a record with either no type or amount.

Additionally, this PR includes some changes in test-coverage, documentation and code-quality

### Visible/Frontend Changes
- [x] The summary does not have trailing commas

### Architectural/Backend Changes
- [x] improve educational material specs
- [x] `materialType` and `materialAmount` are required
- [x] relevant parts of `EducationalMaterialsComponent` are documented better
- [x] several minor code changes that improve the overall readability, resilience and verbosity of the code
