### PR TITLE
Fix service worker problems

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,8 +4,8 @@
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
   "display": "standalone",
-  "scope": "/",
-  "start_url": "/",
+  "scope": ".",
+  "start_url": ".",
   "icons": [
     {
       "src": "assets/icons/icon-72x72.png",


### PR DESCRIPTION
There was a mismatch between the scope of the service worker and the scope/start url of the manifest file which resulted in some browsers not correctly detecting a matching service worker. This might also help with the problem that sometimes updates are not detected correctly on mobile devices.
Now the page is built in a way that a pwa can be installed for each locale (https://demo.aam-digital.com/en-US/) instead of having one pwa for the whole domain (https://demo.aam-digital.com)

### Visible/Frontend Changes
- [x] The install app button is correctly shown on the url bar
- [x] (?) The app updates are recognized properly 

### Architectural/Backend Changes
- [x] Change absolute to relative path in `scope` and `start_url` of `manifest.json`
