### PR TITLE
Creating app with single service worker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,67 +2,12 @@
 # To use it only Docker needs to be installed locally
 # Run the following commands from the root folder to build, run and kill the application
 # >> docker build -f build/Dockerfile -t aam/digital:latest .
-# >> docker run -p=80:80 aam/digital:latest
+# >> docker run -p=80:80 aam/digital:latest:
 # >> docker kill aam-digital
-FROM node:15.11.0-alpine3.13 as builder
-WORKDIR /app
-
-COPY package*.json ./
-COPY patch-webpack.js .
-RUN npm ci --no-progress
-
-RUN $(npm bin)/ng version
-
-COPY . .
-
-ARG APP_VERSION="UNKNOWN"
-RUN sed -i "s/appVersion: \".*\"/appVersion: \"$APP_VERSION\"/g" src/environments/environment*.ts
-
-RUN npm run build-localized
-
-# When set to true, tests are run and coverage will be uploaded to CodeClimate
-ARG UPLOAD_COVERAGE=false
-RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
-    apk --no-cache add curl &&\
-    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter &&\
-    chmod +x ./cc-test-reporter &&\
-    ./cc-test-reporter before-build ; fi
-
-# When set to true, chromium is installed an tests are executed
-ARG RUN_TESTS=false
-ARG CHROME_BIN=/usr/bin/chromium-browser
-# Install chromium for karma, lint code and run tests
-RUN if [ "$RUN_TESTS" = true ] || [ "$UPLOAD_COVERAGE" = true ] ; then \
-    apk --no-cache add chromium &&\
-    npm run lint &&\
-    npm run test-ci ; fi
-
-# The following arguments need to be provided for the code climate test reporter to work correctly
-# The commit sha
-ARG GIT_COMMIT_SHA
-# The branch
-ARG GIT_BRANCH
-# The time of the commit, can be extracted with `git log -1 --pretty=format:%ct`
-ARG GIT_COMMITTED_AT
-# The ID for the test reporter, can be found on CodeCoverage
-ARG CC_TEST_REPORTER_ID
-RUN if [ "$UPLOAD_COVERAGE" = true ] ; then ./cc-test-reporter after-build --debug ; fi
-
-# Information required to upload the sourcemap to sentry
-# If not set, nothing is uploaded
-ARG SENTRY_AUTH_TOKEN
-ARG SENTRY_ORG
-ARG SENTRY_PROJECT
-RUN if [ "$SENTRY_AUTH_TOKEN" != "" ] ; then \
-    npm install -g @sentry/cli &&\
-    sentry-cli --auth-token=$SENTRY_AUTH_TOKEN releases --org=$SENTRY_ORG --project=$SENTRY_PROJECT files ndb-core@$APP_VERSION upload-sourcemaps dist  && \
-    rm dist/*/*.map ; fi
-
-### PROD image
 
 FROM nginx:1.21-alpine
 COPY ./build/default.conf /etc/nginx/templates/default.conf
-COPY --from=builder /app/dist/ /usr/share/nginx/html
+COPY dist/ /usr/share/nginx/html
 # The port on which the app will run in the Docker container
 ENV PORT=80
 # The url to the webdav server

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,12 +2,70 @@
 # To use it only Docker needs to be installed locally
 # Run the following commands from the root folder to build, run and kill the application
 # >> docker build -f build/Dockerfile -t aam/digital:latest .
-# >> docker run -p=80:80 aam/digital:latest:
+# >> docker run -p=80:80 aam/digital:latest
 # >> docker kill aam-digital
+FROM node:15.11.0-alpine3.13 as builder
+WORKDIR /app
+
+COPY package*.json ./
+COPY patch-webpack.js .
+RUN npm ci --no-progress
+
+RUN $(npm bin)/ng version
+
+COPY . .
+
+ARG APP_VERSION="UNKNOWN"
+RUN sed -i "s/appVersion: \".*\"/appVersion: \"$APP_VERSION\"/g" src/environments/environment*.ts
+
+RUN npm run build-localized
+
+# Merge the service workers for the different locales
+RUN node build/merge-service-workers.js
+
+# When set to true, tests are run and coverage will be uploaded to CodeClimate
+ARG UPLOAD_COVERAGE=false
+RUN if [ "$UPLOAD_COVERAGE" = true ] ; then \
+    apk --no-cache add curl &&\
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter &&\
+    chmod +x ./cc-test-reporter &&\
+    ./cc-test-reporter before-build ; fi
+
+# When set to true, chromium is installed an tests are executed
+ARG RUN_TESTS=false
+ARG CHROME_BIN=/usr/bin/chromium-browser
+# Install chromium for karma, lint code and run tests
+RUN if [ "$RUN_TESTS" = true ] || [ "$UPLOAD_COVERAGE" = true ] ; then \
+    apk --no-cache add chromium &&\
+    npm run lint &&\
+    npm run test-ci ; fi
+
+# The following arguments need to be provided for the code climate test reporter to work correctly
+# The commit sha
+ARG GIT_COMMIT_SHA
+# The branch
+ARG GIT_BRANCH
+# The time of the commit, can be extracted with `git log -1 --pretty=format:%ct`
+ARG GIT_COMMITTED_AT
+# The ID for the test reporter, can be found on CodeCoverage
+ARG CC_TEST_REPORTER_ID
+RUN if [ "$UPLOAD_COVERAGE" = true ] ; then ./cc-test-reporter after-build --debug ; fi
+
+# Information required to upload the sourcemap to sentry
+# If not set, nothing is uploaded
+ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
+RUN if [ "$SENTRY_AUTH_TOKEN" != "" ] ; then \
+    npm install -g @sentry/cli &&\
+    sentry-cli --auth-token=$SENTRY_AUTH_TOKEN releases --org=$SENTRY_ORG --project=$SENTRY_PROJECT files ndb-core@$APP_VERSION upload-sourcemaps dist  && \
+    rm dist/*/*.map ; fi
+
+### PROD image
 
 FROM nginx:1.21-alpine
 COPY ./build/default.conf /etc/nginx/templates/default.conf
-COPY dist/ /usr/share/nginx/html
+COPY --from=builder /app/dist/ /usr/share/nginx/html
 # The port on which the app will run in the Docker container
 ENV PORT=80
 # The url to the webdav server

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+
+const distFolder = "dist";
+
+function getNgswConfig(locale) {
+  const swConfig = fs.readFileSync(`${distFolder}/${locale}/ngsw.json`);
+  return JSON.parse(swConfig);
+}
+
+const locales = fs
+  .readdirSync(distFolder)
+  .filter((locale) => fs.lstatSync(`${distFolder}/${locale}`).isDirectory());
+
+const firstLocale = locales.pop();
+const combined = getNgswConfig(firstLocale);
+locales.forEach((locale) => {
+  const additional = getNgswConfig(locale);
+
+  // combine asset groups
+  additional.assetGroups.forEach((group) => {
+    combined.assetGroups
+      .find((g) => g.name === group.name)
+      .urls.push(...group.urls);
+  });
+
+  // combine hash tables
+  Object.assign(combined.hashTable, additional.hashTable);
+  fs.unlinkSync(`${distFolder}/${locale}/ngsw.json`);
+  fs.unlinkSync(`${distFolder}/${locale}/ngsw-worker.json`);
+});
+
+combined.index = "/index.html";
+
+fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
+fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
+fs.renameSync(
+  `${distFolder}/${firstLocale}/ngsw-worker.json`,
+  `${distFolder}/ngsw-worker.json`
+);

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -26,7 +26,7 @@ locales.forEach((locale) => {
   // combine hash tables
   Object.assign(combined.hashTable, additional.hashTable);
   fs.unlinkSync(`${distFolder}/${locale}/ngsw.json`);
-  fs.unlinkSync(`${distFolder}/${locale}/ngsw-worker.json`);
+  fs.unlinkSync(`${distFolder}/${locale}/ngsw-worker.js`);
 });
 
 combined.index = "/index.html";
@@ -34,6 +34,6 @@ combined.index = "/index.html";
 fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
 fs.renameSync(
-  `${distFolder}/${firstLocale}/ngsw-worker.json`,
-  `${distFolder}/ngsw-worker.json`
+  `${distFolder}/${firstLocale}/ngsw-worker.js`,
+  `${distFolder}/ngsw-worker.js`
 );

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -85,7 +85,7 @@ import { TranslatableMatPaginator } from "./core/translation/TranslatableMatPagi
 @NgModule({
   declarations: [AppComponent],
   imports: [
-    ServiceWorkerModule.register("ngsw-worker.js", {
+    ServiceWorkerModule.register("/ngsw-worker.js", {
       enabled: environment.production,
     }),
     Angulartics2Module.forRoot({

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,8 +4,8 @@
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
   "display": "standalone",
-  "scope": ".",
-  "start_url": ".",
+  "scope": "/",
+  "start_url": "/",
   "icons": [
     {
       "src": "assets/icons/icon-72x72.png",


### PR DESCRIPTION
Angular automatically builds a service worker for each language/locale that is available. This means each locale is a separate PWA that can be installed. By combining the individual service workers, the whole app with all locales becomes one PWA that can be installed. 

### Visible/Frontend Changes
-- 

### Architectural/Backend Changes
- [x] Merging service workers in Dockerfile
- [x] Adjusted scope to be absolute and the root folder
