### PR TITLE
Unregister old service workers

### DIFF
--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -44,10 +44,6 @@ combined.index = "/index.html";
 
 fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
-fs.renameSync(
-  `${distFolder}/${firstLocale}/safety-worker.js`,
-  `${distFolder}/${firstLocale}/ngsw-worker.js`
-);
 
 // Adjust service worker to allow changing language offline
 const swFile = fs
@@ -59,3 +55,7 @@ const patchedSw = swFile.replace(
 );
 fs.writeFileSync(`${distFolder}/ngsw-worker.js`, patchedSw);
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw-worker.js`);
+fs.renameSync(
+  `${distFolder}/${firstLocale}/safety-worker.js`,
+  `${distFolder}/${firstLocale}/ngsw-worker.js`
+);


### PR DESCRIPTION
Currently a problem exists with more recent version that have service workers under `/en-US/ngsw-worker.js` which result in problems when trying to update

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
