### PR TITLE
fix: not displaying school in child block if no school info is available

### DIFF
--- a/src/app/child-dev-project/children/child-block/child-block.component.html
+++ b/src/app/child-dev-project/children/child-block/child-block.component.html
@@ -26,7 +26,7 @@
     <div fxFlex="grow">
       <h3>{{ entity?.name }}</h3>
       <p><fa-icon icon="phone"></fa-icon> {{ entity?.phone }}</p>
-      <ng-container>
+      <ng-container *ngIf="entity?.schoolId || entity?.schoolClass">
         <p>
           <app-school-block [entityId]="entity?.schoolId"></app-school-block>,
         </p>
@@ -36,7 +36,7 @@
             [linkDisabled]="true"
           ></app-school-block
           >,
-          <ng-container i18n="The class a child is attending|e.g. 'class 8'">
+          <ng-container i18n="The class a child is attending|e.g. 'class 8'" *ngIf="entity.schoolClass">
             class {{ entity?.schoolClass }}
           </ng-container>
         </p>


### PR DESCRIPTION
some of our users don't use the schools feature which results in some display bugs inside the `ChildBlockComponent` this change turns of the school info if nothing is available
