### PR TITLE
Strict type check in Angular compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "deep-object-diff": "^1.1.0",
         "faker": "^5.5.3",
         "flag-icon-css": "^3.5.0",
-        "idb": "^6.1.2",
+        "idb": "^6.1.5",
         "json-query": "^2.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -16220,9 +16220,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-      "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -44386,9 +44386,9 @@
       "requires": {}
     },
     "idb": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-      "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "deep-object-diff": "^1.1.0",
     "faker": "^5.5.3",
     "flag-icon-css": "^3.5.0",
-    "idb": "^6.1.2",
+    "idb": "^6.1.5",
     "json-query": "^2.2.2",
     "lodash": "^4.17.21",
     "md5": "^2.3.0",

--- a/src/app/child-dev-project/children/child-block/child-block.component.html
+++ b/src/app/child-dev-project/children/child-block/child-block.component.html
@@ -28,9 +28,6 @@
       <p><fa-icon icon="phone"></fa-icon> {{ entity?.phone }}</p>
       <ng-container *ngIf="entity?.schoolId || entity?.schoolClass">
         <p>
-          <app-school-block [entityId]="entity?.schoolId"></app-school-block>,
-        </p>
-        <p>
           <app-school-block
             [entityId]="entity?.schoolId"
             [linkDisabled]="true"

--- a/src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.ts
+++ b/src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.ts
@@ -38,6 +38,11 @@ export class DemoChildGenerator extends DemoDataGenerator<Child> {
     child.dateOfBirth = faker.dateOfBirth(5, 20);
     child["motherTongue"] = faker.random.arrayElement(languages);
     child.center = faker.random.arrayElement(centersWithProbability);
+    child.phone =
+      "+" +
+      faker.datatype.number({ min: 10, max: 99 }) +
+      " " +
+      faker.datatype.number({ min: 10000000, max: 99999999 });
 
     child.admissionDate = faker.date.past(child.age - 4);
 

--- a/src/app/child-dev-project/children/model/child.ts
+++ b/src/app/child-dev-project/children/model/child.ts
@@ -100,6 +100,11 @@ export class Child extends Entity {
   })
   photo: Photo;
 
+  @DatabaseField({
+    label: $localize`:Label for the phone number of a child:Phone Number`,
+  })
+  phone: string;
+
   get age(): number {
     return this.dateOfBirth ? calculateAge(this.dateOfBirth) : null;
   }

--- a/src/app/child-dev-project/schools/school-block/school-block.component.html
+++ b/src/app/child-dev-project/schools/school-block/school-block.component.html
@@ -1,14 +1,4 @@
-<span (mouseenter)="showTooltip()" (mouseleave)="hideTooltip()">
+<span>
   <app-fa-dynamic-icon [icon]="icon"></app-fa-dynamic-icon>
   {{ entity?.name }}
 </span>
-
-<div style="position: absolute" *ngIf="tooltip">
-  <div
-    class="mat-elevation-z3 school-tooltip"
-    (mouseenter)="showTooltip()"
-    (mouseleave)="hideTooltip()"
-  >
-    <div>{{ entity?.language || entity?.medium}}</div>
-  </div>
-</div>

--- a/src/app/child-dev-project/schools/school-block/school-block.component.ts
+++ b/src/app/child-dev-project/schools/school-block/school-block.component.ts
@@ -22,8 +22,6 @@ export class SchoolBlockComponent implements OnInitDynamicComponent, OnChanges {
   @Input() entity: School = new School("");
   @Input() entityId: string;
   @Input() linkDisabled: boolean;
-  tooltip = false;
-  tooltipTimeout;
 
   constructor(
     private router: Router,
@@ -55,19 +53,6 @@ export class SchoolBlockComponent implements OnInitDynamicComponent, OnChanges {
       return;
     }
     this.entity = await this.entityMapper.load(School, this.entityId);
-  }
-
-  showTooltip() {
-    if (this.tooltipTimeout) {
-      clearTimeout(this.tooltipTimeout);
-    }
-    this.tooltipTimeout = setTimeout(() => (this.tooltip = true), 1000);
-  }
-  hideTooltip() {
-    if (this.tooltipTimeout) {
-      clearTimeout(this.tooltipTimeout);
-    }
-    this.tooltipTimeout = setTimeout(() => (this.tooltip = false), 150);
   }
 
   @HostListener("click") onClick() {

--- a/src/app/core/admin/admin/admin.component.html
+++ b/src/app/core/admin/admin/admin.component.html
@@ -71,7 +71,7 @@
     #backupImport
     type="file"
     style="display: none"
-    (change)="loadBackup($event.target.files[0])"
+    (change)="loadBackup($event)"
   />
 </p>
 
@@ -113,7 +113,7 @@
     #configImport
     type="file"
     style="display: none"
-    (change)="uploadConfigFile($event.target.files[0])"
+    (change)="uploadConfigFile($event)"
   />
 </p>
 

--- a/src/app/core/admin/admin/admin.component.spec.ts
+++ b/src/app/core/admin/admin/admin.component.spec.ts
@@ -167,7 +167,7 @@ describe("AdminComponent", () => {
   it("should save and apply new configuration", fakeAsync(() => {
     const mockFileReader = createFileReaderMock("{}");
     mockConfigService.saveConfig.and.returnValue(Promise.resolve(null));
-    component.uploadConfigFile(null);
+    component.uploadConfigFile({ target: { files: [] } } as any);
     tick();
     expect(mockFileReader.readAsText).toHaveBeenCalled();
     expect(mockConfigService.saveConfig).toHaveBeenCalled();
@@ -178,7 +178,7 @@ describe("AdminComponent", () => {
     mockBackupService.getJsonExport.and.returnValue(Promise.resolve("[]"));
     createDialogMock();
 
-    component.loadBackup(null);
+    component.loadBackup({ target: { files: [] } } as any);
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();
     tick();
     expect(mockFileReader.readAsText).toHaveBeenCalled();

--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -97,8 +97,8 @@ export class AdminComponent implements OnInit {
     this.startDownload(configString, "text/json", "config.json");
   }
 
-  async uploadConfigFile(file: Blob) {
-    const loadedFile = await readFile(file);
+  async uploadConfigFile(inputEvent: Event) {
+    const loadedFile = await readFile(this.getFileFromInputEvent(inputEvent));
     await this.configService.saveConfig(
       this.entityMapper,
       JSON.parse(loadedFile)
@@ -116,11 +116,11 @@ export class AdminComponent implements OnInit {
 
   /**
    * Reset the database to the state from the loaded backup file.
-   * @param file The file object of the backup to be restored
+   * @param inputEvent for the input where a file has been selected
    */
-  async loadBackup(file) {
+  async loadBackup(inputEvent: Event) {
     const restorePoint = await this.backupService.getJsonExport();
-    const newData = await readFile(file);
+    const newData = await readFile(this.getFileFromInputEvent(inputEvent));
 
     const dialogRef = this.confirmationDialog.openDialog(
       $localize`Overwrite complete database?`,
@@ -152,6 +152,11 @@ export class AdminComponent implements OnInit {
           await this.backupService.importJson(restorePoint, true);
         });
     });
+  }
+
+  private getFileFromInputEvent(inputEvent: Event): Blob {
+    const target = inputEvent.target as HTMLInputElement;
+    return target.files[0];
   }
 
   /**

--- a/src/app/core/config/config-fix.ts
+++ b/src/app/core/config/config-fix.ts
@@ -530,6 +530,7 @@ export const defaultJsonConfig = {
                     "center",
                     "status",
                     "address",
+                    "phone"
                   ],
                 ]
               }

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.spec.ts
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.spec.ts
@@ -8,6 +8,8 @@ import { ConfigService } from "../../config/config.service";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatSelectModule } from "@angular/material/select";
 import { ConfigurableEnumModule } from "../configurable-enum.module";
+import { TypedFormControl } from "../../entity-components/entity-utils/dynamic-form-components/edit-component";
+import { ConfigurableEnumValue } from "../configurable-enum.interface";
 
 describe("EditConfigurableEnumComponent", () => {
   let component: EditConfigurableEnumComponent;
@@ -38,7 +40,7 @@ describe("EditConfigurableEnumComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<ConfigurableEnumValue>;
     formGroup.registerControl(component.formControlName, formControl);
     component.enumId = "";
     fixture.detectChanges();

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.spec.ts
@@ -15,8 +15,8 @@ import { MockSessionModule } from "../../../session/mock-session.module";
 import { EntityMapperService } from "../../../entity/entity-mapper.service";
 
 describe("ListPaginatorComponent", () => {
-  let component: ListPaginatorComponent<any>;
-  let fixture: ComponentFixture<ListPaginatorComponent<any>>;
+  let component: ListPaginatorComponent;
+  let fixture: ComponentFixture<ListPaginatorComponent>;
 
   beforeEach(
     waitForAsync(() => {

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
@@ -6,7 +6,6 @@ import {
   SimpleChanges,
   AfterViewInit,
 } from "@angular/core";
-import { Entity } from "../../../entity/model/entity";
 import { MatPaginator, PageEvent } from "@angular/material/paginator";
 import { MatTableDataSource } from "@angular/material/table";
 import { User } from "../../../user/user";
@@ -21,12 +20,11 @@ import { filter } from "rxjs/operators";
   templateUrl: "./list-paginator.component.html",
   styleUrls: ["./list-paginator.component.scss"],
 })
-export class ListPaginatorComponent<E extends Entity>
-  implements OnChanges, AfterViewInit {
+export class ListPaginatorComponent implements OnChanges, AfterViewInit {
   readonly pageSizeOptions = [10, 20, 50];
   readonly defaultPageSize = 10;
 
-  @Input() dataSource: MatTableDataSource<E>;
+  @Input() dataSource: MatTableDataSource<any>;
   @Input() idForSavingPagination: string;
 
   @ViewChild(MatPaginator) paginator: MatPaginator;

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditAgeComponent } from "./edit-age.component";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatDatepickerModule } from "@angular/material/datepicker";
@@ -9,7 +9,7 @@ import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { MatNativeDateModule } from "@angular/material/core";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { MatInputModule } from "@angular/material/input";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditAgeComponent", () => {
   let component: EditAgeComponent;
@@ -34,11 +34,7 @@ describe("EditAgeComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditAgeComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<Date>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.spec.ts
@@ -9,6 +9,7 @@ import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { MatNativeDateModule } from "@angular/material/core";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { MatInputModule } from "@angular/material/input";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditAgeComponent", () => {
   let component: EditAgeComponent;
@@ -36,7 +37,7 @@ describe("EditAgeComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<Date>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-boolean/edit-boolean.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-boolean/edit-boolean.component.spec.ts
@@ -4,6 +4,7 @@ import { EditBooleanComponent } from "./edit-boolean.component";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatCheckboxModule } from "@angular/material/checkbox";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditBooleanComponent", () => {
   let component: EditBooleanComponent;
@@ -22,7 +23,7 @@ describe("EditBooleanComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<boolean>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-boolean/edit-boolean.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-boolean/edit-boolean.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditBooleanComponent } from "./edit-boolean.component";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatCheckboxModule } from "@angular/material/checkbox";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditBooleanComponent", () => {
   let component: EditBooleanComponent;
@@ -20,11 +20,7 @@ describe("EditBooleanComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditBooleanComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<boolean>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
@@ -1,19 +1,23 @@
 import { EditComponent } from "./edit-component";
 import { FormControl, FormGroup } from "@angular/forms";
 
-export const FORM_CONTROL_NAME = "testProperty";
-
 /**
  * A simple helper class that sets up a EditComponent with the required FormGroup
  * @param component that extends EditComponent
+ * @param propertyName (optional) the name of the property for which the edit component is created
  */
-export function setupEditComponent<T>(component: EditComponent<T>): FormGroup {
+export function setupEditComponent<T>(
+  component: EditComponent<T>,
+  propertyName = "testProperty"
+): FormGroup {
   const formControl = new FormControl();
-  const formGroup = new FormGroup({ testProperty: formControl });
+  const fromGroupConfig = {};
+  fromGroupConfig[propertyName] = formControl;
+  const formGroup = new FormGroup(fromGroupConfig);
   component.onInitFromDynamicConfig({
     formControl: formControl,
     propertySchema: {},
-    formFieldConfig: { id: FORM_CONTROL_NAME },
+    formFieldConfig: { id: propertyName },
   });
   return formGroup;
 }

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
@@ -1,0 +1,15 @@
+import { EditComponent } from "./edit-component";
+import { FormControl, FormGroup } from "@angular/forms";
+
+export const FORM_CONTROL_NAME = "testProperty";
+
+export function setupEditComponent<T>(component: EditComponent<T>): FormGroup {
+  const formControl = new FormControl();
+  const formGroup = new FormGroup({ testProperty: formControl });
+  component.onInitFromDynamicConfig({
+    formControl: formControl,
+    propertySchema: {},
+    formFieldConfig: { id: FORM_CONTROL_NAME },
+  });
+  return formGroup;
+}

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.spec.ts
@@ -3,6 +3,10 @@ import { FormControl, FormGroup } from "@angular/forms";
 
 export const FORM_CONTROL_NAME = "testProperty";
 
+/**
+ * A simple helper class that sets up a EditComponent with the required FormGroup
+ * @param component that extends EditComponent
+ */
 export function setupEditComponent<T>(component: EditComponent<T>): FormGroup {
   const formControl = new FormControl();
   const formGroup = new FormGroup({ testProperty: formControl });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-component.ts
@@ -1,5 +1,5 @@
 import { OnInitDynamicComponent } from "../../../view/dynamic-components/on-init-dynamic-component.interface";
-import { AbstractControl, FormControl } from "@angular/forms";
+import { AbstractControl, FormControl, FormGroup } from "@angular/forms";
 import { FormFieldConfig } from "../../entity-form/entity-form/FormConfig";
 import { EntitySchemaField } from "../../../entity/schema/entity-schema-field";
 
@@ -39,6 +39,10 @@ export class TypedFormControl<T> extends FormControl {
     }
   ) {
     super.setValue(value, options);
+  }
+
+  get parent(): FormGroup {
+    return super.parent as FormGroup;
   }
 }
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-date/edit-date.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-date/edit-date.component.spec.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatDatepickerModule } from "@angular/material/datepicker";
 import { MatInputModule } from "@angular/material/input";
 import { MatNativeDateModule } from "@angular/material/core";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditDateComponent", () => {
   let component: EditDateComponent;
@@ -32,7 +33,7 @@ describe("EditDateComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<Date>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-date/edit-date.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-date/edit-date.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditDateComponent } from "./edit-date.component";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatDatepickerModule } from "@angular/material/datepicker";
 import { MatInputModule } from "@angular/material/input";
 import { MatNativeDateModule } from "@angular/material/core";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditDateComponent", () => {
   let component: EditDateComponent;
@@ -30,11 +30,7 @@ describe("EditDateComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditDateComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<Date>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.spec.ts
@@ -1,13 +1,12 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditEntityArrayComponent } from "./edit-entity-array.component";
-import { FormControl } from "@angular/forms";
 import { EntityMapperService } from "../../../../entity/entity-mapper.service";
 import { Child } from "../../../../../child-dev-project/children/model/child";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { EntityUtilsModule } from "../../entity-utils.module";
 import { EntitySchemaService } from "../../../../entity/schema/entity-schema.service";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditEntityArrayComponent", () => {
   let component: EditEntityArrayComponent;
@@ -30,7 +29,7 @@ describe("EditEntityArrayComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditEntityArrayComponent);
     component = fixture.componentInstance;
-    component.formControl = new FormControl() as TypedFormControl<string[]>;
+    setupEditComponent(component);
     component.entityName = Child.ENTITY_TYPE;
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.spec.ts
@@ -7,6 +7,7 @@ import { Child } from "../../../../../child-dev-project/children/model/child";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { EntityUtilsModule } from "../../entity-utils.module";
 import { EntitySchemaService } from "../../../../entity/schema/entity-schema.service";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditEntityArrayComponent", () => {
   let component: EditEntityArrayComponent;
@@ -29,7 +30,7 @@ describe("EditEntityArrayComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditEntityArrayComponent);
     component = fixture.componentInstance;
-    component.formControl = new FormControl();
+    component.formControl = new FormControl() as TypedFormControl<string[]>;
     component.entityName = Child.ENTITY_TYPE;
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-entity-array/edit-entity-array.component.ts
@@ -1,15 +1,12 @@
 import { Component } from "@angular/core";
 import { EditComponent, EditPropertyConfig } from "../edit-component";
-import { Entity } from "../../../../entity/model/entity";
 
 @Component({
   selector: "app-edit-entity-array",
   templateUrl: "./edit-entity-array.component.html",
   styleUrls: ["./edit-entity-array.component.scss"],
 })
-export class EditEntityArrayComponent extends EditComponent<
-  (string | Entity)[]
-> {
+export class EditEntityArrayComponent extends EditComponent<string[]> {
   placeholder: string;
   entityName: string;
   onInitFromDynamicConfig(config: EditPropertyConfig) {

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-long-text/edit-long-text.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-long-text/edit-long-text.component.spec.ts
@@ -2,10 +2,10 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditLongTextComponent } from "./edit-long-text.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditLongTextComponent", () => {
   let component: EditLongTextComponent;
@@ -26,11 +26,7 @@ describe("EditLongTextComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditLongTextComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<string>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-long-text/edit-long-text.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-long-text/edit-long-text.component.spec.ts
@@ -5,6 +5,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditLongTextComponent", () => {
   let component: EditLongTextComponent;
@@ -28,7 +29,7 @@ describe("EditLongTextComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<string>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-number/edit-number.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-number/edit-number.component.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditNumberComponent } from "./edit-number.component";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditNumberComponent", () => {
   let component: EditNumberComponent;
@@ -26,13 +27,7 @@ describe("EditNumberComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditNumberComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    formGroup = new FormGroup({ testProperty: formControl });
-    component.onInitFromDynamicConfig({
-      formControl: formControl,
-      propertySchema: {},
-      formFieldConfig: { id: "testProperty" },
-    });
+    formGroup = setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-percentage/edit-percentage.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-percentage/edit-percentage.component.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "@angular/forms";
 import { MatInputModule } from "@angular/material/input";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { FORM_CONTROL_NAME, setupEditComponent } from "../edit-component.spec";
 
 describe("EditPercentageComponent", () => {
   let component: EditPercentageComponent;
@@ -31,13 +32,7 @@ describe("EditPercentageComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditPercentageComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    formGroup = new FormGroup({ testProperty: formControl });
-    component.onInitFromDynamicConfig({
-      formControl: formControl,
-      propertySchema: {},
-      formFieldConfig: { id: "testProperty" },
-    });
+    formGroup = setupEditComponent(component);
     fixture.detectChanges();
   });
 
@@ -74,11 +69,11 @@ describe("EditPercentageComponent", () => {
     expect(formGroup.valid).toBeTrue();
 
     const control = new FormControl(0, [Validators.required]);
-    formGroup.setControl("testProperty", control);
+    formGroup.setControl(FORM_CONTROL_NAME, control);
     component.onInitFromDynamicConfig({
       formControl: control,
       propertySchema: {},
-      formFieldConfig: { id: "testProperty" },
+      formFieldConfig: { id: FORM_CONTROL_NAME },
     });
 
     component.formControl.setValue(null);

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-percentage/edit-percentage.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-percentage/edit-percentage.component.spec.ts
@@ -10,12 +10,13 @@ import {
 } from "@angular/forms";
 import { MatInputModule } from "@angular/material/input";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { FORM_CONTROL_NAME, setupEditComponent } from "../edit-component.spec";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditPercentageComponent", () => {
   let component: EditPercentageComponent;
   let fixture: ComponentFixture<EditPercentageComponent>;
   let formGroup: FormGroup;
+  const propertyName = "percentageProperty";
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -32,7 +33,7 @@ describe("EditPercentageComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditPercentageComponent);
     component = fixture.componentInstance;
-    formGroup = setupEditComponent(component);
+    formGroup = setupEditComponent(component, propertyName);
     fixture.detectChanges();
   });
 
@@ -69,11 +70,11 @@ describe("EditPercentageComponent", () => {
     expect(formGroup.valid).toBeTrue();
 
     const control = new FormControl(0, [Validators.required]);
-    formGroup.setControl(FORM_CONTROL_NAME, control);
+    formGroup.setControl(propertyName, control);
     component.onInitFromDynamicConfig({
       formControl: control,
       propertySchema: {},
-      formFieldConfig: { id: FORM_CONTROL_NAME },
+      formFieldConfig: { id: propertyName },
     });
 
     component.formControl.setValue(null);

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-photo/edit-photo.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-photo/edit-photo.component.spec.ts
@@ -4,6 +4,8 @@ import { EditPhotoComponent } from "./edit-photo.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { FormControl, FormGroup } from "@angular/forms";
 import { SessionService } from "../../../../session/session-service/session.service";
+import { TypedFormControl } from "../edit-component";
+import { Photo } from "../../../../../child-dev-project/children/child-photo-service/photo";
 
 describe("EditPhotoComponent", () => {
   let component: EditPhotoComponent;
@@ -25,7 +27,7 @@ describe("EditPhotoComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<Photo>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-photo/edit-photo.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-photo/edit-photo.component.spec.ts
@@ -2,10 +2,8 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditPhotoComponent } from "./edit-photo.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { FormControl, FormGroup } from "@angular/forms";
 import { SessionService } from "../../../../session/session-service/session.service";
-import { TypedFormControl } from "../edit-component";
-import { Photo } from "../../../../../child-dev-project/children/child-photo-service/photo";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditPhotoComponent", () => {
   let component: EditPhotoComponent;
@@ -24,11 +22,7 @@ describe("EditPhotoComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditPhotoComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<Photo>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.spec.ts
@@ -7,7 +7,7 @@ import {
 
 import { EditSingleEntityComponent } from "./edit-single-entity.component";
 import { EntityMapperService } from "../../../../entity/entity-mapper.service";
-import { FormControl, Validators } from "@angular/forms";
+import { Validators } from "@angular/forms";
 import { EntitySchemaService } from "../../../../entity/schema/entity-schema.service";
 import { EntityFormService } from "../../../entity-form/entity-form.service";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -15,6 +15,7 @@ import { ChildSchoolRelation } from "../../../../../child-dev-project/children/m
 import { School } from "../../../../../child-dev-project/schools/model/school";
 import { EntityUtilsModule } from "../../entity-utils.module";
 import { Child } from "../../../../../child-dev-project/children/model/child";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditSingleEntityComponent", () => {
   let component: EditSingleEntityComponent;
@@ -42,7 +43,7 @@ describe("EditSingleEntityComponent", () => {
     const entityFormService = TestBed.inject(EntityFormService);
     component.formControl = entityFormService
       .createFormGroup([{ id: "schoolId" }], new ChildSchoolRelation())
-      .get("schoolId") as FormControl;
+      .get("schoolId") as TypedFormControl<string>;
     component.formControlName = "schoolId";
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text/edit-text.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text/edit-text.component.spec.ts
@@ -5,6 +5,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
+import { TypedFormControl } from "../edit-component";
 
 describe("EditTextComponent", () => {
   let component: EditTextComponent;
@@ -28,7 +29,7 @@ describe("EditTextComponent", () => {
     const formControl = new FormControl();
     const formGroup = new FormGroup({});
     component.formControlName = "testControl";
-    component.formControl = formControl;
+    component.formControl = formControl as TypedFormControl<string>;
     formGroup.registerControl(component.formControlName, formControl);
     fixture.detectChanges();
   });

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text/edit-text.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text/edit-text.component.spec.ts
@@ -1,11 +1,11 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EditTextComponent } from "./edit-text.component";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { TypedFormControl } from "../edit-component";
+import { setupEditComponent } from "../edit-component.spec";
 
 describe("EditTextComponent", () => {
   let component: EditTextComponent;
@@ -26,11 +26,7 @@ describe("EditTextComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditTextComponent);
     component = fixture.componentInstance;
-    const formControl = new FormControl();
-    const formGroup = new FormGroup({});
-    component.formControlName = "testControl";
-    component.formControl = formControl as TypedFormControl<string>;
-    formGroup.registerControl(component.formControlName, formControl);
+    setupEditComponent(component);
     fixture.detectChanges();
   });
 

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.html
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.html
@@ -17,7 +17,7 @@
       <mat-basic-chip
         [selectable]="selectable && formControl.enabled"
         [removable]="removable && formControl.enabled"
-        *ngFor="let entity of selection_"
+        *ngFor="let entity of selectedEntities"
         class="chip"
       >
         <app-display-entity [entityToDisplay]="entity"></app-display-entity>

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
@@ -90,47 +90,44 @@ describe("EntitySelectComponent", () => {
     fixture.detectChanges();
   });
 
-  it("contains the initial selection when passed as entity-arguments", fakeAsync(() => {
+  it("contains the initial selection as entities", fakeAsync(() => {
     component.entityType = User.ENTITY_TYPE;
-    fixture.detectChanges();
-    tick();
-    component.selectionInputType = "entity";
-    const expectation = testUsers.slice(2, 3);
-    component.selection = expectation;
-    expect(component.selection_).toEqual(expectation);
-  }));
+    const expectation = testUsers.slice(2, 3).map((user) => user.getId());
 
-  it("contains the initial selection when passed as id-arguments", fakeAsync(() => {
-    component.entityType = User.ENTITY_TYPE;
-    component.selectionInputType = "id";
-    const expectation = testUsers.slice(2, 3).map((child) => child.getId());
     component.selection = expectation;
     fixture.detectChanges();
     tick();
-    expect(component.selection_.every((s) => typeof s === "object")).toBeTrue();
-    expect(component.selection_.map((s) => s.getId())).toEqual(expectation);
+
+    component.selectedEntities.forEach((s) => expect(s).toBeInstanceOf(User));
+    expect(component.selectedEntities.map((s) => s.getId())).toEqual(
+      expectation
+    );
   }));
 
   it("emits whenever a new entity is selected", fakeAsync(() => {
     spyOn(component.selectionChange, "emit");
     component.entityType = User.ENTITY_TYPE;
     tick();
-    component.selectionInputType = "entity";
+
     component.selectEntity(testUsers[0]);
-    expect(component.selectionChange.emit).toHaveBeenCalledWith([testUsers[0]]);
+    expect(component.selectionChange.emit).toHaveBeenCalledWith([
+      testUsers[0].getId(),
+    ]);
+
     component.selectEntity(testUsers[1]);
     expect(component.selectionChange.emit).toHaveBeenCalledWith([
-      testUsers[0],
-      testUsers[1],
+      testUsers[0].getId(),
+      testUsers[1].getId(),
     ]);
     tick();
   }));
 
   it("emits whenever a selected entity is removed", () => {
     spyOn(component.selectionChange, "emit");
-    component.selection_ = [...testUsers];
-    component.selectionInputType = "id";
+    component.selectedEntities = [...testUsers];
+
     component.unselectEntity(testUsers[0]);
+
     const remainingChildren = testUsers
       .filter((c) => c.getId() !== testUsers[0].getId())
       .map((c) => c.getId());
@@ -142,13 +139,13 @@ describe("EntitySelectComponent", () => {
   it("adds a new entity if it matches a known entity", () => {
     component.allEntities = testUsers;
     component.select({ input: null, value: testUsers[0]["name"] });
-    expect(component.selection_).toEqual([testUsers[0]]);
+    expect(component.selectedEntities).toEqual([testUsers[0]]);
   });
 
   it("does not add anything if a new entity doesn't match", () => {
     component.allEntities = testUsers;
     component.select({ input: null, value: "ZZ" });
-    expect(component.selection_).toEqual([]);
+    expect(component.selectedEntities).toEqual([]);
   });
 
   it("autocompletes with the default accessor", (done) => {

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.ts
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.ts
@@ -45,45 +45,33 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
 
   /**
    * The (initial) selection. Can be used in combination with {@link selectionChange}
-   * to enable two-way binding to either an array of entities or an array of strings
-   * corresponding to the id's of the entities.
-   * The type (id's or entities) will be determined by the setting of the
-   * {@link selectionInputType}
+   * to enable two-way binding to an array of strings corresponding to the id's of the entities.
    * @param sel The initial selection
    */
-  @Input() set selection(sel: (string | E)[]) {
+  @Input() set selection(sel: string[]) {
     if (!Array.isArray(sel)) {
-      this.selection_ = [];
+      this.selectedEntities = [];
       return;
     }
-    if (this.selectionInputType === "id") {
-      this.loading
-        .pipe(
-          untilDestroyed(this),
-          filter((isLoading) => !isLoading)
-        )
-        .subscribe((_) => {
-          this.selection_ = this.allEntities.filter((e) =>
-            sel.find((s) => s === e.getId())
-          );
-        });
-    } else {
-      this.selection_ = sel as E[];
-    }
+    this.loading
+      .pipe(
+        untilDestroyed(this),
+        filter((isLoading) => !isLoading)
+      )
+      .subscribe((_) => {
+        this.selectedEntities = this.allEntities.filter((e) =>
+          sel.find((s) => s === e.getId())
+        );
+      });
   }
   /** Underlying data-array */
-  selection_: E[] = [];
-  /**
-   * The type to publish and receive; either string-id's or entities
-   * Defaults to string-id's
-   */
-  @Input() selectionInputType: "id" | "entity" = "id";
+  selectedEntities: E[] = [];
   /**
    * called whenever the selection changes.
    * This happens when a new entity is being added or an existing
    * one is removed
    */
-  @Output() selectionChange = new EventEmitter<(string | E)[]>();
+  @Output() selectionChange = new EventEmitter<string[]>();
   /**
    * The label is what is seen above the list. For example when used
    * in the note-details-view, this is "Children"
@@ -178,7 +166,7 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
    * @param entity the entity to select
    */
   selectEntity(entity: E) {
-    this.selection_.push(entity);
+    this.selectedEntities.push(entity);
     this.emitChange();
     this.inputField.nativeElement.value = "";
     this.formControl.setValue(null);
@@ -230,11 +218,11 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
    * @param entity The entity to remove
    */
   unselectEntity(entity: E) {
-    const index = this.selection_.findIndex(
+    const index = this.selectedEntities.findIndex(
       (e) => e.getId() === entity.getId()
     );
     if (index !== -1) {
-      this.selection_.splice(index, 1);
+      this.selectedEntities.splice(index, 1);
       this.emitChange();
       // Update the form control to re-run the filter function
       this.formControl.updateValueAndValidity();
@@ -242,14 +230,10 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
   }
 
   private emitChange() {
-    if (this.selectionInputType === "id") {
-      this.selectionChange.emit(this.selection_.map((e) => e.getId()));
-    } else {
-      this.selectionChange.emit(this.selection_);
-    }
+    this.selectionChange.emit(this.selectedEntities.map((e) => e.getId()));
   }
 
   private isSelected(entity: E): boolean {
-    return this.selection_.some((e) => e.getId() === entity.getId());
+    return this.selectedEntities.some((e) => e.getId() === entity.getId());
   }
 }

--- a/src/app/features/data-import/data-import/data-import.component.html
+++ b/src/app/features/data-import/data-import/data-import.component.html
@@ -9,5 +9,5 @@
   #csvImport
   type="file"
   style="display: none"
-  (change)="importCsvFile($event.target.files[0])"
+  (change)="importCsvFile($event)"
 />

--- a/src/app/features/data-import/data-import/data-import.component.spec.ts
+++ b/src/app/features/data-import/data-import/data-import.component.spec.ts
@@ -36,7 +36,7 @@ describe("DataImportComponent", () => {
   });
 
   it("should call handleCsvImport() in DataImportService", () => {
-    component.importCsvFile(mockCsvFile);
+    component.importCsvFile({ target: { files: [mockCsvFile] } } as any);
     expect(mockDataImportService.handleCsvImport).toHaveBeenCalledWith(
       mockCsvFile
     );

--- a/src/app/features/data-import/data-import/data-import.component.ts
+++ b/src/app/features/data-import/data-import/data-import.component.ts
@@ -12,7 +12,8 @@ import { DataImportService } from "../data-import.service";
 export class DataImportComponent {
   constructor(private dataImportService: DataImportService) {}
 
-  importCsvFile(file: Blob): void {
-    this.dataImportService.handleCsvImport(file);
+  importCsvFile(inputEvent: Event): void {
+    const target = inputEvent.target as HTMLInputElement;
+    this.dataImportService.handleCsvImport(target.files[0]);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,8 @@
       "dom"
     ],
     "resolveJsonModule": true
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
This PR adds the [strictTemplates](https://angular.io/guide/template-typecheck#strict-mode) compiler option for the Angular/Typescript compiler. This performs further static analysis on the types used inside the app. This should help us to make more use of Typescript and detect errors earlier.

### Visible/Frontend Changes
-- 

### Architectural/Backend Changes
- [x] Enabled `strictTemplates` for the Angular compiler
- [x] Fixed type errors that were in the system
