### PR TITLE
Report Component no longer shows an error when config is undefined

### DIFF
--- a/src/app/features/reporting/reporting/reporting.component.ts
+++ b/src/app/features/reporting/reporting/reporting.component.ts
@@ -37,7 +37,7 @@ export class ReportingComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.data.subscribe(
       (data: RouteData<ReportingComponentConfig>) => {
-        this.availableReports = data.config.reports;
+        this.availableReports = data.config?.reports;
         if (this.availableReports?.length === 1) {
           this.selectedReport = this.availableReports[0];
         }


### PR DESCRIPTION
see issue: #984 

### Architectural/Backend Changes
- [x] Error is no longer shown in the console
