### PR TITLE
Sort roll call participants

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.html
@@ -20,6 +20,7 @@
     <app-roll-call
       *ngIf="currentStage === 1"
       [eventEntity]="event"
+      [sortParticipantsBy]="config?.sortParticipantsBy"
       (exit)="finishRollCallState()"
       (complete)="saveRollCallResult($event)"
     >

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
@@ -1,6 +1,16 @@
 import { Component } from "@angular/core";
 import { EntityMapperService } from "../../../core/entity/entity-mapper.service";
 import { Note } from "../../notes/model/note";
+import { ActivatedRoute } from "@angular/router";
+import { RouteData } from "../../../core/view/dynamic-routing/view-config.interface";
+
+/**
+ * additional config specifically for AddDayAttendanceComponent
+ */
+export interface AddDayAttendanceConfig {
+  /** (optional) property name of the participant entities by which they are sorted for the roll call */
+  sortParticipantsBy?: string;
+}
 
 @Component({
   selector: "app-add-day-attendance",
@@ -8,6 +18,8 @@ import { Note } from "../../notes/model/note";
   styleUrls: ["./add-day-attendance.component.scss"],
 })
 export class AddDayAttendanceComponent {
+  config?: AddDayAttendanceConfig;
+
   currentStage = 0;
 
   day = new Date();
@@ -20,7 +32,14 @@ export class AddDayAttendanceComponent {
     $localize`:One of the stages while recording child-attendances:Record Attendance`,
   ];
 
-  constructor(private entityMapper: EntityMapperService) {}
+  constructor(
+    private entityMapper: EntityMapperService,
+    private route: ActivatedRoute
+  ) {
+    this.route.data.subscribe((data: RouteData<AddDayAttendanceConfig>) => {
+      this.config = data.config;
+    });
+  }
 
   finishBasicInformationStage(event: Note) {
     this.event = event;

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -13,7 +13,6 @@ import { By } from "@angular/platform-browser";
 import { ConfigService } from "../../../../core/config/config.service";
 import { ConfigurableEnumConfig } from "../../../../core/configurable-enum/configurable-enum.interface";
 import { Child } from "../../../children/model/child";
-import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
 import { LoggingService } from "../../../../core/logging/logging.service";
 import { defaultAttendanceStatusTypes } from "../../../../core/config/default-config/default-attendance-status-types";
 import { AttendanceModule } from "../../attendance.module";
@@ -22,6 +21,8 @@ import { MockSessionModule } from "../../../../core/session/mock-session.module"
 import { ConfirmationDialogService } from "../../../../core/confirmation-dialog/confirmation-dialog.service";
 import { of } from "rxjs";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
+import { LoginState } from "../../../../core/session/session-states/login-state.enum";
+import { SimpleChange } from "@angular/core";
 
 describe("RollCallComponent", () => {
   let component: RollCallComponent;
@@ -29,28 +30,36 @@ describe("RollCallComponent", () => {
 
   const testEvent = Note.create(new Date());
   let mockConfigService: jasmine.SpyObj<ConfigService>;
-  let mockEntityMapper: jasmine.SpyObj<EntityMapperService>;
   let mockLoggingService: jasmine.SpyObj<LoggingService>;
+
+  let participant1, participant2: Child;
+
+  const dummyChanges = {
+    eventEntity: new SimpleChange(undefined, {}, true),
+  };
 
   beforeEach(
     waitForAsync(() => {
+      participant1 = new Child("child1");
+      participant2 = new Child("child2");
+
       mockConfigService = jasmine.createSpyObj("mockConfigService", [
         "getConfig",
       ]);
       mockConfigService.getConfig.and.returnValue([]);
-      mockEntityMapper = jasmine.createSpyObj(["load"]);
-      mockEntityMapper.load.and.resolveTo();
       mockLoggingService = jasmine.createSpyObj(["warn"]);
 
       TestBed.configureTestingModule({
         imports: [
           AttendanceModule,
-          MockSessionModule,
+          MockSessionModule.withState(LoginState.LOGGED_IN, [
+            participant1,
+            participant2,
+          ]),
           FontAwesomeTestingModule,
         ],
         providers: [
           { provide: ConfigService, useValue: mockConfigService },
-          { provide: EntityMapperService, useValue: mockEntityMapper },
           { provide: LoggingService, useValue: mockLoggingService },
           { provide: ChildrenService, useValue: {} },
         ],
@@ -87,9 +96,9 @@ describe("RollCallComponent", () => {
       },
     ];
     mockConfigService.getConfig.and.returnValue(testStatusEnumConfig);
-    component.eventEntity = Note.create(new Date());
-    component.eventEntity.addChild("1");
-    await component.ngOnInit();
+    component.eventEntity = new Note();
+    component.eventEntity.addChild(participant1.getId());
+    await component.ngOnChanges(dummyChanges);
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -101,22 +110,15 @@ describe("RollCallComponent", () => {
 
   it("should not record attendance if childId does not exist", fakeAsync(() => {
     const nonExistingChildId = "notExistingChild";
-    const existingChild = new Child("existingChild");
     const noteWithNonExistingChild = new Note();
-    noteWithNonExistingChild.addChild(existingChild.getId());
+    noteWithNonExistingChild.addChild(participant1.getId());
     noteWithNonExistingChild.addChild(nonExistingChildId);
     component.eventEntity = noteWithNonExistingChild;
 
-    mockEntityMapper.load.and.callFake((con, id) =>
-      id === existingChild.getId()
-        ? Promise.resolve(existingChild as any)
-        : Promise.reject()
-    );
-
-    component.ngOnInit();
+    component.ngOnChanges(dummyChanges);
     tick();
 
-    expect(component.entries.map((e) => e.child)).toEqual([existingChild]);
+    expect(component.entries.map((e) => e.child)).toEqual([participant1]);
     expect(
       component.eventEntity.children.includes(nonExistingChildId)
     ).toBeFalse();
@@ -131,56 +133,41 @@ describe("RollCallComponent", () => {
     const absentStatus = defaultAttendanceStatusTypes.find(
       (it) => it.countAs === "ABSENT"
     );
-    const attendedChild = new Child("attendedChild");
-    const absentChild = new Child("absentChild");
     const note = new Note("noteWithAttendance");
-    note.addChild(attendedChild.getId());
-    note.addChild(absentChild.getId());
-    mockEntityMapper.load.and.callFake((t, id) => {
-      if (id === absentChild.getId()) {
-        return Promise.resolve(absentChild) as any;
-      }
-      if (id === attendedChild.getId()) {
-        return Promise.resolve(attendedChild) as any;
-      }
-    });
+    note.addChild(participant1.getId());
+    note.addChild(participant2.getId());
+
     component.eventEntity = note;
-    component.ngOnInit();
+    component.ngOnChanges(dummyChanges);
     tick();
 
     const attendedChildAttendance = component.entries.find(
-      ({ child }) => child === attendedChild
+      ({ child }) => child === participant1
     ).attendance;
     const absentChildAttendance = component.entries.find(
-      ({ child }) => child === absentChild
+      ({ child }) => child === participant2
     ).attendance;
     component.markAttendance(attendedChildAttendance, attendedStatus);
     component.markAttendance(absentChildAttendance, absentStatus);
 
-    expect(note.getAttendance(attendedChild.getId()).status).toEqual(
+    expect(note.getAttendance(participant1.getId()).status).toEqual(
       attendedStatus
     );
-    expect(note.getAttendance(absentChild.getId()).status).toEqual(
+    expect(note.getAttendance(participant2.getId()).status).toEqual(
       absentStatus
     );
     flush();
   }));
 
   it("should mark roll call as done when all existing children are finished", fakeAsync(() => {
-    const existingChild1 = new Child("existingChild1");
-    const existingChild2 = new Child("existingChild2");
     const note = new Note();
-    note.addChild(existingChild1.getId());
+    note.addChild(participant1.getId());
     note.addChild("notExistingChild");
-    note.addChild(existingChild2.getId());
-    mockEntityMapper.load.and.returnValues(
-      Promise.resolve(existingChild2),
-      Promise.reject(),
-      Promise.resolve(existingChild1)
-    );
+    note.addChild(participant2.getId());
+
     spyOn(component.complete, "emit");
     component.eventEntity = note;
-    component.ngOnInit();
+    component.ngOnChanges(dummyChanges);
     tick();
 
     component.goToNextParticipant();

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -100,10 +100,11 @@ describe("RollCallComponent", () => {
   });
 
   it("should not record attendance if childId does not exist", fakeAsync(() => {
+    const nonExistingChildId = "notExistingChild";
     const existingChild = new Child("existingChild");
     const noteWithNonExistingChild = new Note();
     noteWithNonExistingChild.addChild(existingChild.getId());
-    noteWithNonExistingChild.addChild("notExistingChild");
+    noteWithNonExistingChild.addChild(nonExistingChildId);
     component.eventEntity = noteWithNonExistingChild;
 
     mockEntityMapper.load.and.callFake((con, id) =>
@@ -116,6 +117,9 @@ describe("RollCallComponent", () => {
     tick();
 
     expect(component.entries.map((e) => e.child)).toEqual([existingChild]);
+    expect(
+      component.eventEntity.children.includes(nonExistingChildId)
+    ).toBeFalse();
     expect(mockLoggingService.warn).toHaveBeenCalled();
     flush();
   }));

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -89,6 +89,7 @@ export class RollCallComponent implements OnInit {
             " for event " +
             this.eventEntity.getId()
         );
+        this.eventEntity.removeChild(childId);
         continue;
       }
       this.entries.push({

--- a/src/app/core/entity/mock-entity-mapper-service.ts
+++ b/src/app/core/entity/mock-entity-mapper-service.ts
@@ -58,7 +58,11 @@ export class MockEntityMapperService extends EntityMapperService {
    * @param id
    */
   public get(entityType: string, id: string): Entity {
-    return this.data.get(entityType)?.get(id);
+    const result = this.data.get(entityType)?.get(id);
+    if (!result) {
+      throw { status: 404 };
+    }
+    return result;
   }
 
   /**

--- a/src/app/core/session/mock-session.module.ts
+++ b/src/app/core/session/mock-session.module.ts
@@ -12,6 +12,7 @@ import { AnalyticsService } from "../analytics/analytics.service";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Angulartics2Module } from "angulartics2";
 import { RouterTestingModule } from "@angular/router/testing";
+import { Entity } from "../entity/model/entity";
 
 export const TEST_USER = "test";
 export const TEST_PASSWORD = "pass";
@@ -36,9 +37,10 @@ export const TEST_PASSWORD = "pass";
 })
 export class MockSessionModule {
   static withState(
-    loginState = LoginState.LOGGED_IN
+    loginState = LoginState.LOGGED_IN,
+    data: Entity[] = []
   ): ModuleWithProviders<MockSessionModule> {
-    const mockedEntityMapper = mockEntityMapper([new User(TEST_USER)]);
+    const mockedEntityMapper = mockEntityMapper([new User(TEST_USER), ...data]);
     return {
       ngModule: MockSessionModule,
       providers: [

--- a/src/app/utils/utils.spec.ts
+++ b/src/app/utils/utils.spec.ts
@@ -44,4 +44,22 @@ describe("Utils", () => {
 
     expect(sortedDesc).toEqual([forth, third, second, first]);
   });
+
+  it("should sort undefined last", () => {
+    const first = { number: 1 };
+    const second = { number: 10 };
+    const third = { number: undefined };
+
+    const sorted = [second, third, first].sort(
+      sortByAttribute("number", "asc")
+    );
+
+    expect(sorted).toEqual([first, second, third]);
+
+    const sortedDesc = [second, third, first].sort(
+      sortByAttribute("number", "desc")
+    );
+
+    expect(sortedDesc).toEqual([third, second, first]);
+  });
 });

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -53,8 +53,8 @@ export function calculateAge(dateOfBirth: Date): number {
   return age;
 }
 
-export function sortByAttribute<OBJECT, PROPERTY extends keyof OBJECT>(
-  attribute: PROPERTY,
+export function sortByAttribute<OBJECT>(
+  attribute: keyof OBJECT,
   order: "asc" | "desc" = "asc"
 ): (e1: OBJECT, e2: OBJECT) => number {
   return (e1, e2) => {
@@ -62,7 +62,17 @@ export function sortByAttribute<OBJECT, PROPERTY extends keyof OBJECT>(
     const value2 = e2[attribute];
     if (value1 === value2) {
       return 0;
-    } else if (value1 < value2) {
+    }
+
+    // treat undefined specifically as greatest value (otherwise they remain stuck at their original position)
+    if (value1 === undefined) {
+      return order === "asc" ? 1 : -1;
+    }
+    if (value2 === undefined) {
+      return order === "asc" ? -1 : 1;
+    }
+
+    if (value1 < value2) {
       return order === "asc" ? -1 : 1;
     } else {
       return order === "asc" ? 1 : -1;


### PR DESCRIPTION
on request of one of our clients, this PR adds the option to configure a property by which participants are ordered when shown one after another in the "record attendance" / "roll call" workflow.

also, fixes #931 