### PR TITLE
fix problem with deleted children in exports

### DIFF
--- a/src/app/core/export/export-service/export.service.ts
+++ b/src/app/core/export/export-service/export.service.ts
@@ -161,7 +161,7 @@ export class ExportService {
       // queryData() always returns an array, simple queries should be a direct value however
       return value[0];
     }
-    return value;
+    return value.filter((val) => val !== undefined);
   }
 
   /**


### PR DESCRIPTION
### Visible/Frontend Changes
--
### Architectural/Backend Changes
- [x] If a query is returning undefined, this result is not used for further sub-queries, which currently results in errors with the default notes export 
