### PR TITLE
Fix: Record Attendance without a date can no longer be edited

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html
@@ -6,10 +6,12 @@
           Event-Record label|Record an event for a particular date that is to be
           inputted
         "
-        >Date</mat-label
+      >Date
+      </mat-label
       >
       <input
         matInput
+        #dateField="ngModel"
         [(ngModel)]="date"
         required
         [matDatepicker]="datePicker"
@@ -45,8 +47,8 @@
         class="activity-card"
         *ngFor="let event of filteredExistingEvents"
         [event]="event"
-        (click)="eventSelected.emit(event)"
         [recurring]="event.isNewFromActivity"
+        (click)="selectEvent(event)"
       >
       </app-activity-card>
     </div>

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.scss
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.scss
@@ -53,7 +53,5 @@ $bottom-control-padding: 16px;
 }
 
 .activity-card {
-  max-width: 500px;
-  display: contents;
   cursor: pointer;
 }

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -1,4 +1,10 @@
-import { Component, EventEmitter, OnInit, Output } from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  OnInit,
+  Output,
+  ViewChild,
+} from "@angular/core";
 import { AttendanceService } from "../../attendance.service";
 import { Note } from "../../../notes/model/note";
 import { EntityMapperService } from "../../../../core/entity/entity-mapper.service";
@@ -8,6 +14,9 @@ import { NoteDetailsComponent } from "../../../notes/note-details/note-details.c
 import { FormDialogService } from "../../../../core/form-dialog/form-dialog.service";
 import { FilterComponentSettings } from "../../../../core/entity-components/entity-list/filter-component.settings";
 import { FilterGeneratorService } from "../../../../core/entity-components/entity-list/filter-generator.service";
+import { AlertService } from "../../../../core/alerts/alert.service";
+import { AlertDisplay } from "../../../../core/alerts/alert-display";
+import { NgModel } from "@angular/forms";
 
 @Component({
   selector: "app-roll-call-setup",
@@ -28,6 +37,8 @@ export class RollCallSetupComponent implements OnInit {
 
   showingAll: boolean = false;
 
+  @ViewChild("dateField") dateField: NgModel;
+
   /**
    * filters are displayed in the UI only if at least this many events are listed.
    *
@@ -40,7 +51,8 @@ export class RollCallSetupComponent implements OnInit {
     private attendanceService: AttendanceService,
     private sessionService: SessionService,
     private formDialog: FormDialogService,
-    private filterGenerator: FilterGeneratorService
+    private filterGenerator: FilterGeneratorService,
+    private alertService: AlertService
   ) {}
 
   async ngOnInit() {
@@ -185,6 +197,14 @@ export class RollCallSetupComponent implements OnInit {
   ) {
     selectedFilter.selectedOption = optionKey;
     this.filterExistingEvents();
+  }
+
+  selectEvent(event: NoteForActivitySetup) {
+    if (this.dateField.valid) {
+      this.eventSelected.emit(event);
+    } else {
+      this.alertService.addWarning("Invalid Date", AlertDisplay.TEMPORARY);
+    }
   }
 }
 

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -203,7 +203,10 @@ export class RollCallSetupComponent implements OnInit {
     if (this.dateField.valid) {
       this.eventSelected.emit(event);
     } else {
-      this.alertService.addWarning("Invalid Date", AlertDisplay.TEMPORARY);
+      this.alertService.addWarning(
+        $localize`:Alert when selected date is invalid:Invalid Date`,
+        AlertDisplay.TEMPORARY
+      );
     }
   }
 }

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -182,8 +182,17 @@
         <note priority="1" from="meaning">Not listed</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="5765050500477761549" datatype="html">
+        <source>Invalid Date</source>
+        <target state="translated">Ungültiges Datum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts</context>
+          <context context-type="linenumber">207,206</context>
+        </context-group>
+        <note priority="1" from="description">Alert when selected date is invalid</note>
       </trans-unit>
       <trans-unit id="67beb29a599fc9ce9ea95f0407cc99ec5742573c" datatype="html">
         <source> Attendance completed. </source>
@@ -2895,12 +2904,12 @@
           <context context-type="linenumber">77,75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9c00f41dcd57e401bbfc793d515647b1a357df88" datatype="html">
-        <source>Date</source>
+      <trans-unit id="252cd5ef769c41f0160173268d14e13286e117f2" datatype="html">
+        <source>Date </source>
         <target state="translated">Datum</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">9,14</context>
+          <context context-type="linenumber">9,15</context>
         </context-group>
         <note priority="1" from="description">Record an event for a particular date that is to be
           inputted</note>
@@ -2909,20 +2918,20 @@
       <trans-unit id="a83874208b1b8fdf59818f3350613530e4a2f286" datatype="html">
         <source> Show less </source>
         <target state="translated"> Weniger anzeigen </target>
+        <note priority="1" from="description">Show less entries of a list</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">65,69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
-        <note priority="1" from="description">Show less entries of a list</note>
       </trans-unit>
       <trans-unit id="2bd16e97fe2b587c1bd3f4144a56edcb113c77fc" datatype="html">
         <source> Show more </source>
         <target state="translated"> Mehr anzeigen </target>
+        <note priority="1" from="description">Show more entries of a list</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">70,74</context>
+          <context context-type="linenumber">72</context>
         </context-group>
-        <note priority="1" from="description">Show more entries of a list</note>
       </trans-unit>
       <trans-unit id="8104421162933956065" datatype="html">
         <source>Notes</source>
@@ -4194,7 +4203,7 @@
         <note priority="1" from="description">Delete confirmation message</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">256</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6568368650313555376" datatype="html">
@@ -4203,7 +4212,7 @@
         <note priority="1" from="description">Record deleted info</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e26051095cf9572610ef63702b2260ae80f3b2d7" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -351,12 +351,12 @@
           <context context-type="linenumber">77,75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9c00f41dcd57e401bbfc793d515647b1a357df88" datatype="html">
-        <source>Date</source>
+      <trans-unit id="252cd5ef769c41f0160173268d14e13286e117f2" datatype="html">
+        <source>Date </source>
         <target state="translated">Date</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">9,14</context>
+          <context context-type="linenumber">9,15</context>
         </context-group>
         <note priority="1" from="description">Record an event for a particular date that is to be
           inputted</note>
@@ -365,20 +365,20 @@
       <trans-unit id="a83874208b1b8fdf59818f3350613530e4a2f286" datatype="html">
         <source> Show less </source>
         <target state="translated"> Afficher moins </target>
+        <note priority="1" from="description">Show less entries of a list</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">65,69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
-        <note priority="1" from="description">Show less entries of a list</note>
       </trans-unit>
       <trans-unit id="2bd16e97fe2b587c1bd3f4144a56edcb113c77fc" datatype="html">
         <source> Show more </source>
         <target state="translated"> Plus d'évènements </target>
+        <note priority="1" from="description">Show more entries of a list</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">70,74</context>
+          <context context-type="linenumber">72</context>
         </context-group>
-        <note priority="1" from="description">Show more entries of a list</note>
       </trans-unit>
       <trans-unit id="f715bc9f865bb754f70df0fb24d3182fd80c368d" datatype="html">
         <source> My event is not listed ... </source>
@@ -387,8 +387,17 @@
         <note priority="1" from="meaning">Not listed</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="5765050500477761549" datatype="html">
+        <source>Invalid Date</source>
+        <target state="new">Invalid Date</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts</context>
+          <context context-type="linenumber">207,206</context>
+        </context-group>
+        <note priority="1" from="description">Alert when selected date is invalid</note>
       </trans-unit>
       <trans-unit id="67beb29a599fc9ce9ea95f0407cc99ec5742573c" datatype="html">
         <source> Attendance completed. </source>
@@ -4153,7 +4162,7 @@
         <note priority="1" from="description">Record deleted info</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4295329798815830785" datatype="html">
@@ -4162,7 +4171,7 @@
         <note priority="1" from="description">Delete confirmation message</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">256</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e26051095cf9572610ef63702b2260ae80f3b2d7" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -318,11 +318,11 @@
           <context context-type="linenumber">77,75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9c00f41dcd57e401bbfc793d515647b1a357df88" datatype="html">
-        <source>Date</source>
+      <trans-unit id="252cd5ef769c41f0160173268d14e13286e117f2" datatype="html">
+        <source>Date </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">9,14</context>
+          <context context-type="linenumber">9,15</context>
         </context-group>
         <note priority="1" from="description">Record an event for a particular date that is to be
           inputted</note>
@@ -332,7 +332,7 @@
         <source> Show less </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">65,69</context>
+          <context context-type="linenumber">67,71</context>
         </context-group>
         <note priority="1" from="description">Show less entries of a list</note>
       </trans-unit>
@@ -340,7 +340,7 @@
         <source> Show more </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">70,74</context>
+          <context context-type="linenumber">72,76</context>
         </context-group>
         <note priority="1" from="description">Show more entries of a list</note>
       </trans-unit>
@@ -348,10 +348,18 @@
         <source> My event is not listed ... </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.html</context>
-          <context context-type="linenumber">81,86</context>
+          <context context-type="linenumber">83,88</context>
         </context-group>
         <note priority="1" from="description">Allows to create a new event</note>
         <note priority="1" from="meaning">Not listed</note>
+      </trans-unit>
+      <trans-unit id="5765050500477761549" datatype="html">
+        <source>Invalid Date</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts</context>
+          <context context-type="linenumber">207,206</context>
+        </context-group>
+        <note priority="1" from="description">Alert when selected date is invalid</note>
       </trans-unit>
       <trans-unit id="67beb29a599fc9ce9ea95f0407cc99ec5742573c" datatype="html">
         <source> Attendance completed. </source>
@@ -3680,7 +3688,7 @@
         <source>Record deleted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">255,254</context>
+          <context context-type="linenumber">260,259</context>
         </context-group>
         <note priority="1" from="description">Record deleted info</note>
       </trans-unit>
@@ -3688,7 +3696,7 @@
         <source>Are you sure you want to delete this record?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts</context>
-          <context context-type="linenumber">256</context>
+          <context context-type="linenumber">261</context>
         </context-group>
         <note priority="1" from="description">Delete confirmation message</note>
       </trans-unit>


### PR DESCRIPTION
see issue: #1119 

### Visible/Frontend Changes
- [x] When the date is not set or otherwise invalid, a user can no longer record an attendance

### Architectural/Backend Changes
None
