### PR TITLE
feat: multi select configurable enum

### DIFF
--- a/doc/compodoc_sources/concepts/configuration.md
+++ b/doc/compodoc_sources/concepts/configuration.md
@@ -43,7 +43,7 @@ Config is currently stored in the normal app database with the fixed _id `"_id":
 This document in the database has to contain a single property `data` that holds the config object whose parts are described here.
 
 Example:
-```
+```json
 {
   "_id": "Config:CONFIG_ENTITY",
   "data": {
@@ -75,25 +75,25 @@ The top level entry `navigationMenu` builds the visible and clickable items for 
 Each navigation menu item object has to have the three properties `name`, `icon` and `link`. `name` hold the inscription of the item in the navigation menu in the app, `icon` indicates the little icon picture that is shown before the textual inscription of the item in the navigation menu and `link` contains the URL or view that the user is directed to when clicking on the navigation menu item. For every link given, there necessarily has to be a corresponding view-entry on the top level of the config file.
 
 Example:
-```
+```json
   "navigationMenu": {
     "items": [
-        {
-            "name": "Dashboard",
-            "icon": "home",
-            "link": "/"
-        },
-        {
-            "name": "Children",
-            "icon": "child",
-            "link": "/child"
-        },
-        ...
-        {
-            "name": "Help",
-            "icon": "question-circle",
-            "link": "/help"
-        }
+      {
+        "name": "Dashboard",
+        "icon": "home",
+        "link": "/"
+      },
+      {
+        "name": "Children",
+        "icon": "child",
+        "link": "/child"
+      },
+      ...
+      {
+        "name": "Help",
+        "icon": "question-circle",
+        "link": "/help"
+      }
     ]
   },
 ```
@@ -118,25 +118,25 @@ The Dashboard-Component for example takes as `"widgets:"` an array of subcompone
 
 Example:
 
-```
+```json
 "view:": {
-    "component": "Dashboard",
-    "config": {
-      "widgets": [
-        {
-            "component": "ChildrenCountDashboard"
-        },
-        {
-            "component": "RecentNotesDashboard"
-        },
-        {
-            "component": "NoRecentNotesDashboard",
-            "config": {
-                "sinceDays": 28,
-                "fromBeginningOfWeek": false
-        }
-        },
-        ...
+  "component": "Dashboard",
+  "config": {
+    "widgets": [
+      {
+        "component": "ChildrenCountDashboard"
+      },
+      {
+        "component": "RecentNotesDashboard"
+      },
+      {
+        "component": "NoRecentNotesDashboard",
+        "config": {
+          "sinceDays": 28,
+          "fromBeginningOfWeek": false
+      }
+      },
+      ...
 ```
 
 #### List components
@@ -150,19 +150,19 @@ The configuration for the columns happens with the [FormFieldConfiguration](../.
 If all the information is available on the schema or through the datatype of a property, it is sufficient to put a string with the name of the property into the columns array.
 
 Example:
-```
+```json
 "view:child": {
-    "component": "ChildrenList",
-    "config": {
-        "title": "Children List",
-        "columns": [
-          "projectNumber",
-          {
-            "view": "ChildBlock",
-            "label": "Name",
-            "id": "name"
-          },
-            ...
+  "component": "ChildrenList",
+  "config": {
+    "title": "Children List",
+    "columns": [
+      "projectNumber",
+      {
+        "view": "ChildBlock",
+        "label": "Name",
+        "id": "name"
+      },
+        ...
 ```
 
 The `"columnGroup"` object holds the three properties `"default"`, `"mobile"` and `"groups"`.
@@ -173,28 +173,28 @@ If `"default"` or `"mobile"` is not defined, the first entry of `"groups"` will 
 Properties that are listed in any of the `groups` arrays and don't require further configurations, can be omitted from the `columns` array, the `EntityListComponent` will automatically add them.
 
 Example:
-```
-        "columnGroup": {
-            "default": "School Info",
-            "mobile": "Mobile",
-            "groups": [
-            {
-                "name": "Basic Info",
-                "columns": [
-                    "projectNumber",
-                    "name",
-                    ...
-                    "status"
-                ]
-            },
-            {
-                "name": "School Info",
-                "columns": [
-                    "projectNumber",
-                    "name",
-                    ...
-                ]
-            },
+```json
+"columnGroup": {
+  "default": "School Info",
+  "mobile": "Mobile",
+  "groups": [
+  {
+    "name": "Basic Info",
+    "columns": [
+      "projectNumber",
+      "name",
+      ...
+      "status"
+    ]
+  },
+  {
+    "name": "School Info",
+    "columns": [
+      "projectNumber",
+      "name",
+      ...
+    ]
+  },
 
 ```
 
@@ -207,23 +207,23 @@ The prebuilt option is used to enable or disable filters that contain more logic
 This option requires the fields `"type"` and `"id"`, where `"id"` matched the `id` of a prebuilt filter inside a component.
 
 Example:
-```
-        "filters": [
-                {
-                    "id": "language"
-                },
-                {
-                    "id": "privateSchool",
-                    "default": "all",
-                    "true": "Private School",
-                    "false": "Government School",
-                    "all": "All"
-                },
-                {
-                  "id": "date",
-                  "type": "prebuilt"
-                },
-        ]
+```json
+"filters": [
+  {
+    "id": "language"
+  },
+  {
+    "id": "privateSchool",
+    "default": "all",
+    "true": "Private School",
+    "false": "Government School",
+    "all": "All"
+  },
+  {
+    "id": "date",
+    "type": "prebuilt"
+  },
+]
 ```
 
 #### Detail components
@@ -240,7 +240,7 @@ The entity will then be loaded using the entity name and the id which is read fr
 The `"panels"` field expects an array of panel definitions.
 Each panel has a `"title"` and an array of `"components"`.
 The component configuration requires another `"title"`, the `"component"` that should be rendered (the component has to be defined here [OnInitDynamicComponent](../../interfaces/OnInitDynamicComponent.html)) and a configuration (`"config"`) which is passed to this component.
-```
+```json
     "config": {
       "icon": "child",
       "entity": "Child",
@@ -282,7 +282,7 @@ The definitions for the columns is defined by the [FormFieldConfiguration](../..
 However, the schema definitions of the entity should be sufficient so that only the names of the properties which should be editable in the form have to be provided.
 This means instead of placing an object in the `cols` array, simple strings do the same job.
 
-```
+```json
   "config": {
     "cols": [
       [
@@ -309,7 +309,7 @@ This should only be set to  `true`, when the use-case only allows one active sch
 The configuration is according to the [EntitySubrecordComponent](../how-to-guides/entity-subrecord-component.md);
 
 Example:
-```
+```json
   "config": {
     "single": true,
     "columns": [
@@ -331,7 +331,7 @@ The attribute field allows to add attributes to an entity:
 Each attribute requires a `"name"` and a `"schema"` which refers to the entity [schemas](entity-schema-system.md).
 
 Example:
-```
+```json
 "entity:Child": {
     "attributes": [
         {"name": "address", "schema": { "dataType": "string", "label": "Address" } },
@@ -348,7 +348,7 @@ Permissions for interaction on entities can be given or denied using the config.
 This will disable buttons in the app to create, delete or edit entities if the user is not permitted.
 
 The following example will only allow `admin` users to create, edit and delete `School` objects:
-```
+```json
 "entity:School": {
   "permissions": {
     "create": ["admin"],
@@ -358,7 +358,7 @@ The following example will only allow `admin` users to create, edit and delete `
 }
 ```
 Buttons can be marked as part of an interaction using the `appDisableEntityInteraction` directive:
-```
+```html
 <button
   (click)="switchEdit()"
   *appDisableEntityOperation="{entity: entity?.getConstructor(), operation: operationType.UPDATE}"
@@ -379,7 +379,7 @@ The `"id"` should always stay the same as it is written to the database and iden
 This text may be changed without any negative effect to data consistency and the change will instantly be visible in all saved entries of this type.
 
 Example:
-```
+```json
 "enum:project-status": [
     {
         "id": "ACTIVE",
@@ -401,7 +401,7 @@ Example:
 In order to use such an "enum" in entity fields, you need to set the schema datatype and the form type in the according config objects:
 
 In the entity, set the dataType to "configurable-enum" and the "innerDataType" to the id of the enum config:
-```
+```json
 "entity:Child": {
   {"name": "status", "schema": { "dataType": "configurable-enum", "innerDataType": "project-status"  } }
   ...
@@ -410,7 +410,7 @@ In the entity, set the dataType to "configurable-enum" and the "innerDataType" t
 #### Display a configurable enum property in the list view
 
 In the List View columns config, use the "DisplayConfigurableEnum" component for the field:
-```
+```json
 "columns": [
   {
     "component": "DisplayConfigurableEnum",
@@ -425,7 +425,7 @@ In the List View columns config, use the "DisplayConfigurableEnum" component for
 
 In the Details View config for a "Form" component, use the "configurable-enum-select" input type
 and additionally define the "enumId" of the enum config it refers to:
-```
+```json
 "component": "Form",
 "config": {
   "cols": [
@@ -435,9 +435,29 @@ and additionally define the "enumId" of the enum config it refers to:
         "input": "configurable-enum-select",
         "enumId": "project-status",
         "placeholder": "Status"
-      },
+      }
+    ]
+  ]
+}
 ```
 
+#### Allowing multi select
+
+A property can also be defined in a way that multiple values can be selected.
+To all multiple selection, the `dataType` needs to be `array`, the `innerDataType` `configurable-enum` and the name of the configurable enum has to be in the `additional` field.
+The following example creates a property `materials` where multiple values from the `materials` configurable enum can be selected.
+
+```json
+{
+  "name": "materials",
+  "schema": {
+    "dataType": "array",
+    "innerDataType": "configurable-enum",
+    "additional": "materials",
+    "label": "Materials"
+  }
+}
+```
 
 #### Defining Note interaction types
 There are a few specially built-in types of enums.

--- a/doc/compodoc_sources/concepts/configuration.md
+++ b/doc/compodoc_sources/concepts/configuration.md
@@ -393,7 +393,7 @@ Example:
         "id": "DROPPED",
         "label": "dropped out of the programme"
     }
-}
+]
 ```
 
 #### Defining configurable enum properties
@@ -444,7 +444,7 @@ and additionally define the "enumId" of the enum config it refers to:
 #### Allowing multi select
 
 A property can also be defined in a way that multiple values can be selected.
-To all multiple selection, the `dataType` needs to be `array`, the `innerDataType` `configurable-enum` and the name of the configurable enum has to be in the `additional` field.
+To allow multiple selection, the `dataType` needs to be `array`, the `innerDataType` `configurable-enum` and the name of the configurable enum has to be in the `additional` field.
 The following example creates a property `materials` where multiple values from the `materials` configurable enum can be selected.
 
 ```json

--- a/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.spec.ts
+++ b/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.spec.ts
@@ -38,6 +38,11 @@ describe("ConfigurableEnumDatatype", () => {
       innerDataType: "test-enum",
     })
     option: ConfigurableEnumValue;
+    @DatabaseField({
+      dataType: "configurable-enum",
+      additional: "test-enum",
+    })
+    optionInAdditional: ConfigurableEnumValue;
   }
 
   let entitySchemaService: EntitySchemaService;
@@ -94,5 +99,18 @@ describe("ConfigurableEnumDatatype", () => {
     const rawData = entitySchemaService.transformEntityToDatabaseFormat(entity);
 
     expect(rawData.option).toEqual(testOptionKey);
+  });
+
+  it("should also support the name of the enum in the 'additional' field", () => {
+    const data = {
+      _id: "Test",
+      optionInAdditional: "TEST_3",
+    };
+    const entity = new TestEntity();
+
+    entitySchemaService.loadDataIntoEntity(entity, data);
+
+    expect(entity.optionInAdditional).toEqual(TEST_CONFIG[2]);
+    expect(entity.getId()).toBe("Test");
   });
 });

--- a/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
+++ b/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
@@ -32,7 +32,10 @@ export class ConfigurableEnumDatatype
     value: string,
     schemaField: EntitySchemaField
   ): ConfigurableEnumValue {
-    let enumId = schemaField.innerDataType;
+    const isInnerDataType = schemaField.innerDataType === this.name;
+    let enumId = isInnerDataType
+      ? schemaField.additional
+      : schemaField.innerDataType;
     if (!enumId.startsWith(CONFIGURABLE_ENUM_CONFIG_PREFIX)) {
       enumId = CONFIGURABLE_ENUM_CONFIG_PREFIX + enumId;
     }

--- a/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
+++ b/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.ts
@@ -32,10 +32,7 @@ export class ConfigurableEnumDatatype
     value: string,
     schemaField: EntitySchemaField
   ): ConfigurableEnumValue {
-    const isInnerDataType = schemaField.innerDataType === this.name;
-    let enumId = isInnerDataType
-      ? schemaField.additional
-      : schemaField.innerDataType;
+    let enumId = schemaField.additional || schemaField.innerDataType;
     if (!enumId.startsWith(CONFIGURABLE_ENUM_CONFIG_PREFIX)) {
       enumId = CONFIGURABLE_ENUM_CONFIG_PREFIX + enumId;
     }

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
@@ -1,14 +1,14 @@
-<!--<mat-form-field [formGroup]="formControl.parent">-->
-<!--  <mat-label>-->
-<!--    {{ label }}-->
-<!--  </mat-label>-->
-<!--  <mat-select [formControlName]="formControlName">-->
-<!--    <mat-option *appConfigurableEnum="let o of enumId" [value]="o">-->
-<!--      {{ o.label }}-->
-<!--    </mat-option>-->
-<!--  </mat-select>-->
-<!--  <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">-->
-<!--    This field is required-->
-<!--  </mat-error>-->
-<!--</mat-form-field>-->
+<mat-form-field [formGroup]="formControl.parent">
+  <mat-label>
+    {{ label }}
+  </mat-label>
+  <mat-select [formControlName]="formControlName" [multiple]="multi">
+    <mat-option *appConfigurableEnum="let o of enumId" [value]="o">
+      {{ o.label }}
+    </mat-option>
+  </mat-select>
+  <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">
+    This field is required
+  </mat-error>
+</mat-form-field>
 

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.html
@@ -1,14 +1,14 @@
-<mat-form-field [formGroup]="formControl.parent">
-  <mat-label>
-    {{ label }}
-  </mat-label>
-  <mat-select [formControlName]="formControlName">
-    <mat-option *appConfigurableEnum="let o of enumId" [value]="o">
-      {{ o.label }}
-    </mat-option>
-  </mat-select>
-  <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">
-    This field is required
-  </mat-error>
-</mat-form-field>
+<!--<mat-form-field [formGroup]="formControl.parent">-->
+<!--  <mat-label>-->
+<!--    {{ label }}-->
+<!--  </mat-label>-->
+<!--  <mat-select [formControlName]="formControlName">-->
+<!--    <mat-option *appConfigurableEnum="let o of enumId" [value]="o">-->
+<!--      {{ o.label }}-->
+<!--    </mat-option>-->
+<!--  </mat-select>-->
+<!--  <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">-->
+<!--    This field is required-->
+<!--  </mat-error>-->
+<!--</mat-form-field>-->
 

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.ts
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.ts
@@ -5,6 +5,7 @@ import {
 } from "../../entity-components/entity-utils/dynamic-form-components/edit-component";
 import { ConfigurableEnumValue } from "../configurable-enum.interface";
 import { DynamicComponent } from "../../view/dynamic-components/dynamic-component.decorator";
+import { arrayEntitySchemaDatatype } from "../../entity/schema-datatypes/datatype-array";
 
 @DynamicComponent("EditConfigurableEnum")
 @Component({
@@ -14,9 +15,13 @@ import { DynamicComponent } from "../../view/dynamic-components/dynamic-componen
 })
 export class EditConfigurableEnumComponent extends EditComponent<ConfigurableEnumValue> {
   enumId: string;
+  multi = false;
 
   onInitFromDynamicConfig(config: EditPropertyConfig) {
     super.onInitFromDynamicConfig(config);
+    if (config.propertySchema.dataType === arrayEntitySchemaDatatype.name) {
+      this.multi = true;
+    }
     this.enumId =
       config.formFieldConfig.additional ||
       config.propertySchema.additional ||

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.ts
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.ts
@@ -18,6 +18,8 @@ export class EditConfigurableEnumComponent extends EditComponent<ConfigurableEnu
   onInitFromDynamicConfig(config: EditPropertyConfig) {
     super.onInitFromDynamicConfig(config);
     this.enumId =
-      config.formFieldConfig.additional || config.propertySchema.innerDataType;
+      config.formFieldConfig.additional ||
+      config.propertySchema.additional ||
+      config.propertySchema.innerDataType;
   }
 }

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -37,7 +37,6 @@ export class EntityFormComponent implements OnInit {
    * @param columns The columns which should be displayed
    */
   @Input() set columns(columns: (FormFieldConfig | string)[][]) {
-    console.log("called", columns);
     this._columns = columns.map((row) =>
       row.map((field) => {
         if (typeof field === "string") {

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -37,6 +37,7 @@ export class EntityFormComponent implements OnInit {
    * @param columns The columns which should be displayed
    */
   @Input() set columns(columns: (FormFieldConfig | string)[][]) {
+    console.log("called", columns);
     this._columns = columns.map((row) =>
       row.map((field) => {
         if (typeof field === "string") {
@@ -106,6 +107,7 @@ export class EntityFormComponent implements OnInit {
       flattenedFormFields,
       this.entity
     );
+    console.log("config", flattenedFormFields);
     this.form = this.entityFormService.createFormGroup(
       flattenedFormFields,
       this.entity

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -107,7 +107,6 @@ export class EntityFormComponent implements OnInit {
       flattenedFormFields,
       this.entity
     );
-    console.log("config", flattenedFormFields);
     this.form = this.entityFormService.createFormGroup(
       flattenedFormFields,
       this.entity

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
@@ -114,5 +114,7 @@ const Template: Story<EntityFormComponent> = (args: EntityFormComponent) => ({
 export const Primary = Template.bind({});
 Primary.args = {
   entity: new Child(),
+  columns: cols,
+  _columns: cols,
   creatingNew: true,
 };

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
@@ -114,6 +114,7 @@ const Template: Story<EntityFormComponent> = (args: EntityFormComponent) => ({
 export const Primary = Template.bind({});
 Primary.args = {
   entity: new Child(),
+  // Both need to be set otherwise story breaks
   columns: cols,
   _columns: cols,
   creatingNew: true,

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
@@ -84,7 +84,7 @@ const cols = [
       label: "Assigned school(s)",
     },
   ],
-  ["school"],
+  ["school", "configurable-enum-array"],
 ];
 
 Child.schema.set("has_rationCard", {
@@ -98,6 +98,12 @@ Child.schema.set("school", {
   additional: School.ENTITY_TYPE,
   viewComponent: "DisplayEntity",
   editComponent: "EditSingleEntity",
+});
+Child.schema.set("configurable-enum-array", {
+  dataType: "array",
+  innerDataType: "configurable-enum",
+  additional: "document-status",
+  label: "Enum Multi Select",
 });
 
 const Template: Story<EntityFormComponent> = (args: EntityFormComponent) => ({

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.stories.ts
@@ -84,7 +84,7 @@ const cols = [
       label: "Assigned school(s)",
     },
   ],
-  ["school", "configurable-enum-array"],
+  [{ id: "school" }, { id: "configurable-enum-array" }],
 ];
 
 Child.schema.set("has_rationCard", {
@@ -114,6 +114,5 @@ const Template: Story<EntityFormComponent> = (args: EntityFormComponent) => ({
 export const Primary = Template.bind({});
 Primary.args = {
   entity: new Child(),
-  columns: cols,
   creatingNew: true,
 };

--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -237,7 +237,7 @@ describe("EntitySchemaService", () => {
     expect(displayComponent).toEqual("DisplayText");
   });
 
-  it("should return the display and edit component for the innerDataType if dataType  is array", () => {
+  it("should return the display and edit component for the innerDataType if dataType is array", () => {
     class TestEntity extends Entity {
       @DatabaseField({ innerDataType: dateOnlyEntitySchemaDatatype.name })
       dates: Date[];

--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -20,6 +20,7 @@ import { waitForAsync } from "@angular/core/testing";
 import { EntitySchemaService } from "./entity-schema.service";
 import { DatabaseField } from "../database-field.decorator";
 import { EntitySchemaDatatype } from "./entity-schema-datatype";
+import { dateOnlyEntitySchemaDatatype } from "../schema-datatypes/datatype-date-only";
 
 describe("EntitySchemaService", () => {
   let entitySchemaService: EntitySchemaService;
@@ -234,5 +235,25 @@ describe("EntitySchemaService", () => {
     );
 
     expect(displayComponent).toEqual("DisplayText");
+  });
+
+  it("should return the display and edit component for the innerDataType if dataType  is array", () => {
+    class TestEntity extends Entity {
+      @DatabaseField({ innerDataType: dateOnlyEntitySchemaDatatype.name })
+      dates: Date[];
+    }
+    const propertySchema = TestEntity.schema.get("dates");
+
+    const displayComponent = entitySchemaService.getComponent(
+      propertySchema,
+      "view"
+    );
+    expect(displayComponent).toBe(dateOnlyEntitySchemaDatatype.viewComponent);
+
+    const editComponent = entitySchemaService.getComponent(
+      propertySchema,
+      "edit"
+    );
+    expect(editComponent).toBe(dateOnlyEntitySchemaDatatype.editComponent);
   });
 });

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -198,9 +198,20 @@ export class EntitySchemaService {
     }
     const componentAttribute =
       mode === "view" ? "viewComponent" : "editComponent";
-    return (
-      propertySchema[componentAttribute] ||
-      this.getDatatypeOrDefault(propertySchema.dataType)[componentAttribute]
+    if (propertySchema[componentAttribute]) {
+      return propertySchema[componentAttribute];
+    }
+
+    const dataType = this.getDatatypeOrDefault(propertySchema.dataType);
+    if (dataType?.[componentAttribute]) {
+      return dataType[componentAttribute];
+    }
+
+    const innerDataType = this.getDatatypeOrDefault(
+      propertySchema.innerDataType
     );
+    if (innerDataType?.[componentAttribute]) {
+      return innerDataType[componentAttribute];
+    }
   }
 }

--- a/src/app/core/latest-changes/update-manager.service.ts
+++ b/src/app/core/latest-changes/update-manager.service.ts
@@ -98,9 +98,8 @@ export class UpdateManagerService {
   }
 
   private showUpdateNotification() {
-    const currentVersion = window.localStorage.getItem(
-      LatestChangesDialogService.VERSION_KEY
-    );
+    const currentVersion =
+      window.localStorage.getItem(LatestChangesDialogService.VERSION_KEY) || "";
     if (currentVersion.startsWith(this.UPDATE_PREFIX)) {
       // Sometimes this is triggered multiple times for one update
       return;


### PR DESCRIPTION
It's now possible to have configurable enums where multiple values can be selected.
This is according to angular materials [multi-select](https://material.angular.io/components/select/overview#multiple-selection) feature for the select component.

### Visible/Frontend Changes
- [x] Added multiple selection support to select dropdown

### Architectural/Backend Changes
- [x] name of configurable enum can be in `innerDataType` **or** `additional`
- [x] added documentation for multiple select configurable enum
- [x] Fixed entity-form story
