### PR TITLE
Custom Exception 

### DIFF
--- a/src/app/core/database/pouch-database.spec.ts
+++ b/src/app/core/database/pouch-database.spec.ts
@@ -215,45 +215,4 @@ describe("PouchDatabase tests", () => {
     expect(result).toEqual(testQueryResults);
     expect(pouchDB.query).toHaveBeenCalledWith(testQuery, {});
   });
-
-  it("should log the ID when requesting a not existing entity", async () => {
-    const notExistingId = "Not-existing-id";
-    return expectPromiseToRejectWithDocId(
-      database.get(notExistingId),
-      notExistingId
-    );
-  });
-
-  it("should log the ID when putting a doc with wrong rev", async () => {
-    const doc = {
-      _id: "someId",
-      _rev: "1-invalidRev",
-    };
-    return expectPromiseToRejectWithDocId(database.put(doc), doc._id);
-  });
-
-  it("should log the ID when removing a not existing doc", () => {
-    const notExistingDoc = {
-      _id: "not_existing_id",
-      _rev: "1-someRev",
-    };
-    return expectPromiseToRejectWithDocId(
-      database.remove(notExistingDoc),
-      notExistingDoc._id
-    );
-  });
-
-  it("should log the view name when querying a not existing view", () => {
-    const notExistingView = "search_index/by_name";
-    return expectPromiseToRejectWithDocId(
-      database.query(notExistingView, {}),
-      notExistingView
-    );
-  });
-
-  function expectPromiseToRejectWithDocId(prom: Promise<any>, id: string) {
-    return prom
-      .then(() => fail())
-      .catch((e) => expect(e.affectedDocument).toBe(id));
-  }
 });

--- a/src/app/core/database/pouch-database.ts
+++ b/src/app/core/database/pouch-database.ts
@@ -104,15 +104,18 @@ export class PouchDatabase extends Database {
    * @param options PouchDB options object as in the normal PouchDB library
    */
   allDocs(options?: GetAllOptions) {
-    return this._pouchDB.allDocs(options).then((result) => {
-      const resultArray = [];
-      for (const row of result.rows) {
-        resultArray.push(row.doc);
-      }
-      return resultArray;
-    }).catch((err) => {
-      throw new DatabaseException(err)
-    });
+    return this._pouchDB
+      .allDocs(options)
+      .then((result) => {
+        const resultArray = [];
+        for (const row of result.rows) {
+          resultArray.push(row.doc);
+        }
+        return resultArray;
+      })
+      .catch((err) => {
+        throw new DatabaseException(err);
+      });
   }
 
   /**


### PR DESCRIPTION
Digging deeper into the problem already mentioned in #1178 it turns out that PouchDB exceptions have a `toString()` method which does only includes **some** parts of the exception object. 
By using a own object rather than the PouchDB one this has been changed so **all** properties are logged.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Transforming PouchDB errors to own `DatabaseException` class
