### PR TITLE
NGINX redirect to default language

### DIFF
--- a/build/default.conf
+++ b/build/default.conf
@@ -31,7 +31,7 @@ server {
 
     # Set the default language when nothing is entered in the url
     location / {
-        try_files $uri /${DEFAULT_LANGUAGE}/index.html;
+        return 301 /${DEFAULT_LANGUAGE}$request_uri;
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
see issue: #XX

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Client is redirected to url of default language instead of directly serving `index.html` file for the default locale
