### PR TITLE
Refactor open dialog

### DIFF
--- a/doc/compodoc_sources/how-to-guides/dialogs-notifications.md
+++ b/doc/compodoc_sources/how-to-guides/dialogs-notifications.md
@@ -8,31 +8,29 @@ Before executing an action with far-reaching consequences (e.g. deleting an enti
 you should request explicit confirmation from the user through a confirmation dialog box.
 To reduce boiler-plate code for this, you can use the [ConfirmationDialogService](../../injectables/ConfirmationDialogService.html):
 
-```
+```javascript
 constructor(private confirmationDialog: ConfirmationDialogService) {}
 ```
 
 The service is a wrapper for [MatDialog](https://material.angular.io/components/dialog/overview).
 Use it to open a dialog box with your text:
-```
-const dialogRef = this.confirmationDialog
-  .openDialog('Delete?', 'Are you sure you want to delete this Child?');
+```javascript
+const confirmed = await this.confirmationDialog
+  .getConfirmation('Delete?', 'Are you sure you want to delete this Child?');
 ```
 
 You can then react to the user action (whether "Yes" or "No" was clicked):
-```
-dialogRef.afterClosed().subscribe(confirmed => {
-  if (confirmed) {
-    // do something
-  }
-});
+```javascript
+if (confirmed) {
+  // do something
+}
 ```
 
 You can also display dialogs with only one "OK" button rather than the yes/no option
 by setting the optional 'buttons' parameter:
-```
+```javascript
 this.confirmationDialog
-  .openDialog('Info', 'No options here, just some text.', OkButton);
+  .getConfirmation('Info', 'No options here, just some text.', OkButton);
 ```
 In this case also consider whether you really want to use a "blocking" dialog box
 or if a simple "alert" notification may be the better choice.
@@ -46,7 +44,7 @@ You can display a short notification text to the user in an non-disrupting way u
 This will show a small hovering notification box towards the bottom of the screen
 (through [MatSnackBar](https://material.angular.io/components/snack-bar/api)):
 
-```
+```javascript
 constructor(private alertService: AlertService) {
   this.alertService.addInfo('info message');
   this.alertService.addWarning('warning message');

--- a/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/add-day-attendance.component.ts
@@ -74,7 +74,7 @@ export class AddDayAttendanceComponent {
 
   exit() {
     if (this.rollCallComponent?.isDirty) {
-      this.confirmationDialog.openDialog(
+      this.confirmationDialog.getConfirmation(
         $localize`:Exit from the current screen:Exit`,
         $localize`Do you want to save your progress before going back?`,
         this.buttons,

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -158,12 +158,12 @@ describe("RollCallComponent", () => {
 
   it("should not open the dialog when the roll call is finished", () => {
     const confirmationDialogService = TestBed.inject(ConfirmationDialogService);
-    spyOn(confirmationDialogService, "openDialog");
+    spyOn(confirmationDialogService, "getConfirmation");
     spyOnProperty(component, "isFinished").and.returnValue(true);
 
     component.finish();
 
-    expect(confirmationDialogService.openDialog).not.toHaveBeenCalled();
+    expect(confirmationDialogService.getConfirmation).not.toHaveBeenCalled();
   });
 
   it("isn't dirty initially", () => {

--- a/src/app/conflict-resolution/compare-rev/compare-rev.component.spec.ts
+++ b/src/app/conflict-resolution/compare-rev/compare-rev.component.spec.ts
@@ -14,7 +14,6 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ConfirmationDialogService } from "../../core/confirmation-dialog/confirmation-dialog.service";
 import { Database } from "../../core/database/database";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
-import { BehaviorSubject } from "rxjs";
 import { AutoResolutionService } from "../auto-resolution/auto-resolution.service";
 
 describe("CompareRevComponent", () => {
@@ -43,11 +42,10 @@ describe("CompareRevComponent", () => {
         false
       );
 
-      const confDialogMock = {
-        // by default immediately simulate a confirmed dialog result
-        openDialog: () => ({ afterClosed: () => new BehaviorSubject(true) }),
-      };
-      spyOn(confDialogMock, "openDialog").and.callThrough();
+      const confDialogMock = jasmine.createSpyObj<ConfirmationDialogService>([
+        "openDialog",
+      ]);
+      confDialogMock.openDialog.and.resolveTo(true);
 
       TestBed.configureTestingModule({
         imports: [

--- a/src/app/conflict-resolution/compare-rev/compare-rev.component.spec.ts
+++ b/src/app/conflict-resolution/compare-rev/compare-rev.component.spec.ts
@@ -43,9 +43,9 @@ describe("CompareRevComponent", () => {
       );
 
       const confDialogMock = jasmine.createSpyObj<ConfirmationDialogService>([
-        "openDialog",
+        "getConfirmation",
       ]);
-      confDialogMock.openDialog.and.resolveTo(true);
+      confDialogMock.getConfirmation.and.resolveTo(true);
 
       TestBed.configureTestingModule({
         imports: [

--- a/src/app/conflict-resolution/compare-rev/compare-rev.component.ts
+++ b/src/app/conflict-resolution/compare-rev/compare-rev.component.ts
@@ -90,22 +90,20 @@ export class CompareRevComponent {
    * Resolve the displayed conflict by deleting the conflicting revision doc and keeping the current doc.
    * @param docToDelete Document to be deleted
    */
-  public resolveByDelete(docToDelete: any) {
-    const dialogRef = this.confirmationDialog.openDialog(
+  public async resolveByDelete(docToDelete: any) {
+    const confirmed = await this.confirmationDialog.openDialog(
       $localize`Delete Conflicting Version?`,
       $localize`Are you sure you want to keep the current version and delete this conflicting version? ${this.stringify(
         docToDelete
       )}`
     );
 
-    dialogRef.afterClosed().subscribe(async (confirmed) => {
-      if (confirmed) {
-        const success = await this.deleteDoc(docToDelete);
-        if (success) {
-          this.resolution = $localize`deleted conflicting version`;
-        }
+    if (confirmed) {
+      const success = await this.deleteDoc(docToDelete);
+      if (success) {
+        this.resolution = $localize`deleted conflicting version`;
       }
-    });
+    }
   }
 
   private async deleteDoc(docToDelete: any): Promise<boolean> {
@@ -150,24 +148,22 @@ export class CompareRevComponent {
 
     const newChanges = diff(originalDoc, this.doc);
 
-    const dialogRef = this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.openDialog(
       $localize`Save Changes for Conflict Resolution?`,
       $localize`Are you sure you want to save the following changes and delete the conflicting version? ${this.stringify(
         newChanges
       )}`
     );
-    dialogRef.afterClosed().subscribe(async (confirmed) => {
-      if (confirmed) {
-        const successSave = await this.saveDoc(this.doc);
-        const successDel = await this.deleteDoc(this.revDoc);
-        if (successSave && successDel) {
-          if (diffStringToApply === this.diffs) {
-            this.resolution = $localize`selected conflicting version`;
-          } else {
-            this.resolution = $localize`resolved manually`;
-          }
+    if (confirmed) {
+      const successSave = await this.saveDoc(this.doc);
+      const successDel = await this.deleteDoc(this.revDoc);
+      if (successSave && successDel) {
+        if (diffStringToApply === this.diffs) {
+          this.resolution = $localize`selected conflicting version`;
+        } else {
+          this.resolution = $localize`resolved manually`;
         }
       }
-    });
+    }
   }
 }

--- a/src/app/conflict-resolution/compare-rev/compare-rev.component.ts
+++ b/src/app/conflict-resolution/compare-rev/compare-rev.component.ts
@@ -91,7 +91,7 @@ export class CompareRevComponent {
    * @param docToDelete Document to be deleted
    */
   public async resolveByDelete(docToDelete: any) {
-    const confirmed = await this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.getConfirmation(
       $localize`Delete Conflicting Version?`,
       $localize`Are you sure you want to keep the current version and delete this conflicting version? ${this.stringify(
         docToDelete
@@ -148,7 +148,7 @@ export class CompareRevComponent {
 
     const newChanges = diff(originalDoc, this.doc);
 
-    const confirmed = await this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.getConfirmation(
       $localize`Save Changes for Conflict Resolution?`,
       $localize`Are you sure you want to save the following changes and delete the conflicting version? ${this.stringify(
         newChanges

--- a/src/app/core/admin/admin/admin.component.spec.ts
+++ b/src/app/core/admin/admin/admin.component.spec.ts
@@ -11,8 +11,6 @@ import { BackupService } from "../services/backup.service";
 import { AppConfig } from "../../app-config/app-config";
 import { ConfigService } from "../../config/config.service";
 import { ConfirmationDialogService } from "../../confirmation-dialog/confirmation-dialog.service";
-import { of } from "rxjs";
-import { MatDialogRef } from "@angular/material/dialog";
 import { SessionType } from "../../session/session-type";
 import { AdminModule } from "../admin.module";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
@@ -21,17 +19,19 @@ describe("AdminComponent", () => {
   let component: AdminComponent;
   let fixture: ComponentFixture<AdminComponent>;
 
-  const mockConfigService: jasmine.SpyObj<ConfigService> = jasmine.createSpyObj(
-    ConfigService,
-    ["exportConfig", "saveConfig", "loadConfig"]
-  );
-  const mockBackupService: jasmine.SpyObj<BackupService> = jasmine.createSpyObj(
-    BackupService,
-    ["getJsonExport", "getCsvExport", "clearDatabase", "importJson"]
-  );
+  const mockConfigService = jasmine.createSpyObj<ConfigService>([
+    "exportConfig",
+    "saveConfig",
+    "loadConfig",
+  ]);
+  const mockBackupService = jasmine.createSpyObj<BackupService>([
+    "getJsonExport",
+    "getCsvExport",
+    "clearDatabase",
+    "importJson",
+  ]);
 
-  const confirmationDialogMock: jasmine.SpyObj<ConfirmationDialogService> = jasmine.createSpyObj(
-    ConfirmationDialogService,
+  const confirmationDialogMock = jasmine.createSpyObj<ConfirmationDialogService>(
     ["openDialog"]
   );
 
@@ -51,15 +51,6 @@ describe("AdminComponent", () => {
     // mock FileReader constructor
     spyOn(window, "FileReader").and.returnValue(mockFileReader);
     return mockFileReader;
-  }
-
-  function createDialogMock(): jasmine.SpyObj<MatDialogRef<any>> {
-    const mockDialogRef: jasmine.SpyObj<
-      MatDialogRef<any>
-    > = jasmine.createSpyObj("mockDialogRef", ["afterClosed"]);
-    mockDialogRef.afterClosed.and.returnValue(of(true));
-    confirmationDialogMock.openDialog.and.returnValue(mockDialogRef);
-    return mockDialogRef;
   }
 
   beforeEach(
@@ -99,7 +90,7 @@ describe("AdminComponent", () => {
 
   it("should call backup service for json export", fakeAsync(() => {
     spyOn(document, "createElement").and.callFake(() => tmplink);
-    mockBackupService.getJsonExport.and.returnValue(Promise.resolve(""));
+    mockBackupService.getJsonExport.and.resolveTo("");
     component.saveBackup();
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();
     tick();
@@ -108,7 +99,7 @@ describe("AdminComponent", () => {
 
   it("should call backup service for csv export", fakeAsync(() => {
     spyOn(document, "createElement").and.returnValue(tmplink);
-    mockBackupService.getCsvExport.and.returnValue(Promise.resolve(""));
+    mockBackupService.getCsvExport.and.resolveTo("");
     component.saveCsvExport();
     expect(mockBackupService.getCsvExport).toHaveBeenCalled();
     tick();
@@ -125,7 +116,7 @@ describe("AdminComponent", () => {
 
   it("should save and apply new configuration", fakeAsync(() => {
     const mockFileReader = createFileReaderMock("{}");
-    mockConfigService.saveConfig.and.returnValue(Promise.resolve(null));
+    mockConfigService.saveConfig.and.resolveTo(null);
     component.uploadConfigFile({ target: { files: [] } } as any);
     tick();
     expect(mockFileReader.readAsText).toHaveBeenCalled();
@@ -134,8 +125,8 @@ describe("AdminComponent", () => {
 
   it("should open dialog and call backup service when loading backup", fakeAsync(() => {
     const mockFileReader = createFileReaderMock("[]");
-    mockBackupService.getJsonExport.and.returnValue(Promise.resolve("[]"));
-    createDialogMock();
+    mockBackupService.getJsonExport.and.resolveTo("[]");
+    confirmationDialogMock.openDialog.and.resolveTo(true);
 
     component.loadBackup({ target: { files: [] } } as any);
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();
@@ -148,8 +139,8 @@ describe("AdminComponent", () => {
   }));
 
   it("should open dialog when clearing database", fakeAsync(() => {
-    mockBackupService.getJsonExport.and.returnValue(Promise.resolve(""));
-    createDialogMock();
+    mockBackupService.getJsonExport.and.resolveTo("");
+    confirmationDialogMock.openDialog.and.resolveTo(true);
 
     component.clearDatabase();
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();

--- a/src/app/core/admin/admin/admin.component.spec.ts
+++ b/src/app/core/admin/admin/admin.component.spec.ts
@@ -32,7 +32,7 @@ describe("AdminComponent", () => {
   ]);
 
   const confirmationDialogMock = jasmine.createSpyObj<ConfirmationDialogService>(
-    ["openDialog"]
+    ["getConfirmation"]
   );
 
   const tmplink: jasmine.SpyObj<HTMLAnchorElement> = jasmine.createSpyObj(
@@ -126,13 +126,13 @@ describe("AdminComponent", () => {
   it("should open dialog and call backup service when loading backup", fakeAsync(() => {
     const mockFileReader = createFileReaderMock("[]");
     mockBackupService.getJsonExport.and.resolveTo("[]");
-    confirmationDialogMock.openDialog.and.resolveTo(true);
+    confirmationDialogMock.getConfirmation.and.resolveTo(true);
 
     component.loadBackup({ target: { files: [] } } as any);
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();
     tick();
     expect(mockFileReader.readAsText).toHaveBeenCalled();
-    expect(confirmationDialogMock.openDialog).toHaveBeenCalled();
+    expect(confirmationDialogMock.getConfirmation).toHaveBeenCalled();
     flush();
     expect(mockBackupService.clearDatabase).toHaveBeenCalled();
     expect(mockBackupService.importJson).toHaveBeenCalled();
@@ -140,12 +140,12 @@ describe("AdminComponent", () => {
 
   it("should open dialog when clearing database", fakeAsync(() => {
     mockBackupService.getJsonExport.and.resolveTo("");
-    confirmationDialogMock.openDialog.and.resolveTo(true);
+    confirmationDialogMock.getConfirmation.and.resolveTo(true);
 
     component.clearDatabase();
     expect(mockBackupService.getJsonExport).toHaveBeenCalled();
     tick();
-    expect(confirmationDialogMock.openDialog).toHaveBeenCalled();
+    expect(confirmationDialogMock.getConfirmation).toHaveBeenCalled();
     flush();
     expect(mockBackupService.clearDatabase).toHaveBeenCalled();
   }));

--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -103,32 +103,30 @@ export class AdminComponent implements OnInit {
     const restorePoint = await this.backupService.getJsonExport();
     const newData = await readFile(this.getFileFromInputEvent(inputEvent));
 
-    const dialogRef = this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.openDialog(
       `Overwrite complete database?`,
       `Are you sure you want to restore this backup? This will
       delete all ${JSON.parse(restorePoint).length} existing records,
       restoring ${JSON.parse(newData).length} records from the loaded file.`
     );
 
-    dialogRef.afterClosed().subscribe(async (confirmed) => {
-      if (!confirmed) {
-        return;
-      }
+    if (!confirmed) {
+      return;
+    }
 
-      await this.backupService.clearDatabase();
-      await this.backupService.importJson(newData, true);
+    await this.backupService.clearDatabase();
+    await this.backupService.importJson(newData, true);
 
-      const snackBarRef = this.snackBar.open(`Backup restored`, "Undo", {
-        duration: 8000,
-      });
-      snackBarRef
-        .onAction()
-        .pipe(untilDestroyed(this))
-        .subscribe(async () => {
-          await this.backupService.clearDatabase();
-          await this.backupService.importJson(restorePoint, true);
-        });
+    const snackBarRef = this.snackBar.open(`Backup restored`, "Undo", {
+      duration: 8000,
     });
+    snackBarRef
+      .onAction()
+      .pipe(untilDestroyed(this))
+      .subscribe(async () => {
+        await this.backupService.clearDatabase();
+        await this.backupService.importJson(restorePoint, true);
+      });
   }
 
   private getFileFromInputEvent(inputEvent: Event): Blob {
@@ -142,29 +140,27 @@ export class AdminComponent implements OnInit {
   async clearDatabase() {
     const restorePoint = await this.backupService.getJsonExport();
 
-    const dialogRef = this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.openDialog(
       `Empty complete database?`,
       `Are you sure you want to clear the database? This will delete all ${
         restorePoint.split("\n").length
       } existing records in the database!`
     );
 
-    dialogRef.afterClosed().subscribe(async (confirmed) => {
-      if (!confirmed) {
-        return;
-      }
+    if (!confirmed) {
+      return;
+    }
 
-      await this.backupService.clearDatabase();
+    await this.backupService.clearDatabase();
 
-      const snackBarRef = this.snackBar.open(`Import completed`, "Undo", {
-        duration: 8000,
-      });
-      snackBarRef
-        .onAction()
-        .pipe(untilDestroyed(this))
-        .subscribe(async () => {
-          await this.backupService.importJson(restorePoint, true);
-        });
+    const snackBarRef = this.snackBar.open(`Import completed`, "Undo", {
+      duration: 8000,
     });
+    snackBarRef
+      .onAction()
+      .pipe(untilDestroyed(this))
+      .subscribe(async () => {
+        await this.backupService.importJson(restorePoint, true);
+      });
   }
 }

--- a/src/app/core/admin/admin/admin.component.ts
+++ b/src/app/core/admin/admin/admin.component.ts
@@ -103,7 +103,7 @@ export class AdminComponent implements OnInit {
     const restorePoint = await this.backupService.getJsonExport();
     const newData = await readFile(this.getFileFromInputEvent(inputEvent));
 
-    const confirmed = await this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.getConfirmation(
       `Overwrite complete database?`,
       `Are you sure you want to restore this backup? This will
       delete all ${JSON.parse(restorePoint).length} existing records,
@@ -140,7 +140,7 @@ export class AdminComponent implements OnInit {
   async clearDatabase() {
     const restorePoint = await this.backupService.getJsonExport();
 
-    const confirmed = await this.confirmationDialog.openDialog(
+    const confirmed = await this.confirmationDialog.getConfirmation(
       `Empty complete database?`,
       `Are you sure you want to clear the database? This will delete all ${
         restorePoint.split("\n").length

--- a/src/app/core/confirmation-dialog/confirmation-dialog.service.spec.ts
+++ b/src/app/core/confirmation-dialog/confirmation-dialog.service.spec.ts
@@ -1,20 +1,18 @@
-import { TestBed, inject } from "@angular/core/testing";
+import { TestBed } from "@angular/core/testing";
 
 import { ConfirmationDialogService } from "./confirmation-dialog.service";
-import { MatDialogModule } from "@angular/material/dialog";
+import { ConfirmationDialogModule } from "./confirmation-dialog.module";
 
 describe("ConfirmationDialogService", () => {
+  let service: ConfirmationDialogService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ConfirmationDialogService],
-      imports: [MatDialogModule],
+      imports: [ConfirmationDialogModule],
     });
+    service = TestBed.inject(ConfirmationDialogService);
   });
 
-  it("should be created", inject(
-    [ConfirmationDialogService],
-    (service: ConfirmationDialogService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
 });

--- a/src/app/core/confirmation-dialog/confirmation-dialog.service.ts
+++ b/src/app/core/confirmation-dialog/confirmation-dialog.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from "@angular/core";
-import { MatDialog, MatDialogRef } from "@angular/material/dialog";
+import { MatDialog } from "@angular/material/dialog";
 import {
   ConfirmationDialogButton,
   ConfirmationDialogComponent,
   YesNoButtons,
 } from "./confirmation-dialog/confirmation-dialog.component";
+import { map } from "rxjs/operators";
 
 /**
  * Inject this service instead of MatDialog if you need a simple, configurable confirmation dialog box
@@ -31,23 +32,25 @@ export class ConfirmationDialogService {
    * @param buttons The buttons to show. Defaults to 'yes' and 'no', but can be
    * arbitrary
    * @param closeButton Whether a single icon-button with an 'x' is shown to the user
-   * @return The reference to the opened MatDialog.
-   *          You can use this to control the dialog or subscribe to its result:
-   *          (`ref.afterClosed().subscribe(confirmed => myAction(confirmed));`
+   * @returns promise that resolves to true if the user confirmed and false otherwise`
    */
   openDialog(
     title: string,
     text: string,
     buttons: ConfirmationDialogButton[] = YesNoButtons,
     closeButton = true
-  ): MatDialogRef<ConfirmationDialogComponent> {
-    return this.dialog.open(ConfirmationDialogComponent, {
-      data: {
-        title: title,
-        text: text,
-        buttons: buttons,
-        closeButton: closeButton,
-      },
-    });
+  ): Promise<boolean> {
+    return this.dialog
+      .open(ConfirmationDialogComponent, {
+        data: {
+          title: title,
+          text: text,
+          buttons: buttons,
+          closeButton: closeButton,
+        },
+      })
+      .afterClosed()
+      .pipe(map((choice) => !!choice))
+      .toPromise();
   }
 }

--- a/src/app/core/confirmation-dialog/confirmation-dialog.service.ts
+++ b/src/app/core/confirmation-dialog/confirmation-dialog.service.ts
@@ -14,12 +14,13 @@ import { map } from "rxjs/operators";
  * Import the {@link ConfirmationDialogModule} in your root module to provide this service.
  *
  * @example
- const dialogRef = this.confirmationDialog.openDialog('Delete?', 'Are you sure you want to delete this record?');
- dialogRef.afterClosed().subscribe(confirmed => {
+ this.confirmationDialog
+  .getConfirmation('Delete?', 'Are you sure you want to delete this record?')
+  .then((confirmed) => {
     if (confirmed) {
        // delete
     }
- });
+  });
  */
 @Injectable()
 export class ConfirmationDialogService {
@@ -34,7 +35,7 @@ export class ConfirmationDialogService {
    * @param closeButton Whether a single icon-button with an 'x' is shown to the user
    * @returns promise that resolves to true if the user confirmed and false otherwise`
    */
-  openDialog(
+  getConfirmation(
     title: string,
     text: string,
     buttons: ConfirmationDialogButton[] = YesNoButtons,

--- a/src/app/core/entity/entity-remove.service.spec.ts
+++ b/src/app/core/entity/entity-remove.service.spec.ts
@@ -23,8 +23,8 @@ describe("EntityRemoveService", () => {
     mockEntityMapper = jasmine.createSpyObj(["remove", "save"]);
     snackBarSpy = jasmine.createSpyObj(["open"]);
     mockSnackBarRef = jasmine.createSpyObj(["onAction", "afterDismissed"]);
-    mockConfirmationDialog = jasmine.createSpyObj(["openDialog"]);
-    mockConfirmationDialog.openDialog.and.resolveTo(true);
+    mockConfirmationDialog = jasmine.createSpyObj(["getConfirmation"]);
+    mockConfirmationDialog.getConfirmation.and.resolveTo(true);
     snackBarSpy.open.and.returnValue(mockSnackBarRef);
     mockEntityMapper.remove.and.resolveTo();
     TestBed.configureTestingModule({
@@ -45,7 +45,7 @@ describe("EntityRemoveService", () => {
   });
 
   it("emits once and closes when the user has cancelled", (done) => {
-    mockConfirmationDialog.openDialog.and.resolveTo(false);
+    mockConfirmationDialog.getConfirmation.and.resolveTo(false);
     service
       .remove(new Entity())
       .pipe(toArray())

--- a/src/app/core/entity/entity-remove.service.spec.ts
+++ b/src/app/core/entity/entity-remove.service.spec.ts
@@ -9,9 +9,7 @@ import {
 } from "@angular/material/snack-bar";
 import { ConfirmationDialogService } from "../confirmation-dialog/confirmation-dialog.service";
 import { Entity } from "./model/entity";
-import { NEVER, Observable, Subject } from "rxjs";
-import { MatDialogRef } from "@angular/material/dialog";
-import { ConfirmationDialogComponent } from "../confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
+import { NEVER, Observable } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 describe("EntityRemoveService", () => {
@@ -20,18 +18,13 @@ describe("EntityRemoveService", () => {
   let snackBarSpy: jasmine.SpyObj<MatSnackBar>;
   let mockSnackBarRef: jasmine.SpyObj<MatSnackBarRef<TextOnlySnackBar>>;
   let mockConfirmationDialog: jasmine.SpyObj<ConfirmationDialogService>;
-  let mockDialogRef: jasmine.SpyObj<MatDialogRef<ConfirmationDialogComponent>>;
-  let afterClosed: Subject<boolean>;
 
   beforeEach(() => {
     mockEntityMapper = jasmine.createSpyObj(["remove", "save"]);
     snackBarSpy = jasmine.createSpyObj(["open"]);
     mockSnackBarRef = jasmine.createSpyObj(["onAction", "afterDismissed"]);
     mockConfirmationDialog = jasmine.createSpyObj(["openDialog"]);
-    mockDialogRef = jasmine.createSpyObj(["afterClosed"]);
-    afterClosed = new Subject<boolean>();
-    mockDialogRef.afterClosed.and.returnValue(afterClosed);
-    mockConfirmationDialog.openDialog.and.returnValue(mockDialogRef);
+    mockConfirmationDialog.openDialog.and.resolveTo(true);
     snackBarSpy.open.and.returnValue(mockSnackBarRef);
     mockEntityMapper.remove.and.resolveTo();
     TestBed.configureTestingModule({
@@ -47,15 +40,12 @@ describe("EntityRemoveService", () => {
     service = TestBed.inject(EntityRemoveService);
   });
 
-  afterEach(() => {
-    afterClosed.complete();
-  });
-
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
 
   it("emits once and closes when the user has cancelled", (done) => {
+    mockConfirmationDialog.openDialog.and.resolveTo(false);
     service
       .remove(new Entity())
       .pipe(toArray())
@@ -72,7 +62,6 @@ describe("EntityRemoveService", () => {
           done();
         }
       );
-    afterClosed.next(false);
   });
 
   it("deletes the entity and finishes if the action is never undone", (done) => {
@@ -99,7 +88,6 @@ describe("EntityRemoveService", () => {
           done();
         }
       );
-    afterClosed.next(true);
   });
 
   it("emits twice when an entity was deleted and the user pressed undo", (done) => {
@@ -127,6 +115,5 @@ describe("EntityRemoveService", () => {
           done();
         }
       );
-    afterClosed.next(true);
   });
 });

--- a/src/app/core/entity/entity-remove.service.ts
+++ b/src/app/core/entity/entity-remove.service.ts
@@ -90,22 +90,19 @@ export class EntityRemoveService {
     const dialogText =
       textOptions?.dialogText ||
       $localize`:Delete confirmation text:Are you sure you want to delete this ${entity.getType()}?`;
-    const dialogRef = this.confirmationDialog.openDialog(
-      dialogTitle,
-      dialogText
-    );
-
-    dialogRef.afterClosed().subscribe(async (confirmed) => {
-      if (confirmed) {
-        const snackBarTitle =
-          textOptions?.deletedEntityInformation ||
-          $localize`:Deleted Entity information:Deleted Entity ${entity.toString()}`;
-        await this.removeEntityAndOpenSnackBar(entity, snackBarTitle, subject);
-      } else {
-        subject.next(RemoveResult.CANCELLED);
-        subject.complete();
-      }
-    });
+    this.confirmationDialog
+      .openDialog(dialogTitle, dialogText)
+      .then((confirmed) => {
+        if (confirmed) {
+          const snackBarTitle =
+            textOptions?.deletedEntityInformation ||
+            $localize`:Deleted Entity information:Deleted Entity ${entity.toString()}`;
+          this.removeEntityAndOpenSnackBar(entity, snackBarTitle, subject);
+        } else {
+          subject.next(RemoveResult.CANCELLED);
+          subject.complete();
+        }
+      });
     return subject.asObservable();
   }
 

--- a/src/app/core/entity/entity-remove.service.ts
+++ b/src/app/core/entity/entity-remove.service.ts
@@ -91,7 +91,7 @@ export class EntityRemoveService {
       textOptions?.dialogText ||
       $localize`:Delete confirmation text:Are you sure you want to delete this ${entity.getType()}?`;
     this.confirmationDialog
-      .openDialog(dialogTitle, dialogText)
+      .getConfirmation(dialogTitle, dialogText)
       .then((confirmed) => {
         if (confirmed) {
           const snackBarTitle =

--- a/src/app/core/form-dialog/form-dialog.service.spec.ts
+++ b/src/app/core/form-dialog/form-dialog.service.spec.ts
@@ -16,13 +16,7 @@ import { EntityAbility } from "../permissions/ability/entity-ability";
 describe("FormDialogService", () => {
   let service: FormDialogService;
 
-  let mockConfirmationDialog: jasmine.SpyObj<ConfirmationDialogService>;
-
   beforeEach(() => {
-    mockConfirmationDialog = jasmine.createSpyObj("mockConfirmationDialog", [
-      "openDialog",
-    ]);
-
     TestBed.configureTestingModule({
       imports: [
         FormDialogModule,
@@ -35,7 +29,7 @@ describe("FormDialogService", () => {
       providers: [
         {
           provide: ConfirmationDialogService,
-          useValue: mockConfirmationDialog,
+          useValue: jasmine.createSpyObj(["openDialog"]),
         },
         {
           provide: EntityAbility,

--- a/src/app/core/form-dialog/form-dialog.service.spec.ts
+++ b/src/app/core/form-dialog/form-dialog.service.spec.ts
@@ -29,7 +29,7 @@ describe("FormDialogService", () => {
       providers: [
         {
           provide: ConfirmationDialogService,
-          useValue: jasmine.createSpyObj(["openDialog"]),
+          useValue: jasmine.createSpyObj(["getConfirmation"]),
         },
         {
           provide: EntityAbility,

--- a/src/app/core/form-dialog/form-dialog.service.ts
+++ b/src/app/core/form-dialog/form-dialog.service.ts
@@ -17,7 +17,7 @@ import { EntityAbility } from "../permissions/ability/entity-ability";
  * Import the {@link FormDialogModule} in your root module to provide this service.
  *
  * @example
- formDialog.openDialog(NoteDetailsComponent, noteEntity);
+ formDialog.getConfirmation(NoteDetailsComponent, noteEntity);
  */
 @Injectable()
 export class FormDialogService {
@@ -58,7 +58,7 @@ export class FormDialogService {
     dialogRef.beforeClosed().subscribe((activelyClosed) => {
       if (!activelyClosed && dialogWrapper.isFormDirty) {
         this.confirmationDialog
-          .openDialog(
+          .getConfirmation(
             $localize`:Save changes header:Save Changes?`,
             $localize`:Save changes message:Do you want to save the changes you made to the record?`
           )

--- a/src/app/core/form-dialog/form-dialog.service.ts
+++ b/src/app/core/form-dialog/form-dialog.service.ts
@@ -62,14 +62,9 @@ export class FormDialogService {
             $localize`:Save changes header:Save Changes?`,
             $localize`:Save changes message:Do you want to save the changes you made to the record?`
           )
-          .afterClosed()
-          .subscribe((confirmed) => {
-            if (confirmed) {
-              dialogWrapper.save();
-            } else {
-              dialogWrapper.cancel();
-            }
-          });
+          .then((confirmed) =>
+            confirmed ? dialogWrapper.save() : dialogWrapper.cancel()
+          );
       }
     });
 

--- a/src/app/features/data-import/data-import.service.spec.ts
+++ b/src/app/features/data-import/data-import.service.spec.ts
@@ -21,8 +21,8 @@ describe("DataImportService", () => {
 
   beforeEach(
     waitForAsync(() => {
-      mockConfirmationService = jasmine.createSpyObj(["openDialog"]);
-      mockConfirmationService.openDialog.and.resolveTo(true);
+      mockConfirmationService = jasmine.createSpyObj(["getConfirmation"]);
+      mockConfirmationService.getConfirmation.and.resolveTo(true);
       TestBed.configureTestingModule({
         imports: [DataImportModule, DatabaseTestingModule, ChildrenModule],
         providers: [

--- a/src/app/features/data-import/data-import.service.ts
+++ b/src/app/features/data-import/data-import.service.ts
@@ -107,7 +107,7 @@ export class DataImportService {
     if (importMeta.transactionId) {
       refText = $localize`${refText} All existing records imported with the transaction id '${importMeta.transactionId}' will be deleted!`;
     }
-    return this.confirmationDialog.openDialog(refTitle, refText);
+    return this.confirmationDialog.getConfirmation(refTitle, refText);
   }
 
   private async deleteExistingRecords(importMeta: ImportMetaData) {

--- a/src/app/features/data-import/data-import.service.ts
+++ b/src/app/features/data-import/data-import.service.ts
@@ -107,11 +107,7 @@ export class DataImportService {
     if (importMeta.transactionId) {
       refText = $localize`${refText} All existing records imported with the transaction id '${importMeta.transactionId}' will be deleted!`;
     }
-    const dialogRef = this.confirmationDialog.openDialog(refTitle, refText);
-
-    return new Promise<boolean>((resolve) => {
-      dialogRef.afterClosed().subscribe((confirmed) => resolve(confirmed));
-    });
+    return this.confirmationDialog.openDialog(refTitle, refText);
   }
 
   private async deleteExistingRecords(importMeta: ImportMetaData) {


### PR DESCRIPTION
### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Refactored and renamed `openDialog` function for `ConfirmationDialogService` to remove boilerplate code
