### PR TITLE
doc: fixed docs to get correctly displayed by compodoc

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,14 +33,14 @@ import { LoggingService } from "./core/logging/logging.service";
 import { EntityRegistry } from "./core/entity/database-entity.decorator";
 import { filter } from "rxjs/operators";
 
-@Component({
-  selector: "app-root",
-  template: "<app-ui></app-ui>",
-})
 /**
  * Component as the main entry point for the app.
  * Actual logic and UI structure is defined in other modules.
  */
+@Component({
+  selector: "app-root",
+  template: "<app-ui></app-ui>",
+})
 export class AppComponent {
   constructor(
     private viewContainerRef: ViewContainerRef, // need this small hack in order to catch application root view container ref

--- a/src/app/child-dev-project/notes/note-attendance-block/note-attendance-count-block.component.ts
+++ b/src/app/child-dev-project/notes/note-attendance-block/note-attendance-count-block.component.ts
@@ -5,15 +5,15 @@ import { Note } from "../model/note";
 import { AttendanceLogicalStatus } from "../../attendance/model/attendance-status";
 import { DynamicComponent } from "../../../core/view/dynamic-components/dynamic-component.decorator";
 
+/**
+ * Displays the amount of children with a given attendance status at a given note.
+ */
 @DynamicComponent("NoteAttendanceCountBlock")
 @Component({
   selector: "app-note-attendance-count-block",
   templateUrl: "./note-attendance-count-block.component.html",
   styleUrls: ["./note-attendance-count-block.component.scss"],
 })
-/**
- * Displays the amount of children with a given attendance status at a given note.
- */
 export class NoteAttendanceCountBlockComponent
   implements OnInitDynamicComponent, OnInit {
   /**

--- a/src/app/core/database/pouch-database.ts
+++ b/src/app/core/database/pouch-database.ts
@@ -24,7 +24,6 @@ import { Injectable } from "@angular/core";
 import { fromEvent, Observable } from "rxjs";
 import { filter, map } from "rxjs/operators";
 
-@Injectable()
 /**
  * Wrapper for a PouchDB instance to decouple the code from
  * that external library.
@@ -32,6 +31,7 @@ import { filter, map } from "rxjs/operators";
  * Additional convenience functions on top of the PouchDB API
  * should be implemented in the abstract {@link Database}.
  */
+@Injectable()
 export class PouchDatabase extends Database {
   /**
    * Small helper function which creates a database with in-memory PouchDB initialized

--- a/src/app/core/demo-data/demo-data-initializer.service.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.ts
@@ -14,7 +14,6 @@ import memory from "pouchdb-adapter-memory";
 import { Database } from "../database/database";
 import { PouchDatabase } from "../database/pouch-database";
 
-@Injectable()
 /**
  * This service handles everything related to the demo-mode
  *  - Register users (demo and demo-admin)
@@ -22,6 +21,7 @@ import { PouchDatabase } from "../database/pouch-database";
  *  - Automatically login user (demo)
  *  - Synchronizes (local) databases of different users in the same browser
  */
+@Injectable()
 export class DemoDataInitializerService {
   private liveSyncHandle: PouchDB.Replication.Sync<any>;
   private pouchDatabase: PouchDatabase;

--- a/src/app/core/entity-components/entity-details/form/form.component.ts
+++ b/src/app/core/entity-components/entity-details/form/form.component.ts
@@ -8,6 +8,10 @@ import { Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { DynamicComponent } from "../../../view/dynamic-components/dynamic-component.decorator";
 
+/**
+ * A simple wrapper function of the EntityFormComponent which can be used as a dynamic component
+ * e.g. as a panel for the EntityDetailsComponent.
+ */
 @DynamicComponent("Form")
 @Component({
   selector: "app-form",
@@ -20,10 +24,6 @@ import { DynamicComponent } from "../../../view/dynamic-components/dynamic-compo
     (onCancel)="cancelClicked()"
   ></app-entity-form>`,
 })
-/**
- * A simple wrapper function of the EntityFormComponent which can be used as a dynamic component
- * e.g. as a panel for the EntityDetailsComponent.
- */
 export class FormComponent implements OnInitDynamicComponent {
   entity: Entity;
   columns: FormFieldConfig[][] = [];

--- a/src/app/core/entity-components/entity-form/entity-form.service.ts
+++ b/src/app/core/entity-components/entity-form/entity-form.service.ts
@@ -8,11 +8,11 @@ import { DynamicValidatorsService } from "./dynamic-form-validators/dynamic-vali
 import { EntityAbility } from "../../permissions/ability/entity-ability";
 import { EntitySchema } from "../../entity/schema/entity-schema";
 
-@Injectable()
 /**
  * This service provides helper functions for creating tables or forms for an entity as well as saving
  * new changes correctly to the entity.
  */
+@Injectable()
 export class EntityFormService {
   constructor(
     private fb: FormBuilder,

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -5,11 +5,6 @@ import { FormGroup } from "@angular/forms";
 import { EntityFormService } from "../entity-form.service";
 import { AlertService } from "../../../alerts/alert.service";
 
-@Component({
-  selector: "app-entity-form",
-  templateUrl: "./entity-form.component.html",
-  styleUrls: ["./entity-form.component.scss"],
-})
 /**
  * A general purpose form component for displaying and editing entities.
  * It uses the FormFieldConfig interface for building the form fields but missing information are also fetched from
@@ -19,6 +14,11 @@ import { AlertService } from "../../../alerts/alert.service";
  * This component can be used directly or in a popup.
  * Inside the entity details component use the FormComponent which is registered as dynamic component.
  */
+@Component({
+  selector: "app-entity-form",
+  templateUrl: "./entity-form.component.html",
+  styleUrls: ["./entity-form.component.scss"],
+})
 export class EntityFormComponent implements OnInit {
   /**
    * The entity which should be displayed and edited

--- a/src/app/core/entity-components/entity-utils/view-components/readonly-function/entity-function.pipe.ts
+++ b/src/app/core/entity-components/entity-utils/view-components/readonly-function/entity-function.pipe.ts
@@ -1,13 +1,13 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { Entity } from "../../../../entity/model/entity";
 
-@Pipe({
-  name: "entityFunction",
-})
 /**
  * A simple pipe which passes the input entity to the input function.
  * This reduces the change detection cycles, because the function is only re-calculated once the entity changed.
  */
+@Pipe({
+  name: "entityFunction",
+})
 export class EntityFunctionPipe implements PipeTransform {
   transform(value: Entity, func?: (entity: Entity) => any): any {
     return func(value);

--- a/src/app/core/export/download-service/download.service.ts
+++ b/src/app/core/export/download-service/download.service.ts
@@ -4,11 +4,11 @@ import { ExportDataFormat } from "../export-data-directive/export-data.directive
 import { ExportService } from "../export-service/export.service";
 import { LoggingService } from "../../logging/logging.service";
 
-@Injectable()
 /**
  * This service allows to start a download process from the browser.
  * Depending on the browser and the setting this might open a popup or directly download the file.
  */
+@Injectable()
 export class DownloadService {
   constructor(
     private exportService: ExportService,

--- a/src/app/core/permissions/ability/entity-ability.ts
+++ b/src/app/core/permissions/ability/entity-ability.ts
@@ -4,7 +4,6 @@ import { Ability, subject } from "@casl/ability";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { Entity } from "../../entity/model/entity";
 
-@Injectable()
 /**
  * An extension of the Ability class which can check permissions on Entities.
  * Inject this class in your component to check for permissions.
@@ -19,6 +18,7 @@ import { Entity } from "../../entity/model/entity";
  * ```
  * Entities are transformed to the database format and permissions are evaluated based on the configuration found in the database.
  */
+@Injectable()
 export class EntityAbility extends Ability<[EntityAction, string | any]> {
   constructor(private entitySchemaService: EntitySchemaService) {
     super([]);

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -9,13 +9,13 @@ import { AnalyticsService } from "../../analytics/analytics.service";
 import { EntityAbility } from "../ability/entity-ability";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
 
-@Injectable()
 /**
  * This service checks whether the relevant rules for the current user changed.
  * If it detects a change, all Entity types that have read restrictions are collected.
  * All entities of these entity types are loaded and checked whether the currently logged-in user has read permissions.
  * If one entity is found for which the user does **not** have read permissions, then the local database is destroyed and a new sync has to start.
  */
+@Injectable()
 export class PermissionEnforcerService {
   /**
    * This is a suffix used to persist the user-relevant rules in local storage to later check for changes.

--- a/src/app/core/permissions/permission-guard/user-role.guard.ts
+++ b/src/app/core/permissions/permission-guard/user-role.guard.ts
@@ -3,10 +3,10 @@ import { ActivatedRouteSnapshot, CanActivate } from "@angular/router";
 import { SessionService } from "../../session/session-service/session.service";
 import { RouteData } from "../../view/dynamic-routing/view-config.interface";
 
-@Injectable()
 /**
  * A guard that checks the roles of the current user against the permissions which are saved in the route data.
  */
+@Injectable()
 export class UserRoleGuard implements CanActivate {
   constructor(private sessionService: SessionService) {}
 

--- a/src/app/core/webdav/webdav-wrapper.service.ts
+++ b/src/app/core/webdav/webdav-wrapper.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@angular/core";
 import webdav, { WebDAVClient, WebDAVClientOptions } from "webdav";
 
-@Injectable({
-  providedIn: "root",
-})
 /**
  * This Class only wraps the webdav library module in order for it to be mock-able in tests
  */
+@Injectable({
+  providedIn: "root",
+})
 export class WebdavWrapperService {
   public createClient(
     remoteUrl: string,

--- a/src/app/features/data-import/data-import.service.ts
+++ b/src/app/features/data-import/data-import.service.ts
@@ -14,10 +14,10 @@ import { monthEntitySchemaDatatype } from "../../core/entity/schema-datatypes/da
 import moment from "moment";
 import { EntityRegistry } from "../../core/entity/database-entity.decorator";
 
-@Injectable()
 /**
  * This service handels the parsing of CSV files and importing of data
  */
+@Injectable()
 export class DataImportService {
   private readonly dateDataTypes = [
     dateEntitySchemaDatatype,


### PR DESCRIPTION
Compodoc does only correctly assign a comment to a class if it comes **before** the decorators (e.g. `@Injectable`).
Otherwise the comment is not shown for a given class in [our documentation](https://aam-digital.github.io/ndb-core/documentation/index.html).

### Visible/Frontend Changes
-

### Architectural/Backend Changes
- [x] Move class comments before decorators
