### PR TITLE
Edit entity label fix

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.stories.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.stories.ts
@@ -14,13 +14,15 @@ import { ConfigurableEnumDatatype } from "../../../configurable-enum/configurabl
 import { FormFieldConfig } from "../../entity-form/entity-form/FormConfig";
 import { ChildrenModule } from "../../../../child-dev-project/children/children.module";
 import { ChildrenService } from "../../../../child-dev-project/children/children.service";
-import { of, Subject } from "rxjs";
+import { NEVER, of, Subject } from "rxjs";
 import { AttendanceLogicalStatus } from "../../../../child-dev-project/attendance/model/attendance-status";
 import { MockedTestingModule } from "../../../../utils/mocked-testing.module";
 import { AbilityService } from "../../../permissions/ability/ability.service";
 import { faker } from "../../../demo-data/faker";
 import { StorybookBaseModule } from "../../../../utils/storybook-base.module";
 import { mockEntityMapper } from "../../../entity/mock-entity-mapper-service";
+import { Ability } from "@casl/ability";
+import { EntityAbility } from "../../../permissions/ability/entity-ability";
 
 const configService = new ConfigService(mockEntityMapper());
 const schemaService = new EntitySchemaService();
@@ -59,6 +61,7 @@ export default {
                 faker.random.arrayElement(childGenerator.entities)
               ),
             loadType: () => Promise.resolve(childGenerator.entities),
+            receiveUpdates: () => NEVER,
           },
         },
         { provide: EntitySchemaService, useValue: schemaService },
@@ -73,7 +76,12 @@ export default {
         },
         {
           provide: AbilityService,
-          useValue: { abilityUpdateNotifier: new Subject() },
+          useValue: { abilityUpdated: new Subject() },
+        },
+
+        {
+          provide: EntityAbility,
+          useValue: new Ability([{ subject: "all", action: "manage" }]),
         },
       ],
     }),

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.html
@@ -1,14 +1,5 @@
 <mat-form-field *ngIf="!selectedEntity || editingSelectedEntity" [formGroup]="formControl.parent">
   <mat-label>{{ label }}</mat-label>
-  <!--
-    This input is need for detecting errors in the form.
-    The actual input used for editing is below.
-   -->
-  <input
-    matInput
-    [formControl]="formControl"
-    hidden
-  />
   <input
     #inputElement
     matInput
@@ -20,6 +11,15 @@
     (focusin)="updateAutocomplete(inputElement.value)"
     (focusout)="select(inputElement.value)"
   >
+  <!--
+  This input is need for detecting errors in the form.
+  The actual input used for editing is below.
+ -->
+  <input
+    matInput
+    [formControl]="formControl"
+    hidden
+  />
   <mat-autocomplete
     #autoSuggestions="matAutocomplete"
     (optionSelected)="select($event.option.value)"
@@ -33,6 +33,7 @@
       ></app-display-entity>
     </mat-option>
   </mat-autocomplete>
+
   <mat-error *ngIf="formControl.errors?.required" i18n="Error message for any input">
     This field is required
   </mat-error>

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-single-entity/edit-single-entity.component.ts
@@ -36,7 +36,9 @@ export class EditSingleEntityComponent extends EditComponent<string> {
 
   async onInitFromDynamicConfig(config: EditPropertyConfig) {
     super.onInitFromDynamicConfig(config);
-    this.placeholder = $localize`:Placeholder for input to set an entity|context Select User:Select ${this.label}`;
+    this.placeholder = $localize`:Placeholder for input to set an entity|context Select User:Select ${
+      config.formFieldConfig.label || config.propertySchema?.label
+    }`;
     const entityType: string =
       config.formFieldConfig.additional || config.propertySchema.additional;
     this.entities = await this.entityMapperService.loadType(entityType);


### PR DESCRIPTION
Currently there is a bad UX when editing a single entity:
![image](https://user-images.githubusercontent.com/33730997/165137779-47f5dcd4-7ca5-40f3-b615-7114aa1cfcde.png)

This is due to the label being linked to the wrong input element.

### Visible/Frontend Changes
- [x] Input element and label behave correctly

### Architectural/Backend Changes
--
