### PR TITLE
removed interaction types from event index

### DIFF
--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -58,11 +58,6 @@ describe("AttendanceService", () => {
     await entityMapper.save(activity1);
     await entityMapper.save(activity2);
 
-    const someUnrelatedNote = EventNote.create(
-      new Date("2020-01-01"),
-      "report not event"
-    );
-    await entityMapper.save(someUnrelatedNote);
     await entityMapper.save(e1_1);
     await entityMapper.save(e1_2);
     await entityMapper.save(e1_3);
@@ -96,7 +91,7 @@ describe("AttendanceService", () => {
 
     const nonMeetingNote = Note.create(
       new Date("2020-01-02"),
-      "manual event note 2"
+      "manual event note 3"
     );
     nonMeetingNote.addChild("1");
     nonMeetingNote.category = defaultInteractionTypes.find((t) => !t.isMeeting);


### PR DESCRIPTION
Since the permission changes, the indices are created too early and therefore a wrong config (the default config) was used to create the event index `by_date` which resulted in a wrong behavior in the roll call setup.

### Visible/Frontend Changes
- [x] Non-default interaction types are not lost in event index

### Architectural/Backend Changes
- [x] All `EventNote` entities are included in the `by_date` index (not just the ones with a `isMeeting` interaction type)