### PR TITLE
Dashboard translation fix

### DIFF
--- a/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.html
+++ b/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.html
@@ -6,10 +6,10 @@
   i18n-subtitle="Dashboard attendance component subtitle"
   explanation="Cases absent multiple times in the given week"
   i18n-explanation="Dashboard attendance component explanation tooltip"
+  [loading]="!loadingDone"
 >
   <app-widget-content>
-    <h2 *ngIf="!loadingDone" class="headline">Loading...</h2>
-    <div *ngIf="tableDataSource.data.length > 0 && loadingDone" class="table-wrapper">
+    <div *ngIf="tableDataSource.data.length > 0" class="table-wrapper">
       <table
         mat-table
         [dataSource]="tableDataSource"

--- a/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.scss
+++ b/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.scss
@@ -13,10 +13,3 @@
   flex-direction: row;
   gap: 2px;
 }
-
-.headline {
-  height: 100%;
-  display: flex;
-  place-content: center;
-  place-items: center;
-}

--- a/src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.html
+++ b/src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.html
@@ -4,6 +4,7 @@
   [title]="totalChildren"
   subtitle="Cases"
   i18n-subtitle="Dashboard title naming total number of beneficiaries in the system"
+  [loading]="loading"
 >
   <app-widget-content>
     <table class="dashboard-table" i18n-aria-label="Label for children count dashboard" aria-label="Table showing disaggregation of the beneficiaries">

--- a/src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.ts
+++ b/src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.ts
@@ -26,6 +26,7 @@ export class ChildrenCountDashboardComponent
 
   totalChildren: number;
   childrenGroupCounts: { label: string; value: number }[] = [];
+  loading = true;
 
   constructor(
     private childrenService: ChildrenService,
@@ -77,6 +78,7 @@ export class ChildrenCountDashboardComponent
         label: extractHumanReadableLabel(entry[0]),
         value: entry[1],
       }));
+    this.loading = false;
   }
 }
 

--- a/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.html
+++ b/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.html
@@ -4,10 +4,10 @@
   [title]="amountOfConcernedChildren"
   [subtitle]="subtitle"
   [explanation]="tooltip"
+  [loading]="isLoading"
 >
   <app-widget-content>
-    <h2 *ngIf="isLoading" class="headline" i18n>Loading...</h2>
-    <div *ngIf="childrenWithNoteInfoDataSource.data.length > 0 && !isLoading" class="table-wrapper">
+    <div *ngIf="childrenWithNoteInfoDataSource.data.length > 0" class="table-wrapper">
       <table
         mat-table
         [dataSource]="childrenWithNoteInfoDataSource"

--- a/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.scss
+++ b/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.scss
@@ -4,10 +4,3 @@
   display: flex;
   justify-content: flex-end;
 }
-
-.headline {
-  height: 100%;
-  display: flex;
-  place-content: center;
-  place-items: center;
-}

--- a/src/app/core/dashboard/dashboard-widget-base.scss
+++ b/src/app/core/dashboard/dashboard-widget-base.scss
@@ -65,3 +65,10 @@
 .mat-table tr:first-child {
   border-top: none;
 }
+
+.headline {
+  height: 100%;
+  display: flex;
+  place-content: center;
+  place-items: center;
+}

--- a/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.html
+++ b/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.html
@@ -3,15 +3,17 @@
   <div class="widget-header app-{{theme}}">
     <div *ngIf="headline" class="widget-headline">{{headline}}</div>
     <div *ngIf="!headline" class="widget-title">
-      <span *ngIf="!_loading">{{_title}}</span>
-      <mat-spinner *ngIf="_loading" diameter="40"></mat-spinner>
+      <span *ngIf="!titleReady">{{_title}}</span>
+      <mat-spinner *ngIf="titleReady" diameter="40"></mat-spinner>
     </div>
     <div *ngIf="!headline" class="widget-subheadline" [matTooltip]="explanation">{{subtitle}}</div>
     <app-fa-dynamic-icon class="widget-icon" [icon]="icon"></app-fa-dynamic-icon>
   </div>
 
+
   <!-- Content -->
   <div class="widget-content">
-    <ng-content select="app-widget-content"></ng-content>
+    <h2 *ngIf="loading" class="headline" i18n>Loading...</h2>
+    <ng-content *ngIf="!loading" select="app-widget-content"></ng-content>
   </div>
 </div>

--- a/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.scss
+++ b/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.scss
@@ -83,3 +83,11 @@ $border-radius-card: 4px;
 .mat-button-wrapper {
   display: flex;
 }
+
+.headline {
+  height: 100%;
+  display: flex;
+  place-content: center;
+  place-items: center;
+  width: 100%;
+}

--- a/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.ts
+++ b/src/app/core/dashboard/dashboard-widget/dashboard-widget.component.ts
@@ -19,20 +19,23 @@ export class DashboardWidgetComponent {
   @Input() theme: DashboardTheme;
 
   _title: Promise<any>;
-  _loading: boolean;
+  titleReady: boolean;
 
   /** optional tooltip to explain detailed meaning of this widget / statistic */
   @Input() explanation: string;
   @Input() set title(title: PromiseLike<any> | any) {
     if (title && typeof title["then"] === "function") {
-      this._loading = true;
+      this.titleReady = true;
       title.then((value) => {
         this._title = value;
-        this._loading = false;
+        this.titleReady = false;
       });
     } else {
       this._title = title;
     }
   }
   @Input() headline: string;
+
+  /** Show a loading indicator until data is ready to be shown */
+  @Input() loading = false;
 }

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -705,8 +705,8 @@
         <source>Loading...</source>
         <target state="translated">wird geladen ...</target>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="sourcefile">src/app/core/dashboard/dashboard-widget/dashboard-widget.component.html</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ef53f00083d0537e89f52ce3fc949182c6bca8e4" datatype="html">
@@ -1203,7 +1203,7 @@
       </trans-unit>
       <trans-unit id="02b6f9239c84f76fe5b1c6087dba40dad21e194b" datatype="html">
         <source> Download details </source>
-        <target state="translate"> Details herunterladen </target>
+        <target state="translated"> Details herunterladen </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/notes/note-details/note-details.component.html</context>
           <context context-type="linenumber">51</context>
@@ -3804,7 +3804,7 @@
         <note priority="1" from="description">Label for children count dashboard</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4369844267709449786" datatype="html">
@@ -4672,7 +4672,7 @@
         <target state="translated">Ihr Passwort hat sich vor kurzem geändert. Bitte mit dem neuen Passwort versuchen!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/session/session-service/synced-session.service.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1883557110661036774" datatype="html">
@@ -5156,7 +5156,7 @@
         <target state="translated">App installieren</target>
         <note priority="1" from="description">PWA Install Button Label</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
@@ -5165,7 +5165,7 @@
         <target state="translated">Um die App zu installieren, klicken Sie </target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
@@ -5174,7 +5174,7 @@
         <target state="translated">unten auf </target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 2-1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
@@ -5183,7 +5183,7 @@
         <target state="translated"/>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 2-2</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
@@ -5192,7 +5192,7 @@
         <target state="translated">und dann auf </target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 3-1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
@@ -5201,7 +5201,7 @@
         <target state="translated"> (Zum Home-Bildschirm).</target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 3-2</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -911,7 +911,7 @@
         <note priority="1" from="description">Label for children count dashboard</note>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1616102757855967475" datatype="html">
@@ -1578,8 +1578,8 @@
         <source>Loading...</source>
         <target state="translated">Chargement...</target>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="sourcefile">src/app/core/dashboard/dashboard-widget/dashboard-widget.component.html</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ef53f00083d0537e89f52ce3fc949182c6bca8e4" datatype="html">
@@ -4359,7 +4359,7 @@
         <target state="translated">Votre mot de passe a été modifié récemment. Veuillez réessayer avec votre nouveau mot de passe !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/session/session-service/synced-session.service.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1883557110661036774" datatype="html">
@@ -5210,7 +5210,7 @@
         <target state="translated">Installer l'application</target>
         <note priority="1" from="description">PWA Install Button Label</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
@@ -5219,7 +5219,7 @@
         <target state="translated">Pour installer l'application</target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
@@ -5228,7 +5228,7 @@
         <target state="translated">cliquez sur </target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 2-1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
@@ -5237,7 +5237,7 @@
         <target state="translated"> en bas</target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 2-2</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
@@ -5246,7 +5246,7 @@
         <target state="translated">et puis sur </target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 3-1</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
@@ -5255,7 +5255,7 @@
         <target state="translated"> (Ajouter à l'écran d'accueil).</target>
         <note priority="1" from="description">PWA iOS Install Instructions - Line 3-2</note>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -830,7 +830,7 @@
         <source>Table showing disaggregation of the beneficiaries</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/child-dev-project/children/dashboard-widgets/children-count-dashboard/children-count-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <note priority="1" from="description">Label for children count dashboard</note>
       </trans-unit>
@@ -1431,13 +1431,6 @@
           <context context-type="linenumber">14,22</context>
         </context-group>
         <note priority="1" from="description">Explanation for missing currently active entry - part 2 of 2:</note>
-      </trans-unit>
-      <trans-unit id="94516fa213706c67ce5a5b5765681d7fb032033a" datatype="html">
-        <source>Loading...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.html</context>
-          <context context-type="linenumber">9</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="ef53f00083d0537e89f52ce3fc949182c6bca8e4" datatype="html">
         <source><x id="START_TABLE_CELL" ctype="x-td" equiv-text="&lt;td *matCellDef=&quot;let childNoteInfo&quot;&gt;"/><x id="START_TAG_SPAN_1" ctype="x-span_1" equiv-text="&lt;span  class=&quot;dashboard-table-additional-info-cell&quot;&gt;"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span
@@ -3207,6 +3200,13 @@
         </context-group>
         <note priority="1" from="description">Title of dashboard widget that shows a list of certain actions a user can click on</note>
       </trans-unit>
+      <trans-unit id="94516fa213706c67ce5a5b5765681d7fb032033a" datatype="html">
+        <source>Loading...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/dashboard/dashboard-widget/dashboard-widget.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="f10d5109ec72341c3a043905f31ccbfdd4c59923" datatype="html">
         <source>Generating sample data for this demo ...</source>
         <context-group purpose="location">
@@ -3649,6 +3649,54 @@
         </context-group>
         <note priority="1" from="description">Missing permission</note>
       </trans-unit>
+      <trans-unit id="5e589ae47ed0c90beb209018a8f60ed492d8ad8d" datatype="html">
+        <source>Install App</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">PWA Install Button Label</note>
+      </trans-unit>
+      <trans-unit id="240687bf23ceecb815aa0788691b36fc61468b53" datatype="html">
+        <source> To install the app </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">17,18</context>
+        </context-group>
+        <note priority="1" from="description">PWA iOS Install Instructions - Line 1</note>
+      </trans-unit>
+      <trans-unit id="8beef6deafdec7914c3971782faad2ac1e66604d" datatype="html">
+        <source> tap on </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">29,30</context>
+        </context-group>
+        <note priority="1" from="description">PWA iOS Install Instructions - Line 2-1</note>
+      </trans-unit>
+      <trans-unit id="5e1fef8419bb00629ae0fe59c98feced66824e11" datatype="html">
+        <source> at the bottom </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">34,35</context>
+        </context-group>
+        <note priority="1" from="description">PWA iOS Install Instructions - Line 2-2</note>
+      </trans-unit>
+      <trans-unit id="6ac57c355739ba746bcfb893197082f53ac6ee75" datatype="html">
+        <source> and then tap on </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">39,40</context>
+        </context-group>
+        <note priority="1" from="description">PWA iOS Install Instructions - Line 3-1</note>
+      </trans-unit>
+      <trans-unit id="26c649bd93b5051b07a9aed12f707cfa401553d7" datatype="html">
+        <source> (Add to Homescreen). </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/pwa-install/pwa-install.component.html</context>
+          <context context-type="linenumber">43,44</context>
+        </context-group>
+        <note priority="1" from="description">PWA iOS Install Instructions - Line 3-2</note>
+      </trans-unit>
       <trans-unit id="266e3d5d7292b095716537dd0b57ef6784768c14" datatype="html">
         <source> Please Sign In </source>
         <context-group purpose="location">
@@ -3708,7 +3756,7 @@
         <source>Your password was changed recently. Please retry with your new password!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/session/session-service/synced-session.service.ts</context>
-          <context context-type="linenumber">136,135</context>
+          <context context-type="linenumber">146,145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1883557110661036774" datatype="html">
@@ -4614,54 +4662,6 @@
           <context context-type="linenumber">80,81</context>
         </context-group>
         <note priority="1" from="description">Button to download data</note>
-      </trans-unit>
-      <trans-unit id="5e589ae47ed0c90beb209018a8f60ed492d8ad8d" datatype="html">
-        <source>Install App</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">12</context>
-        </context-group>
-        <note priority="1" from="description">PWA Install Button Label</note>
-      </trans-unit>
-      <trans-unit id="240687bf23ceecb815aa0788691b36fc61468b53" datatype="html">
-        <source> To install the app </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">17,18</context>
-        </context-group>
-        <note priority="1" from="description">PWA iOS Install Instructions - Line 1</note>
-      </trans-unit>
-      <trans-unit id="8beef6deafdec7914c3971782faad2ac1e66604d" datatype="html">
-        <source> tap on </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">29,30</context>
-        </context-group>
-        <note priority="1" from="description">PWA iOS Install Instructions - Line 2-1</note>
-      </trans-unit>
-      <trans-unit id="5e1fef8419bb00629ae0fe59c98feced66824e11" datatype="html">
-        <source> at the bottom </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">34,35</context>
-        </context-group>
-        <note priority="1" from="description">PWA iOS Install Instructions - Line 2-2</note>
-      </trans-unit>
-      <trans-unit id="6ac57c355739ba746bcfb893197082f53ac6ee75" datatype="html">
-        <source> and then tap on </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">39,40</context>
-        </context-group>
-        <note priority="1" from="description">PWA iOS Install Instructions - Line 3-1</note>
-      </trans-unit>
-      <trans-unit id="26c649bd93b5051b07a9aed12f707cfa401553d7" datatype="html">
-        <source> (Add to Homescreen). </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pwa-install/pwa-install.component.html</context>
-          <context context-type="linenumber">43,44</context>
-        </context-group>
-        <note priority="1" from="description">PWA iOS Install Instructions - Line 3-2</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
In some dashboard widgets, the `loading...` had no translation or was not even there at all.

### Visible/Frontend Changes
- [x] `loading...` is translated for all dashboards where it is used
- [x] loading indicator for `ChildrenCountDashboard`

### Architectural/Backend Changes
- [x] Moved loading indicator to `DashboardWidget` wrapper
