### PR TITLE
fix: index.html in root is correctly cached

### DIFF
--- a/build/default.conf
+++ b/build/default.conf
@@ -15,7 +15,7 @@ server {
     }
 
     # Service Worker requests should not be changed
-    location ~* ^/ngsw- {
+    location ~* ^/ngsw {
         try_files $uri =404;
     }
 

--- a/build/default.conf
+++ b/build/default.conf
@@ -14,6 +14,11 @@ server {
         try_files $uri /assets/$1 =404;
     }
 
+    # Service Worker requests should not be changed
+    location ~* ^/ngsw- {
+        try_files $uri =404;
+    }
+
     location /de {
         index  index.html index.htm;
         try_files $uri $uri/ /de/index.html;
@@ -29,9 +34,9 @@ server {
         try_files $uri $uri/ /en-US/index.html;
     }
 
-    # Set the default language when nothing is entered in the url
+    # Append the default language when no other path matches (e.g. requesting root index.html)
     location / {
-        try_files $uri /${DEFAULT_LANGUAGE}/index.html;
+        rewrite ^/ /${DEFAULT_LANGUAGE}/$uri;
     }
 
     #error_page  404              /404.html;

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -50,10 +50,11 @@ fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
 const swFile = fs
   .readFileSync(`${distFolder}/${firstLocale}/ngsw-worker.js`)
   .toString();
-const patchedSw = swFile.replace(
-  "return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);",
-  "return this.handleFetch(this.adapter.newRequest('/' + this.adapter.normalizeUrl(req.url).split('/')[1] + '/index.html'), context);"
-);
+//TODO this might be an issue in the root request
+// const patchedSw = swFile.replace(
+//   "return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);",
+//   "return this.handleFetch(this.adapter.newRequest('/' + this.adapter.normalizeUrl(req.url).split('/')[1] + '/index.html'), context);"
+// );
 fs.writeFileSync(`${distFolder}/ngsw-worker.js`, patchedSw);
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw-worker.js`);
 fs.renameSync(

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -47,15 +47,15 @@ fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
 
 // Adjust service worker to allow changing language offline
-const swFile = fs
-  .readFileSync(`${distFolder}/${firstLocale}/ngsw-worker.js`)
-  .toString();
+// const swFile = fs
+//   .readFileSync(`${distFolder}/${firstLocale}/ngsw-worker.js`)
+//   .toString();
 //TODO this might be an issue in the root request
 // const patchedSw = swFile.replace(
 //   "return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);",
 //   "return this.handleFetch(this.adapter.newRequest('/' + this.adapter.normalizeUrl(req.url).split('/')[1] + '/index.html'), context);"
 // );
-fs.writeFileSync(`${distFolder}/ngsw-worker.js`, patchedSw);
+// fs.writeFileSync(`${distFolder}/ngsw-worker.js`, patchedSw);
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw-worker.js`);
 fs.renameSync(
   `${distFolder}/${firstLocale}/safety-worker.js`,

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -41,6 +41,7 @@ locales.forEach((locale) => {
 });
 
 combined.index = "/index.html";
+combined["assetGroups"][0]["urls"].push("/index.html");
 
 fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);

--- a/build/merge-service-workers.js
+++ b/build/merge-service-workers.js
@@ -47,15 +47,15 @@ fs.writeFileSync(`${distFolder}/ngsw.json`, JSON.stringify(combined));
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw.json`);
 
 // Adjust service worker to allow changing language offline
-// const swFile = fs
-//   .readFileSync(`${distFolder}/${firstLocale}/ngsw-worker.js`)
-//   .toString();
+const swFile = fs
+  .readFileSync(`${distFolder}/${firstLocale}/ngsw-worker.js`)
+  .toString();
 //TODO this might be an issue in the root request
 // const patchedSw = swFile.replace(
 //   "return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);",
 //   "return this.handleFetch(this.adapter.newRequest('/' + this.adapter.normalizeUrl(req.url).split('/')[1] + '/index.html'), context);"
 // );
-// fs.writeFileSync(`${distFolder}/ngsw-worker.js`, patchedSw);
+fs.writeFileSync(`${distFolder}/ngsw-worker.js`, swFile);
 fs.unlinkSync(`${distFolder}/${firstLocale}/ngsw-worker.js`);
 fs.renameSync(
   `${distFolder}/${firstLocale}/safety-worker.js`,


### PR DESCRIPTION
Currently our offline functionality still has some limits. To reproduce:

1. Clear browser cache (at least for demo.aam-digital.com)
2. Visit https://demo.aam-digital.com/en-US/
3. Turn off internet
4. Reload page -> should work
5. Visit https://demo.aam-digital.com/
6. Does **not** work (not even `loading...` is shown)

This is because the root `index.html` (e.g. `https://demo.aam-digital.com/index.html`) is not actively cached by the service worker. 
This PR changes this and adds correct handling of requests to root without locale.
Try the same with https://test-deployment-pr-1266.herokuapp.com/en-US/ and https://test-deployment-pr-1266.herokuapp.com/ and it should work.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Currently the `index.html` on root (e.g. `demo.aam-digital.com`) is not defined in the `ngsw.json` and only sometimes cached. This is no changed to `prefetch` which means it will actively be loaded and cached by the service worker
