### PR TITLE
ci(*): remove pre-releases when publishing new official release

### DIFF
--- a/.github/workflows/pre-release-cleanup.yml
+++ b/.github/workflows/pre-release-cleanup.yml
@@ -1,0 +1,18 @@
+name: Pre-Release Cleanup
+on:
+  push:
+    branches:
+      - official-release
+
+jobs:
+  remove-pre-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Previous Pre-Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          keep_latest: 0
+          delete_tag_pattern: master
+          delete_tags: true


### PR DESCRIPTION
closes #1138

I tested the referenced Github Action (https://github.com/dev-drprasad/delete-older-releases), running it locally to manually clean up pre-releases a few times. That worked seamlessly.