### PR TITLE
fix(*): Student overview correctly shows assigned students

### DIFF
--- a/.github/workflows/pre-release-cleanup.yml
+++ b/.github/workflows/pre-release-cleanup.yml
@@ -1,0 +1,18 @@
+name: Pre-Release Cleanup
+on:
+  push:
+    branches:
+      - official-release
+
+jobs:
+  remove-pre-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Previous Pre-Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          keep_latest: 0
+          delete_tag_pattern: master
+          delete_tags: true

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
@@ -25,8 +25,8 @@ describe("RollCallSetupComponent", () => {
   let mockAttendanceService: jasmine.SpyObj<AttendanceService>;
 
   beforeEach(() => {
-    mockChildrenService = jasmine.createSpyObj(["queryRelationsOf"]);
-    mockChildrenService.queryRelationsOf.and.resolveTo([]);
+    mockChildrenService = jasmine.createSpyObj(["queryActiveRelationsOf"]);
+    mockChildrenService.queryActiveRelationsOf.and.resolveTo([]);
     mockAttendanceService = jasmine.createSpyObj([
       "getEventsOnDate",
       "createEventForActivity",

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -120,10 +120,7 @@ describe("AttendanceService", () => {
     childSchool2.childId = "3";
     childSchool2.schoolId = linkedSchoolId;
     childSchool2.start = new Date();
-    spyOn(TestBed.inject(ChildrenService), "queryRelationsOf").and.resolveTo([
-      childSchool1,
-      childSchool2,
-    ]);
+    await entityMapper.saveAll([childSchool1, childSchool2]);
 
     const testNoteWithSchool = Note.create(new Date("2021-01-01"));
     testNoteWithSchool.children = ["1", "2"];
@@ -209,10 +206,7 @@ describe("AttendanceService", () => {
     const testActivity = RecurringActivity.create("new activity");
     testActivity.linkedGroups.push("testSchool");
 
-    spyOn(TestBed.inject(ChildrenService), "queryRelationsOf").and.resolveTo([
-      childSchoolRelation,
-    ]);
-    await entityMapper.save(testActivity);
+    await entityMapper.saveAll([testActivity, childSchoolRelation]);
 
     const activities = await service.getActivitiesForChild("testChild");
     expectEntitiesToMatch(activities, [testActivity]);
@@ -240,14 +234,14 @@ describe("AttendanceService", () => {
     const inactiveActivity = RecurringActivity.create("inactive activity");
     inactiveActivity.linkedGroups.push(inactiveRelation.schoolId);
 
-    spyOn(TestBed.inject(ChildrenService), "queryRelationsOf").and.resolveTo([
+    await entityMapper.saveAll([
       activeRelation1,
       inactiveRelation,
       activeRelation2,
+      activeActivity1,
+      activeActivity2,
+      inactiveActivity,
     ]);
-    await entityMapper.save(activeActivity1);
-    await entityMapper.save(activeActivity2);
-    await entityMapper.save(inactiveActivity);
 
     const activities = await service.getActivitiesForChild("testChild");
     expectEntitiesToMatch(activities, [activeActivity1, activeActivity2]);
@@ -262,10 +256,7 @@ describe("AttendanceService", () => {
     activity.linkedGroups.push(relation.schoolId);
     activity.participants.push(relation.childId);
 
-    spyOn(TestBed.inject(ChildrenService), "queryRelationsOf").and.resolveTo([
-      relation,
-    ]);
-    await entityMapper.save(activity);
+    await entityMapper.saveAll([activity, relation]);
 
     const activities = await service.getActivitiesForChild(relation.childId);
 
@@ -306,12 +297,11 @@ describe("AttendanceService", () => {
     const duplicateChild = new Child();
     const duplicateChildRelation = new ChildSchoolRelation();
     duplicateChildRelation.childId = duplicateChild.getId();
+    duplicateChildRelation.schoolId = linkedSchool.getId();
     const anotherRelation = new ChildSchoolRelation();
     anotherRelation.childId = "another child id";
-    spyOn(TestBed.inject(ChildrenService), "queryRelationsOf").and.resolveTo([
-      duplicateChildRelation,
-      anotherRelation,
-    ]);
+    anotherRelation.schoolId = linkedSchool.getId();
+    await entityMapper.saveAll([duplicateChildRelation, anotherRelation]);
 
     const directlyAddedChild = new Child();
     activity.participants.push(

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -272,7 +272,7 @@ describe("AttendanceService", () => {
     childAttendingSchool.childId = "child attending school";
     const mockQueryRelationsOf = spyOn(
       TestBed.inject(ChildrenService),
-      "queryRelationsOf"
+      "queryActiveRelationsOf"
     ).and.resolveTo([childAttendingSchool]);
 
     const directlyAddedChild = new Child();

--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -217,7 +217,7 @@ export class AttendanceService {
       childId
     );
 
-    const visitedSchools = await this.childrenService.queryRelationsOf(
+    const visitedSchools = await this.childrenService.queryActiveRelationsOf(
       "child",
       childId
     );
@@ -267,7 +267,7 @@ export class AttendanceService {
   ): Promise<string[]> {
     const childIdPromises = linkedGroups.map((groupId) =>
       this.childrenService
-        .queryRelationsOf("school", groupId)
+        .queryActiveRelationsOf("school", groupId)
         .then((relations) =>
           relations.map((r) => r.childId).filter((id) => !!id)
         )

--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -217,9 +217,10 @@ export class AttendanceService {
       childId
     );
 
-    const visitedSchools = (
-      await this.childrenService.queryRelationsOf("child", childId)
-    ).filter((relation) => relation.isActive);
+    const visitedSchools = await this.childrenService.queryRelationsOf(
+      "child",
+      childId
+    );
     for (const currentRelation of visitedSchools) {
       const activitiesThroughRelation = await this.dbIndexing.queryIndexDocs(
         RecurringActivity,

--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -154,7 +154,7 @@ describe("ChildrenService", () => {
   });
 
   it("should get the relations for a child in sorted order", async () => {
-    const relations = await service.queryRelationsOf("child", "3", false);
+    const relations = await service.queryRelationsOf("child", "3");
 
     expect(relations).toHaveSize(2);
     expect(relations[0].start.getTime()).toBeGreaterThanOrEqual(
@@ -163,7 +163,7 @@ describe("ChildrenService", () => {
   });
 
   it("should get all relations for a school", async () => {
-    const relations = await service.queryRelationsOf("school", "1", false);
+    const relations = await service.queryRelationsOf("school", "1");
 
     expect(relations).toHaveSize(2);
     const relation1 = relations.find((relation) => relation.getId() === "1");
@@ -177,7 +177,7 @@ describe("ChildrenService", () => {
     todayRelation.schoolId = "3";
     todayRelation.start = new Date();
     await entityMapper.save(todayRelation);
-    const relations = await service.queryRelationsOf("school", "3");
+    const relations = await service.queryActiveRelationsOf("school", "3");
     expectEntitiesToMatch(relations, [todayRelation]);
   });
 
@@ -187,7 +187,7 @@ describe("ChildrenService", () => {
       .filter((rel) => rel.isActive && rel.childId === "3")
       .sort(sortByAttribute("start", "desc"));
 
-    const result = await service.queryRelationsOf("child", "3");
+    const result = await service.queryActiveRelationsOf("child", "3");
     expect(result).toEqual(activeRelations);
   });
 });

--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -10,6 +10,7 @@ import { Note } from "../notes/model/note";
 import { genders } from "./model/genders";
 import { DatabaseTestingModule } from "../../utils/database-testing.module";
 import { sortByAttribute } from "../../utils/utils";
+import { expectEntitiesToMatch } from "../../utils/expect-entity-data.spec";
 
 describe("ChildrenService", () => {
   let service: ChildrenService;
@@ -106,14 +107,37 @@ describe("ChildrenService", () => {
     expect(recentNotesMap.get(c0)).toBePositiveInfinity();
   });
 
-  it("should load a single child with school info", async () => {
-    const child1 = await service.getChild("1").toPromise();
-    expect(child1.schoolClass).toBe("2");
-    expect(child1.schoolId).toBe("1");
-
+  it("should load a single child and add school info", async () => {
+    // no active relation
     const child2 = await service.getChild("2").toPromise();
     expect(child2.schoolClass).toBeUndefined();
     expect(child2.schoolId).toBeUndefined();
+
+    // one active relation
+    let child1 = await service.getChild("1").toPromise();
+    expect(child1.schoolClass).toBe("2");
+    expect(child1.schoolId).toBe("1");
+
+    // multiple active relations
+    const newRelation = new ChildSchoolRelation();
+    newRelation.childId = child1.getId();
+    newRelation.start = new Date();
+    newRelation.schoolId = "2";
+    newRelation.schoolClass = "3";
+    await entityMapper.save(newRelation);
+    child1 = await service.getChild(child1.getId()).toPromise();
+    expect(child1.schoolClass).toBe("3");
+    expect(child1.schoolId).toBe("2");
+
+    // multiple active, no start date on one
+    const noStartDate = new ChildSchoolRelation();
+    noStartDate.childId = child1.getId();
+    noStartDate.schoolId = "2";
+    noStartDate.schoolClass = "4";
+    await entityMapper.save(noStartDate);
+    child1 = await service.getChild(child1.getId()).toPromise();
+    expect(child1.schoolClass).toBe("4");
+    expect(child1.schoolId).toBe("2");
   });
 
   it("should load all children with school info", async () => {
@@ -130,7 +154,7 @@ describe("ChildrenService", () => {
   });
 
   it("should get the relations for a child in sorted order", async () => {
-    const relations = await service.queryRelationsOf("child", "3");
+    const relations = await service.queryRelationsOf("child", "3", false);
 
     expect(relations).toHaveSize(2);
     expect(relations[0].start.getTime()).toBeGreaterThanOrEqual(
@@ -139,7 +163,7 @@ describe("ChildrenService", () => {
   });
 
   it("should get all relations for a school", async () => {
-    const relations = await service.queryRelationsOf("school", "1");
+    const relations = await service.queryRelationsOf("school", "1", false);
 
     expect(relations).toHaveSize(2);
     const relation1 = relations.find((relation) => relation.getId() === "1");
@@ -153,18 +177,17 @@ describe("ChildrenService", () => {
     todayRelation.schoolId = "3";
     todayRelation.start = new Date();
     await entityMapper.save(todayRelation);
-    const relations = await service.queryRelationsOf("school", "3", true);
-    expect(relations).toHaveSize(1);
-    expect(relations[0]).toHaveId(todayRelation.getId());
+    const relations = await service.queryRelationsOf("school", "3");
+    expectEntitiesToMatch(relations, [todayRelation]);
   });
 
-  it("should only return active relations if specified", async () => {
+  it("should on default only return active relations", async () => {
     const allRelations = await entityMapper.loadType(ChildSchoolRelation);
     const activeRelations = allRelations
       .filter((rel) => rel.isActive && rel.childId === "3")
       .sort(sortByAttribute("start", "desc"));
 
-    const result = await service.queryRelationsOf("child", "3", true);
+    const result = await service.queryRelationsOf("child", "3");
     expect(result).toEqual(activeRelations);
   });
 });

--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -8,8 +8,8 @@ import moment from "moment";
 import { Database } from "../../core/database/database";
 import { Note } from "../notes/model/note";
 import { genders } from "./model/genders";
-import { skip } from "rxjs/operators";
 import { DatabaseTestingModule } from "../../utils/database-testing.module";
+import { sortByAttribute } from "../../utils/utils";
 
 describe("ChildrenService", () => {
   let service: ChildrenService;
@@ -72,30 +72,6 @@ describe("ChildrenService", () => {
 
   // TODO: test getAttendances
 
-  it("should find latest ChildSchoolRelation of a child", async () => {
-    const children = await service.getChildren().toPromise();
-    const promises: Promise<any>[] = [];
-    expect(children).not.toBeEmpty();
-    children.forEach((child) =>
-      promises.push(verifyLatestChildRelations(child, service))
-    );
-    await Promise.all(promises);
-  });
-
-  it("should return ChildSchoolRelations of child in correct order", (done: DoneFn) => {
-    service
-      .getChildren()
-      .toPromise()
-      .then((children) => {
-        const promises: Promise<any>[] = [];
-        expect(children).not.toBeEmpty();
-        children.forEach((child) =>
-          promises.push(verifyChildRelationsOrder(child, service))
-        );
-        Promise.all(promises).then(() => done());
-      });
-  });
-
   it("calculates days since last note for children", async () => {
     const allChildren = await entityMapper.loadType(Child);
 
@@ -130,31 +106,31 @@ describe("ChildrenService", () => {
     expect(recentNotesMap.get(c0)).toBePositiveInfinity();
   });
 
-  it("should set school class and id", async () => {
+  it("should load a single child with school info", async () => {
     const child1 = await service.getChild("1").toPromise();
     expect(child1.schoolClass).toBe("2");
     expect(child1.schoolId).toBe("1");
 
     const child2 = await service.getChild("2").toPromise();
-    expect(child2.schoolClass).toBeNull();
-    expect(child2.schoolId).toBeNull();
+    expect(child2.schoolClass).toBeUndefined();
+    expect(child2.schoolId).toBeUndefined();
   });
 
   it("should load all children with school info", async () => {
-    const children = await service.getChildren().pipe(skip(1)).toPromise();
+    const children = await service.getChildren().toPromise();
     const child1 = children.find((child) => child.getId() === "1");
     expect(child1.schoolClass).toBe("2");
     expect(child1.schoolId).toBe("1");
     const child2 = children.find((child) => child.getId() === "2");
-    expect(child2.schoolClass).toBeNull();
-    expect(child2.schoolId).toBeNull();
+    expect(child2.schoolClass).toBeUndefined();
+    expect(child2.schoolId).toBeUndefined();
     const child3 = children.find((child) => child.getId() === "3");
     expect(child3.schoolClass).toBe("2");
     expect(child3.schoolId).toBe("1");
   });
 
   it("should get the relations for a child in sorted order", async () => {
-    const relations = await service.querySortedRelations("3");
+    const relations = await service.queryRelationsOf("child", "3");
 
     expect(relations).toHaveSize(2);
     expect(relations[0].start.getTime()).toBeGreaterThanOrEqual(
@@ -172,14 +148,24 @@ describe("ChildrenService", () => {
     expect(relation2.childId).toBe("3");
   });
 
-  it("should get a relation which starts today", async () => {
+  it("should get a active relation which starts today", async () => {
     const todayRelation = new ChildSchoolRelation("today");
     todayRelation.schoolId = "3";
     todayRelation.start = new Date();
     await entityMapper.save(todayRelation);
-    const relations = await service.queryRelationsOf("school", "3");
+    const relations = await service.queryRelationsOf("school", "3", true);
     expect(relations).toHaveSize(1);
     expect(relations[0]).toHaveId(todayRelation.getId());
+  });
+
+  it("should only return active relations if specified", async () => {
+    const allRelations = await entityMapper.loadType(ChildSchoolRelation);
+    const activeRelations = allRelations
+      .filter((rel) => rel.isActive && rel.childId === "3")
+      .sort(sortByAttribute("start", "desc"));
+
+    const result = await service.queryRelationsOf("child", "3", true);
+    expect(result).toEqual(activeRelations);
   });
 });
 
@@ -266,52 +252,4 @@ function generateChildSchoolRelationEntities(): ChildSchoolRelation[] {
   data.push(rel3);
 
   return data;
-}
-
-function compareRelations(a: ChildSchoolRelation, b: ChildSchoolRelation) {
-  expect(a.getId()).toEqual(b.getId());
-  expect(a.schoolClass).toEqual(b.schoolClass);
-  expect(a.schoolId).toEqual(b.schoolId);
-  expect(a.childId).toEqual(b.childId);
-  expect(moment(a.start).isSame(b.start, "day")).toBeTrue();
-  expect(moment(a.end).isSame(b.end, "day")).toBeTrue();
-}
-
-async function verifyChildRelationsOrder(
-  child: Child,
-  childrenService: ChildrenService
-) {
-  const relations = await childrenService.queryRelationsOf(
-    "child",
-    child.getId()
-  );
-  relations.sort((a, b) => compareStartDate(a, b));
-  const res = await childrenService.querySortedRelations(child.getId());
-  expect(res.length).toBe(relations.length);
-  for (let i = 0; i < res.length; i++) {
-    compareRelations(res[i], relations[i]);
-  }
-}
-
-async function verifyLatestChildRelations(
-  child: Child,
-  childrenService: ChildrenService
-) {
-  const relations = await childrenService.queryRelationsOf(
-    "child",
-    child.getId()
-  );
-
-  relations.sort((a, b) => compareStartDate(a, b));
-  const res = await childrenService.queryLatestRelation(child.getId());
-  compareRelations(res, relations[0]);
-}
-
-function compareStartDate(a: ChildSchoolRelation, b: ChildSchoolRelation) {
-  const aValue = new Date(a.start);
-  const bValue = new Date(b.start);
-  if (aValue === bValue) {
-    return 0;
-  }
-  return aValue > bValue ? -1 : 1;
 }

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -93,7 +93,7 @@ export class ChildrenService {
   queryLatestRelation(
     childId: string
   ): Promise<ChildSchoolRelation | undefined> {
-    return this.queryRelationsOf("child", childId, true).then((relations) =>
+    return this.queryRelationsOf("child", childId).then((relations) =>
       relations.length > 0 ? relations[0] : undefined
     );
   }
@@ -101,7 +101,7 @@ export class ChildrenService {
   async queryRelationsOf(
     queryType: "child" | "school",
     id: string,
-    onlyActive = false
+    onlyActive = true
   ): Promise<ChildSchoolRelation[]> {
     let relations = await this.dbIndexing.queryIndexDocs(
       ChildSchoolRelation,
@@ -112,7 +112,7 @@ export class ChildrenService {
         descending: true,
       }
     );
-    if (onlyActive) {
+    if (onlyActive === true) {
       relations = relations.filter((rel) => rel.isActive);
     }
     return relations;

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -40,11 +40,11 @@ export class ChildrenService {
       results.next(loadedChildren);
 
       for (const loadedChild of loadedChildren) {
-        const childCurrentSchoolInfo = await this.getCurrentSchoolInfoForChild(
+        const childCurrentSchoolInfo = await this.queryLatestRelation(
           loadedChild.getId()
         );
-        loadedChild.schoolClass = childCurrentSchoolInfo.schoolClass;
-        loadedChild.schoolId = childCurrentSchoolInfo.schoolId;
+        loadedChild.schoolClass = childCurrentSchoolInfo?.schoolClass;
+        loadedChild.schoolId = childCurrentSchoolInfo?.schoolId;
       }
       results.next(loadedChildren);
       results.complete();
@@ -61,13 +61,11 @@ export class ChildrenService {
     const promise = this.entityMapper
       .load<Child>(Child, id)
       .then((loadedChild) => {
-        return this.getCurrentSchoolInfoForChild(id).then(
-          (currentSchoolInfo) => {
-            loadedChild.schoolClass = currentSchoolInfo.schoolClass;
-            loadedChild.schoolId = currentSchoolInfo.schoolId;
-            return loadedChild;
-          }
-        );
+        return this.queryLatestRelation(id).then((currentSchoolInfo) => {
+          loadedChild.schoolClass = currentSchoolInfo?.schoolClass;
+          loadedChild.schoolId = currentSchoolInfo?.schoolId;
+          return loadedChild;
+        });
       });
     return from(promise);
   }
@@ -79,30 +77,13 @@ export class ChildrenService {
         by_child: {
           map: `(doc) => {
             if (!doc._id.startsWith("${ChildSchoolRelation.ENTITY_TYPE}")) return;
-            emit(doc.childId);
-            }`,
+            emit([doc.childId, new Date(doc.start || '3000-01-01').getTime()]);
+          }`,
         },
         by_school: {
           map: `(doc) => {
-            if ( (!doc._id.startsWith("${ChildSchoolRelation.ENTITY_TYPE}")) ||
-                (doc.start && isAfterToday(new Date(doc.start))) ||
-                (doc.end && !isAfterToday(new Date(doc.end))) ) {
-              return;
-            }
-            emit(doc.schoolId);
-            function isAfterToday(date) {
-              const tomorrow = new Date();
-              tomorrow.setHours(0, 0, 0, 0);
-              tomorrow.setDate(tomorrow.getDate() + 1);
-              return date >= tomorrow;
-            }
-            }`,
-        },
-        by_date: {
-          map: `(doc) => {
             if (!doc._id.startsWith("${ChildSchoolRelation.ENTITY_TYPE}")) return;
-            let timestamp = (new Date(doc.start || '3000-01-01')).getTime().toString().padStart(14, "0");
-            emit(doc.childId + '_' + timestamp);
+            emit([doc.schoolId]);
             }`,
         },
       },
@@ -110,39 +91,32 @@ export class ChildrenService {
     return this.dbIndexing.createIndex(designDoc);
   }
 
-  queryLatestRelation(childId: string): Promise<ChildSchoolRelation> {
-    return this.querySortedRelations(childId, 1).then(
-      (children) => children[0]
-    );
-  }
-
-  async querySortedRelations(
-    childId: string,
-    limit?: number
-  ): Promise<ChildSchoolRelation[]> {
-    const options: QueryOptions = {
-      startkey: childId + "_\uffff", //  higher value needs to be startkey
-      endkey: childId + "_", //  \uffff is not a character -> only relations staring with childId will be selected
-      descending: true,
-      include_docs: true,
-      limit: limit,
-    };
-    return this.dbIndexing.queryIndexDocs(
-      ChildSchoolRelation,
-      "childSchoolRelations_index/by_date",
-      options
+  queryLatestRelation(
+    childId: string
+  ): Promise<ChildSchoolRelation | undefined> {
+    return this.queryRelationsOf("child", childId, true).then((relations) =>
+      relations.length > 0 ? relations[0] : undefined
     );
   }
 
   async queryRelationsOf(
     queryType: "child" | "school",
-    id: string
+    id: string,
+    onlyActive = false
   ): Promise<ChildSchoolRelation[]> {
-    return this.dbIndexing.queryIndexDocs(
+    let relations = await this.dbIndexing.queryIndexDocs(
       ChildSchoolRelation,
       "childSchoolRelations_index/by_" + queryType,
-      id
+      {
+        startkey: [id, "\uffff"],
+        endkey: [id],
+        descending: true,
+      }
     );
+    if (onlyActive) {
+      relations = relations.filter((rel) => rel.isActive);
+    }
+    return relations;
   }
 
   getNotesOfChild(childId: string): Observable<Note[]> {
@@ -260,31 +234,5 @@ export class ChildrenService {
         return loadedEntities.filter((o) => o.child === childId);
       })
     );
-  }
-
-  async getCurrentSchoolInfoForChild(
-    childId: string
-  ): Promise<{ schoolId: string; schoolClass: string }> {
-    const relations = (await this.querySortedRelations(childId)) || [];
-    for (const rel of relations) {
-      if (
-        moment(rel.start).isSameOrBefore(moment(), "days") &&
-        moment(rel.end).isSameOrAfter(moment(), "days")
-      ) {
-        return {
-          schoolId: rel.schoolId,
-          schoolClass: rel.schoolClass,
-        };
-      }
-    }
-
-    return {
-      schoolId: null,
-      schoolClass: null,
-    };
-  }
-
-  getSchoolRelationsFor(childId: string): Promise<ChildSchoolRelation[]> {
-    return this.querySortedRelations(childId);
   }
 }

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -11,7 +11,6 @@ import { ChildPhotoService } from "./child-photo-service/child-photo.service";
 import moment, { Moment } from "moment";
 import { LoggingService } from "../../core/logging/logging.service";
 import { DatabaseIndexingService } from "../../core/entity/database-indexing/database-indexing.service";
-import { QueryOptions } from "../../core/database/database";
 
 @Injectable()
 export class ChildrenService {

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -93,17 +93,25 @@ export class ChildrenService {
   queryLatestRelation(
     childId: string
   ): Promise<ChildSchoolRelation | undefined> {
-    return this.queryRelationsOf("child", childId).then((relations) =>
+    return this.queryActiveRelationsOf("child", childId).then((relations) =>
       relations.length > 0 ? relations[0] : undefined
     );
   }
 
-  async queryRelationsOf(
+  queryActiveRelationsOf(
     queryType: "child" | "school",
-    id: string,
-    onlyActive = true
+    id: string
   ): Promise<ChildSchoolRelation[]> {
-    let relations = await this.dbIndexing.queryIndexDocs(
+    return this.queryRelationsOf(queryType, id).then((relations) =>
+      relations.filter((rel) => rel.isActive)
+    );
+  }
+
+  queryRelationsOf(
+    queryType: "child" | "school",
+    id: string
+  ): Promise<ChildSchoolRelation[]> {
+    return this.dbIndexing.queryIndexDocs(
       ChildSchoolRelation,
       "childSchoolRelations_index/by_" + queryType,
       {
@@ -112,10 +120,6 @@ export class ChildrenService {
         descending: true,
       }
     );
-    if (onlyActive === true) {
-      relations = relations.filter((rel) => rel.isActive);
-    }
-    return relations;
   }
 
   getNotesOfChild(childId: string): Observable<Note[]> {

--- a/src/app/child-dev-project/children/model/childSchoolRelation.ts
+++ b/src/app/child-dev-project/children/model/childSchoolRelation.ts
@@ -70,8 +70,7 @@ export class ChildSchoolRelation extends Entity {
    */
   isActiveAt(date: Date): boolean {
     return (
-      this.start &&
-      moment(this.start).isSameOrBefore(date, "day") &&
+      (!this.start || moment(this.start).isSameOrBefore(date, "day")) &&
       (!this.end || moment(this.end).isSameOrAfter(date, "day"))
     );
   }

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
@@ -63,7 +63,8 @@ describe("PreviousSchoolsComponent", () => {
     tick();
     expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
       "child",
-      testChild.getId()
+      testChild.getId(),
+      false
     );
   }));
 

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
@@ -63,8 +63,7 @@ describe("PreviousSchoolsComponent", () => {
     tick();
     expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
       "child",
-      testChild.getId(),
-      false
+      testChild.getId()
     );
   }));
 

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.spec.ts
@@ -27,8 +27,8 @@ describe("PreviousSchoolsComponent", () => {
 
   beforeEach(
     waitForAsync(() => {
-      mockChildrenService = jasmine.createSpyObj(["getSchoolRelationsFor"]);
-      mockChildrenService.getSchoolRelationsFor.and.resolveTo([
+      mockChildrenService = jasmine.createSpyObj(["queryRelationsOf"]);
+      mockChildrenService.queryRelationsOf.and.resolveTo([
         new ChildSchoolRelation(),
       ]);
 
@@ -61,7 +61,8 @@ describe("PreviousSchoolsComponent", () => {
       child: new SimpleChange(undefined, testChild, false),
     });
     tick();
-    expect(mockChildrenService.getSchoolRelationsFor).toHaveBeenCalledWith(
+    expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
+      "child",
       testChild.getId()
     );
   }));

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
@@ -55,7 +55,11 @@ export class PreviousSchoolsComponent
       return;
     }
 
-    this.records = await this.childrenService.queryRelationsOf("child", id);
+    this.records = await this.childrenService.queryRelationsOf(
+      "child",
+      id,
+      false
+    );
     this.hasCurrentlyActiveEntry = this.records.some(
       (record) => record.isActive
     );

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
@@ -55,11 +55,7 @@ export class PreviousSchoolsComponent
       return;
     }
 
-    this.records = await this.childrenService.queryRelationsOf(
-      "child",
-      id,
-      false
-    );
+    this.records = await this.childrenService.queryRelationsOf("child", id);
     this.hasCurrentlyActiveEntry = this.records.some(
       (record) => record.isActive
     );

--- a/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
+++ b/src/app/child-dev-project/children/previous-schools/previous-schools.component.ts
@@ -55,7 +55,7 @@ export class PreviousSchoolsComponent
       return;
     }
 
-    this.records = await this.childrenService.getSchoolRelationsFor(id);
+    this.records = await this.childrenService.queryRelationsOf("child", id);
     this.hasCurrentlyActiveEntry = this.records.some(
       (record) => record.isActive
     );

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
@@ -55,8 +55,7 @@ describe("ChildrenOverviewComponent", () => {
 
     expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
       "school",
-      school.getId(),
-      true
+      school.getId()
     );
     expect(component.records).toEqual([relation1, relation2]);
   }));

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
@@ -55,7 +55,8 @@ describe("ChildrenOverviewComponent", () => {
 
     expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
       "school",
-      school.getId()
+      school.getId(),
+      true
     );
     expect(component.records).toEqual([relation1, relation2]);
   }));

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.spec.ts
@@ -21,7 +21,7 @@ describe("ChildrenOverviewComponent", () => {
 
   beforeEach(
     waitForAsync(() => {
-      mockChildrenService = jasmine.createSpyObj(["queryRelationsOf"]);
+      mockChildrenService = jasmine.createSpyObj(["queryActiveRelationsOf"]);
 
       TestBed.configureTestingModule({
         imports: [SchoolsModule, MockedTestingModule.withState()],
@@ -48,12 +48,15 @@ describe("ChildrenOverviewComponent", () => {
     const relation1 = new ChildSchoolRelation("r1");
     const relation2 = new ChildSchoolRelation("r2");
     const config = { entity: school };
-    mockChildrenService.queryRelationsOf.and.resolveTo([relation1, relation2]);
+    mockChildrenService.queryActiveRelationsOf.and.resolveTo([
+      relation1,
+      relation2,
+    ]);
 
     component.onInitFromDynamicConfig(config);
     tick();
 
-    expect(mockChildrenService.queryRelationsOf).toHaveBeenCalledWith(
+    expect(mockChildrenService.queryActiveRelationsOf).toHaveBeenCalledWith(
       "school",
       school.getId()
     );

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
@@ -55,7 +55,8 @@ export class ChildrenOverviewComponent implements OnInitDynamicComponent {
     this.entity = config.entity;
     this.records = await this.childrenService.queryRelationsOf(
       "school",
-      this.entity.getId()
+      this.entity.getId(),
+      true
     );
   }
 

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
@@ -53,7 +53,7 @@ export class ChildrenOverviewComponent implements OnInitDynamicComponent {
       this.columns = config.config.columns.concat(isActiveIndicator);
     }
     this.entity = config.entity;
-    this.records = await this.childrenService.queryRelationsOf(
+    this.records = await this.childrenService.queryActiveRelationsOf(
       "school",
       this.entity.getId()
     );

--- a/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
+++ b/src/app/child-dev-project/schools/children-overview/children-overview.component.ts
@@ -55,8 +55,7 @@ export class ChildrenOverviewComponent implements OnInitDynamicComponent {
     this.entity = config.entity;
     this.records = await this.childrenService.queryRelationsOf(
       "school",
-      this.entity.getId(),
-      true
+      this.entity.getId()
     );
   }
 

--- a/src/app/core/entity-components/entity-details/entity-details.component.spec.ts
+++ b/src/app/core/entity-components/entity-details/entity-details.component.spec.ts
@@ -65,11 +65,11 @@ describe("EntityDetailsComponent", () => {
   beforeEach(
     waitForAsync(() => {
       mockChildrenService = jasmine.createSpyObj([
-        "getSchoolRelationsFor",
+        "queryRelationsOf",
         "getAserResultsOfChild",
       ]);
       mockEntityRemoveService = jasmine.createSpyObj(["remove"]);
-      mockChildrenService.getSchoolRelationsFor.and.resolveTo([]);
+      mockChildrenService.queryRelationsOf.and.resolveTo([]);
       mockChildrenService.getAserResultsOfChild.and.returnValue(of([]));
       mockAbility = jasmine.createSpyObj(["cannot", "update"]);
       mockAbility.cannot.and.returnValue(false);

--- a/src/app/features/historical-data/historical-data.service.ts
+++ b/src/app/features/historical-data/historical-data.service.ts
@@ -31,7 +31,7 @@ export class HistoricalDataService {
       HistoricalEntityData,
       "historicalData_index/by_entity",
       {
-        startkey: [entityId + "\u0000"],
+        startkey: [entityId, "\uffff"],
         endkey: [entityId],
         descending: true,
       }


### PR DESCRIPTION
Currently the view that is used to load the currently active students on the school details page is bugged. It uses the current time to create the view which results in different students being displayed depending on the time at which the view was created.
This has been changed to use a in-memory filtering with the current date instead.

### Visible/Frontend Changes
- [x] Students listed in the `ChildrenOverview` component are always the same (and the active ones)

### Architectural/Backend Changes
- [x] Removed unneeded view for `ChildSchoolRelation`
- [x] Removed some unnecessary functions
