### PR TITLE
Permission enforcer fix

### DIFF
--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
@@ -14,7 +14,7 @@ import { mockEntityMapper } from "../../entity/mock-entity-mapper-service";
 import { LOCATION_TOKEN } from "../../../utils/di-tokens";
 import { AnalyticsService } from "../../analytics/analytics.service";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 import { EntityAbility } from "../ability/entity-ability";
 import { Config } from "../../config/config";
 import {
@@ -22,6 +22,7 @@ import {
   EntityRegistry,
 } from "../../entity/database-entity.decorator";
 import { UpdatedEntity } from "../../entity/model/entity-update";
+import { ConfigService } from "../../config/config.service";
 
 describe("PermissionEnforcerService", () => {
   let service: PermissionEnforcerService;
@@ -58,6 +59,10 @@ describe("PermissionEnforcerService", () => {
         { provide: AnalyticsService, useValue: mockAnalytics },
         { provide: EntityRegistry, useValue: entityRegistry },
         AbilityService,
+        {
+          provide: ConfigService,
+          useValue: { configUpdates: of(new Config()) },
+        },
       ],
     });
     entityMapper = TestBed.inject(EntityMapperService);
@@ -66,7 +71,7 @@ describe("PermissionEnforcerService", () => {
     TestBed.inject(AbilityService);
   }));
 
-  afterEach(async () => {
+  afterEach(() => {
     window.localStorage.removeItem(
       TEST_USER + "-" + PermissionEnforcerService.LOCALSTORAGE_KEY
     );

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -8,6 +8,8 @@ import { LOCATION_TOKEN } from "../../../utils/di-tokens";
 import { AnalyticsService } from "../../analytics/analytics.service";
 import { EntityAbility } from "../ability/entity-ability";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { ConfigService } from "../../config/config.service";
+import { take } from "rxjs/operators";
 
 /**
  * This service checks whether the relevant rules for the current user changed.
@@ -29,7 +31,8 @@ export class PermissionEnforcerService {
     private database: Database,
     private analyticsService: AnalyticsService,
     private entities: EntityRegistry,
-    @Inject(LOCATION_TOKEN) private location: Location
+    @Inject(LOCATION_TOKEN) private location: Location,
+    private configService: ConfigService
   ) {}
 
   async enforcePermissionsOnLocalData(userRules: DatabaseRule[]) {
@@ -102,6 +105,8 @@ export class PermissionEnforcerService {
   private async dbHasEntitiesWithoutPermissions(
     subjects: EntityConstructor[]
   ): Promise<boolean> {
+    // wait for config service to be ready before using the entity mapper
+    await this.configService.configUpdates.pipe(take(1)).toPromise();
     for (const subject of subjects) {
       const entities = await this.entityMapper.loadType(subject);
       if (entities.some((entity) => this.ability.cannot("read", entity))) {

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -90,7 +90,7 @@ export class PermissionEnforcerService {
   }
 
   private getRelevantSubjects(rule: DatabaseRule): string[] {
-    if (rule.subject === "any") {
+    if (rule.subject === "all") {
       return [...this.entities.keys()];
     } else if (Array.isArray(rule.subject)) {
       return rule.subject;


### PR DESCRIPTION
In the initial sync the permission enforcer might use the entity mapper before the config service has been set up. This is prevented by waiting for the config to be ready.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
