### PR TITLE
Fix permission enforcer

### DIFF
--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
@@ -212,7 +212,21 @@ describe("PermissionEnforcerService", () => {
     );
   }));
 
-  async function updateRulesAndTriggerEnforcer(rules: DatabaseRule[]) {
+  it("should not fail if a non-entity rule exists", fakeAsync(() => {
+    const rules: DatabaseRule[] = [
+      { subject: "Child", action: "manage" },
+      { subject: "org.couchdb.user", action: "read", inverted: true },
+    ];
+    updateRulesAndTriggerEnforcer(rules);
+    tick();
+
+    const storedRules = localStorage.getItem(
+      `${TEST_USER}-${PermissionEnforcerService.LOCALSTORAGE_KEY}`
+    );
+    expect(JSON.parse(storedRules)).toEqual(rules);
+  }));
+
+  function updateRulesAndTriggerEnforcer(rules: DatabaseRule[]) {
     const role = mockSession.getCurrentUser().roles[0];
     const config = new Config(Config.PERMISSION_KEY, { [role]: rules });
     entityUpdates.next({ entity: config, type: "update" });

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -93,13 +93,16 @@ export class PermissionEnforcerService {
   }
 
   private getRelevantSubjects(rule: DatabaseRule): string[] {
+    let subjects: string[];
     if (rule.subject === "all") {
-      return [...this.entities.keys()];
+      subjects = [...this.entities.keys()];
     } else if (Array.isArray(rule.subject)) {
-      return rule.subject;
+      subjects = rule.subject;
     } else {
-      return [rule.subject];
+      subjects = [rule.subject];
     }
+    // Only return valid entities
+    return subjects.filter((sub) => this.entities.has(sub));
   }
 
   private async dbHasEntitiesWithoutPermissions(

--- a/src/app/utils/test-utils/generic-matchers.spec.ts
+++ b/src/app/utils/test-utils/generic-matchers.spec.ts
@@ -29,10 +29,10 @@ const genericMatchers: jasmine.CustomMatcherFactories = {
         )} not to to contain own property ${value}`
     );
   },
-  toBeDate: (util, matchers) => {
+  toBeDate: (util) => {
     return makeCustomMatcher(
       (expected: string | number | Date, actual: string | number | Date) =>
-        util.equals(new Date(expected), new Date(actual), matchers),
+        util.equals(new Date(expected), new Date(actual)),
       (expected, actual) =>
         `Expected date ${util.pp(expected)} to equal ${actual}`,
       (expected, actual) =>


### PR DESCRIPTION
Permission enforcer currently doesnt work if a rule for `org.couchdb.user` is defined.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Fix permission enforcer
- [x] Fix deprecation warning for jasmine (see [docs](https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#matchers-cet))
