### PR TITLE
refactor: using Error subclass otherwise sentry reports this as an error

### DIFF
--- a/src/app/core/database/pouch-database.ts
+++ b/src/app/core/database/pouch-database.ts
@@ -359,8 +359,9 @@ export class PouchDatabase extends Database {
 /**
  * This overwrites PouchDB's error class which only logs limited information
  */
-class DatabaseException {
+class DatabaseException extends Error {
   constructor(error: PouchDB.Core.Error) {
+    super();
     Object.assign(this, error);
   }
 }


### PR DESCRIPTION
Sentry has a problem if a non-error object is thrown.
This should be solved by extending the `Error` class.

![image](https://user-images.githubusercontent.com/33730997/175776851-1778060a-5568-4600-b16a-fa5fde2f0fed.png)

