### PR TITLE
fix: loading indicator is not shown when creating a new entity

### DIFF
--- a/src/app/core/entity-components/entity-details/entity-details.component.spec.ts
+++ b/src/app/core/entity-components/entity-details/entity-details.component.spec.ts
@@ -124,7 +124,7 @@ describe("EntityDetailsComponent", () => {
   }));
 
   it("should load the correct child on startup", fakeAsync(() => {
-    expect(component.isLoading).toBeTrue();
+    component.isLoading = true;
     const testChild = new Child("Test-Child");
     const entityMapper = TestBed.inject(EntityMapperService);
     entityMapper.save(testChild);
@@ -132,6 +132,7 @@ describe("EntityDetailsComponent", () => {
     spyOn(entityMapper, "load").and.callThrough();
 
     routeObserver.next({ get: () => testChild.getId() });
+    expect(component.isLoading).toBeTrue();
     tick();
 
     expect(entityMapper.load).toHaveBeenCalledWith(Child, testChild.getId());

--- a/src/app/core/entity-components/entity-details/entity-details.component.ts
+++ b/src/app/core/entity-components/entity-details/entity-details.component.ts
@@ -34,7 +34,7 @@ import { EntityRegistry } from "../../entity/database-entity.decorator";
 export class EntityDetailsComponent {
   entity: Entity;
   creatingNew = false;
-  isLoading: boolean = true;
+  isLoading = true;
 
   panels: Panel[] = [];
   iconName: string;
@@ -74,7 +74,6 @@ export class EntityDetailsComponent {
       this.entityMapperService.load<Entity>(constr, id).then((entity) => {
         this.entity = entity;
         this.setFullPanelsConfig();
-        this.isLoading = false;
       });
     }
   }
@@ -101,6 +100,7 @@ export class EntityDetailsComponent {
         }),
       };
     });
+    this.isLoading = false;
   }
 
   private getPanelConfig(c: PanelComponent): PanelConfig {


### PR DESCRIPTION
Currently, the loading indicator keeps spinning while creating a new entity in `EntityDetailsComponent`

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
