### PR TITLE
fixed matTable to be only build once all information is available

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.html
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.html
@@ -1,9 +1,13 @@
 <div class="mat-elevation-z1 container">
+  <div *ngIf="isLoading" class="process-spinner">
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  </div>
   <table
     mat-table
     [dataSource]="recordsDataSource"
     matSort
     class="subrecord-table"
+    *ngIf="!isLoading"
   >
     <ng-container *ngFor="let col of filteredColumns" [matColumnDef]="col.id">
       <th
@@ -148,9 +152,6 @@
       class="table-row"
     ></tr>
   </table>
-  <div *ngIf="isLoading" class="process-spinner">
-    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-  </div>
   <app-list-paginator
     *ngIf="!isLoading || recordsDataSource.data.length"
     [dataSource]="recordsDataSource"

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
@@ -66,6 +66,8 @@ export class EntitySubrecordComponent<T extends Entity>
     });
     this.filteredColumns = this._columns.filter((col) => !col.hideFromTable);
   }
+  _columns: FormFieldConfig[] = [];
+  filteredColumns: FormFieldConfig[] = [];
 
   /** data to be displayed */
   @Input()
@@ -82,8 +84,6 @@ export class EntitySubrecordComponent<T extends Entity>
     }
   }
   private _records: Array<T> = [];
-  _columns: FormFieldConfig[] = [];
-  filteredColumns: FormFieldConfig[] = [];
 
   /**
    * factory method to create a new instance of the displayed Entity type
@@ -94,7 +94,7 @@ export class EntitySubrecordComponent<T extends Entity>
   /**
    * Whether the rows of the table are inline editable and new entries can be created through the "+" button.
    */
-  @Input() editable: boolean = true;
+  @Input() editable = true;
 
   /** columns displayed in the template's table */
   @Input() columnsToDisplay = [];
@@ -107,7 +107,15 @@ export class EntitySubrecordComponent<T extends Entity>
 
   idForSavingPagination = "startWert";
 
-  @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatSort) set sort(matSort: MatSort) {
+    // Initialize sort once available
+    this.recordsDataSource.sort = matSort;
+    setTimeout(() => this.initDefaultSort());
+  }
+
+  get sort(): MatSort {
+    return this.recordsDataSource.sort
+  }
 
   /**
    * A function which should be executed when a row is clicked or a new entity created.
@@ -211,7 +219,6 @@ export class EntitySubrecordComponent<T extends Entity>
   }
 
   private initDefaultSort() {
-    this.recordsDataSource.sort = this.sort;
     this.recordsDataSource.sortData = (data, sort) =>
       tableSort(data, {
         active: sort.active as keyof T | "",


### PR DESCRIPTION
When the `EntityList` is directly used in the route (and not in a template) somehow the order of initialization is creating problems. This creates an error in the table and results in things like the paginator, sort and filtering not working anymore. This PR solves this by only creating the table once everything is ready.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
