### PR TITLE
Quick fix: Align the entity correct in the entity select component

### DIFF
--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.html
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.html
@@ -21,6 +21,7 @@
         class="chip"
       >
         <app-display-entity
+          class="display-entity"
           [entityToDisplay]="entity"
           [linkDisabled]="formControl.enabled"
         ></app-display-entity>

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.scss
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.scss
@@ -17,3 +17,8 @@
   margin-left: 0.5em;
   cursor: pointer;
 }
+
+.display-entity {
+  vertical-align: middle;
+  display: inline-block;
+}


### PR DESCRIPTION
Due to PR #1290, the position of the displayed entity is misaligned with the remove button. This PR fixes this by giving the entity-select a `display` of `inline-block`