### PR TITLE
fix(ui): layout issue when sidenav is bigger

### DIFF
--- a/src/app/core/ui/ui/ui.component.html
+++ b/src/app/core/ui/ui/ui.component.html
@@ -59,6 +59,7 @@
 <mat-sidenav-container
   class="app-content mat-typography primary-background"
   (backdropClick)="closeSidenavOnMobile()"
+  autosize
 >
   <mat-sidenav
     #sideNav
@@ -81,7 +82,7 @@
       ></app-navigation>
 
 
-      <div fxFlex >
+      <div fxFlex>
         <div fxLayout="row" class="menu-footer-row">
           <app-pwa-install fxFlex></app-pwa-install>
         </div>


### PR DESCRIPTION
see issue: #1240 
This issue happens when the sidenav is bigger than normal because of a long menu title or a big logo. This makes the sidenav get bigger *after* the content has already been aligned with the smaller sidenav. The content position is only updated on **open**, **window resize** and **mode change**. As nothing like this is happening, the content stays at the position. 

A solution to this is to use the `autosize` directive which makes the sidenav continue looking for changes. There are potential performance issues with this approach but I did not see any impact on the application.

[source](https://material.angular.io/components/sidenav/overview#resizing-an-open-sidenav)

### Visible/Frontend Changes
- [x] Main content always has correct margin to navigation bar

### Architectural/Backend Changes
--
