### PR TITLE
fix(core): using correct timezone when parsing dates

### DIFF
--- a/src/app/core/entity/schema-datatypes/datatype-date-only.spec.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.spec.ts
@@ -2,9 +2,23 @@ import { dateOnlyEntitySchemaDatatype } from "./datatype-date-only";
 
 describe("Schema data type:Date", () => {
   it("should not fail on null values", () => {
-    const nullDateRes = dateOnlyEntitySchemaDatatype.transformToDatabaseFormat(
-      null
-    );
+    const nullDateRes =
+      dateOnlyEntitySchemaDatatype.transformToDatabaseFormat(null);
     expect(nullDateRes).toBeUndefined();
+  });
+
+  it("should correctly transform values", () => {
+    const date = new Date(2022, 0, 1);
+
+    const dbFormat =
+      dateOnlyEntitySchemaDatatype.transformToDatabaseFormat(date);
+    expect(dbFormat).toBe("2022-01-01");
+
+    const objFormat: Date =
+      dateOnlyEntitySchemaDatatype.transformToObjectFormat(dbFormat);
+    expect(objFormat).toBeInstanceOf(Date);
+    expect(objFormat.getFullYear()).toBe(2022);
+    expect(objFormat.getMonth()).toBe(0);
+    expect(objFormat.getDate()).toBe(1);
   });
 });

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -44,8 +44,11 @@ export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
     );
   },
 
-  transformToObjectFormat: (value) => {
-    const date = new Date(value);
+  transformToObjectFormat: (value: string) => {
+    // new Date("2022-01-01") is interpreted as UTC time whereas new Date(2022, 0, 1) is local time
+    // -> we want local time to represent the same day wherever used.
+    const values = value.split("-").map((v) => Number(v));
+    const date = new Date(values[0], values[1] - 1, values[2]);
     if (Number.isNaN(date.getTime())) {
       throw new Error("failed to convert data to Date object: " + value);
     }

--- a/src/app/core/entity/schema-datatypes/datatype-month.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-month.ts
@@ -40,12 +40,14 @@ export const monthEntitySchemaDatatype: EntitySchemaDatatype = {
     );
   },
 
-  transformToObjectFormat: (value) => {
-    value = value
+  transformToObjectFormat: (value: string) => {
+    const values = value
       .toString()
       .replace(/-(\d)-/g, "-0$1-")
-      .replace(/-(\d)$/g, "-0$1");
-    const date = new Date(value);
+      .replace(/-(\d)$/g, "-0$1")
+      .split("-")
+      .map((v) => Number(v));
+    const date = new Date(values[0], values[1] - 1);
     if (Number.isNaN(date.getTime())) {
       throw new Error("failed to convert data to Date object: " + value);
     }


### PR DESCRIPTION
To test the issue on the current version:

1. Set your computers time to a timezone **before** UTC, e.g. `UTC-0600`
2. Create a new `ChildSchoolRelation` (child -> school history)
3. See the start date and the end date are one day before what you selected (even though the right time is saved to the database)

This is because `new Date("2022-01-01")` is interpreted as **UTC time**. Converting this to `UTC-0600` results in 6pm the day before (`2021-12-31`).
The very simple fix to this is to instead use a different date constructor: `new Date(2022, 0, 1)` is interpreted as first of January 2022 in the **local** time.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] datatypes `date-only` and `month` are interpreted with the local timezone
