### PR TITLE
fix: added logging for not-found component

### DIFF
--- a/src/app/core/view/dynamic-routing/not-found/not-found.component.spec.ts
+++ b/src/app/core/view/dynamic-routing/not-found/not-found.component.spec.ts
@@ -3,14 +3,22 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NotFoundComponent } from "./not-found.component";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ViewModule } from "../../view.module";
+import { LOCATION_TOKEN } from "../../../../utils/di-tokens";
+import { LoggingService } from "../../../logging/logging.service";
 
 describe("NotFoundComponent", () => {
   let component: NotFoundComponent;
   let fixture: ComponentFixture<NotFoundComponent>;
+  let mockLogging: jasmine.SpyObj<LoggingService>;
 
   beforeEach(async () => {
+    mockLogging = jasmine.createSpyObj(LoggingService.name, ["warn"]);
     await TestBed.configureTestingModule({
       imports: [ViewModule, RouterTestingModule],
+      providers: [
+        { provide: LOCATION_TOKEN, useValue: { pathname: "/some/path" } },
+        { provide: LoggingService, useValue: mockLogging },
+      ],
     }).compileComponents();
   });
 
@@ -22,5 +30,11 @@ describe("NotFoundComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should call logging service with current route", () => {
+    expect(mockLogging.warn).toHaveBeenCalledWith(
+      "Could not find component for route: /some/path"
+    );
   });
 });

--- a/src/app/core/view/dynamic-routing/not-found/not-found.component.ts
+++ b/src/app/core/view/dynamic-routing/not-found/not-found.component.ts
@@ -1,8 +1,21 @@
-import { Component } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { LoggingService } from "../../../logging/logging.service";
+import { LOCATION_TOKEN } from "../../../../utils/di-tokens";
 
 @Component({
   selector: "app-not-found",
   templateUrl: "./not-found.component.html",
   styleUrls: ["./not-found.component.scss"],
 })
-export class NotFoundComponent {}
+export class NotFoundComponent implements OnInit {
+  constructor(
+    private loggingService: LoggingService,
+    @Inject(LOCATION_TOKEN) private location: Location
+  ) {}
+
+  ngOnInit() {
+    this.loggingService.warn(
+      "Could not find component for route: " + this.location.pathname
+    );
+  }
+}


### PR DESCRIPTION
This should allow us to detect, if the configuration for a instance is missing some things (e.g. the support page)

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Sentry receives a warning when a user access route for which no component is defined
