### PR TITLE
fix: enabled support and user account component for everyone

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -21,6 +21,8 @@ import { ComponentType } from "@angular/cdk/overlay";
 import { Registry } from "./core/registry/dynamic-registry";
 import { ApplicationLoadingComponent } from "./core/view/dynamic-routing/empty/application-loading.component";
 import { NotFoundComponent } from "./core/view/dynamic-routing/not-found/not-found.component";
+import { UserAccountComponent } from "./core/user/user-account/user-account.component";
+import { SupportComponent } from "./core/support/support/support.component";
 
 export class RouteRegistry extends Registry<ComponentType<any>> {}
 export const routesRegistry = new RouteRegistry();
@@ -59,6 +61,8 @@ export const allRoutes: Routes = [
         (m) => m["ComingSoonModule"]
       ),
   },
+  { path: "user", component: UserAccountComponent },
+  { path: "support", component: SupportComponent },
   { path: "404", component: NotFoundComponent },
   { path: "**", pathMatch: "full", component: ApplicationLoadingComponent },
 ];

--- a/src/app/core/config/config-fix.ts
+++ b/src/app/core/config/config-fix.ts
@@ -206,12 +206,6 @@ export const defaultJsonConfig = {
       ]
     }
   },
-  "view:user": {
-    "component": "UserAccount"
-  },
-  "view:support": {
-    "component": "Support"
-  },
   "view:note": {
     "component": "NotesManager",
     "config": {

--- a/src/app/core/support/support.module.ts
+++ b/src/app/core/support/support.module.ts
@@ -17,6 +17,4 @@ import { MatExpansionModule } from "@angular/material/expansion";
   ],
   exports: [SupportComponent],
 })
-export class SupportModule {
-  static dynamicComponents = [SupportComponent];
-}
+export class SupportModule {}

--- a/src/app/core/support/support/support.component.ts
+++ b/src/app/core/support/support/support.component.ts
@@ -7,13 +7,11 @@ import { SwUpdate } from "@angular/service-worker";
 import { Database } from "../../database/database";
 import * as Sentry from "@sentry/browser";
 import { RemoteSession } from "../../session/session-service/remote-session";
-import { RouteTarget } from "../../../app.routing";
 import { ConfirmationDialogService } from "../../confirmation-dialog/confirmation-dialog.service";
 import { HttpClient } from "@angular/common/http";
 import { SyncedSessionService } from "../../session/session-service/synced-session.service";
 import { environment } from "../../../../environments/environment";
 
-@RouteTarget("Support")
 @Component({
   selector: "app-support",
   templateUrl: "./support.component.html",
@@ -133,7 +131,8 @@ export class SupportComponent implements OnInit {
     }
 
     await this.database.destroy();
-    const registrations = await this.window.navigator.serviceWorker.getRegistrations();
+    const registrations =
+      await this.window.navigator.serviceWorker.getRegistrations();
     const unregisterPromises = registrations.map((reg) => reg.unregister());
     await Promise.all(unregisterPromises);
     localStorage.clear();

--- a/src/app/core/user/user-account/user-account.component.ts
+++ b/src/app/core/user/user-account/user-account.component.ts
@@ -22,12 +22,10 @@ import { FormBuilder, ValidationErrors, Validators } from "@angular/forms";
 import { AppConfig } from "../../app-config/app-config";
 import { LoggingService } from "../../logging/logging.service";
 import { SessionType } from "../../session/session-type";
-import { RouteTarget } from "../../../app.routing";
 
 /**
  * User account form to allow the user to view and edit information.
  */
-@RouteTarget("UserAccount")
 @Component({
   selector: "app-user-account",
   templateUrl: "./user-account.component.html",

--- a/src/app/core/user/user.module.ts
+++ b/src/app/core/user/user.module.ts
@@ -47,6 +47,4 @@ import { TabStateModule } from "../../utils/tab-state/tab-state.module";
   ],
   declarations: [UserAccountComponent],
 })
-export class UserModule {
-  static dynamicComponents = [UserAccountComponent];
-}
+export class UserModule {}


### PR DESCRIPTION
Some configs are missing the support page. As this and the user account page are **always** needed, they are just hardcoded now

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
