### PR TITLE
fix: tables adjust to mobile view

### DIFF
--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -30,6 +30,7 @@ import { RouteTarget } from "../../../app.routing";
 import { RouteData } from "../../view/dynamic-routing/view-config.interface";
 import { EntityMapperService } from "../../entity/entity-mapper.service";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { Subscription } from "rxjs";
 
 /**
  * This component allows to create a full blown table with pagination, filtering, searching and grouping.
@@ -85,6 +86,8 @@ export class EntityListComponent<T extends Entity>
   }
 
   selectedColumnGroupIndex_: number = 0;
+
+  private mediaSubscription: Subscription;
 
   /**
    * defines the bottom margin of the topmost row in the
@@ -202,7 +205,10 @@ export class EntityListComponent<T extends Entity>
   }
 
   private adjustTableToScreenSize() {
-    this.media
+    if (this.mediaSubscription) {
+      this.mediaSubscription.unsubscribe();
+    }
+    this.mediaSubscription = this.media
       .asObservable()
       .pipe(map((c) => c[0].mqAlias !== "xs" && c[0].mqAlias !== "md"))
       .subscribe((isBigScreen) => {

--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -294,7 +294,6 @@ export class EntityListComponent<T extends Entity>
   }
 
   private displayColumnGroupByName(columnGroupName: string) {
-    console.log("displaying column group", columnGroupName);
     const selectedColumnIndex =
       this.getSelectedColumnIndexByName(columnGroupName);
     if (selectedColumnIndex !== -1) {

--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -47,7 +47,8 @@ import { EntityRegistry } from "../../entity/database-entity.decorator";
   styleUrls: ["./entity-list.component.scss"],
 })
 export class EntityListComponent<T extends Entity>
-  implements OnChanges, AfterViewInit {
+  implements OnChanges, AfterViewInit
+{
   @Input() allEntities: T[] = [];
   filteredEntities: T[] = [];
   @Input() listConfig: EntityListConfig;
@@ -116,25 +117,6 @@ export class EntityListComponent<T extends Entity>
           this.buildComponentFromConfig(config)
       );
     }
-
-    this.media
-      .asObservable()
-      .pipe(
-        map(
-          (changes) =>
-            changes[0].mqAlias !== "xs" && changes[0].mqAlias !== "md"
-        )
-      )
-      .subscribe((isBigScreen) => {
-        if (!isBigScreen) {
-          this.displayColumnGroupByName(this.mobileColumnGroup);
-        } else if (
-          this.selectedColumnGroupIndex ===
-          this.getSelectedColumnIndexByName(this.mobileColumnGroup)
-        ) {
-          this.displayColumnGroupByName(this.defaultColumnGroup);
-        }
-      });
     this.activatedRoute.queryParams.subscribe((params) => {
       this.loadUrlParams(params);
     });
@@ -175,6 +157,7 @@ export class EntityListComponent<T extends Entity>
       this.initColumnGroups(this.listConfig.columnGroups);
       this.filtersConfig = this.listConfig.filters || [];
       this.displayColumnGroupByName(this.defaultColumnGroup);
+      this.adjustTableToScreenSize();
     }
     if (changes.hasOwnProperty("allEntities")) {
       await this.initFilterSelections();
@@ -216,6 +199,22 @@ export class EntityListComponent<T extends Entity>
       this.defaultColumnGroup = "default";
       this.mobileColumnGroup = "default";
     }
+  }
+
+  private adjustTableToScreenSize() {
+    this.media
+      .asObservable()
+      .pipe(map((c) => c[0].mqAlias !== "xs" && c[0].mqAlias !== "md"))
+      .subscribe((isBigScreen) => {
+        if (!isBigScreen) {
+          this.displayColumnGroupByName(this.mobileColumnGroup);
+        } else if (
+          this.selectedColumnGroupIndex ===
+          this.getSelectedColumnIndexByName(this.mobileColumnGroup)
+        ) {
+          this.displayColumnGroupByName(this.defaultColumnGroup);
+        }
+      });
   }
 
   private loadUrlParams(parameters?: Params) {
@@ -289,9 +288,9 @@ export class EntityListComponent<T extends Entity>
   }
 
   private displayColumnGroupByName(columnGroupName: string) {
-    const selectedColumnIndex = this.getSelectedColumnIndexByName(
-      columnGroupName
-    );
+    console.log("displaying column group", columnGroupName);
+    const selectedColumnIndex =
+      this.getSelectedColumnIndexByName(columnGroupName);
     if (selectedColumnIndex !== -1) {
       this.selectedColumnGroupIndex = selectedColumnIndex;
     }

--- a/src/app/core/entity-components/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-components/entity-list/entity-list.component.ts
@@ -120,12 +120,7 @@ export class EntityListComponent<T extends Entity>
 
     this.media
       .asObservable()
-      .pipe(
-        map(
-          (changes) =>
-            changes[0].mqAlias !== "xs" && changes[0].mqAlias !== "md"
-        )
-      )
+      .pipe(map((c) => c[0].mqAlias !== "xs" && c[0].mqAlias !== "md"))
       .subscribe((isBigScreen) => {
         if (!isBigScreen) {
           this.displayColumnGroupByName(this.mobileColumnGroup);


### PR DESCRIPTION
Tables like the `ChildrenList` or the `NoteDetails` currently don't automatically switch to the mobile view because of a wrong ordering of events.

### Visible/Frontend Changes
- [x] Opening a table on the mobile automatically shows the mobile column groups

### Architectural/Backend Changes
--
