### PR TITLE
fix(*): legacy date values are correctly parsed

### DIFF
--- a/src/app/core/entity/schema-datatypes/datatype-date-only.spec.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.spec.ts
@@ -21,4 +21,18 @@ describe("Schema data type:Date", () => {
     expect(objFormat.getMonth()).toBe(0);
     expect(objFormat.getDate()).toBe(1);
   });
+
+  it("should fallback to legacy date parsing if format is unsupported", () => {
+    let date: Date = dateOnlyEntitySchemaDatatype.transformToObjectFormat(
+      "2013-01-12T00:00:00.000Z"
+    );
+    expect(date.getFullYear()).toBe(2013);
+    expect(date.getMonth()).toBe(0);
+    expect(date.getDate()).toBe(12);
+
+    date = dateOnlyEntitySchemaDatatype.transformToObjectFormat("4/1/2021");
+    expect(date.getFullYear()).toBe(2021);
+    expect(date.getMonth()).toBe(3);
+    expect(date.getDate()).toBe(1);
+  });
 });

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -45,13 +45,12 @@ export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
   },
 
   transformToObjectFormat: (value: string) => {
-    let date: Date;
     // new Date("2022-01-01") is interpreted as UTC time whereas new Date(2022, 0, 1) is local time
     // -> we want local time to represent the same day wherever used.
     const values = value.split("-").map((v) => Number(v));
-    date = new Date(values[0], values[1] - 1, values[2]);
+    let date: Date = new Date(values[0], values[1] - 1, values[2]);
     if (isNaN(date.getTime())) {
-      // fallback to legacy date parsing if format is unsupported
+      // fallback to legacy date parsing if format is not "YYYY-mm-dd"
       date = new Date(value);
     }
     if (Number.isNaN(date.getTime())) {

--- a/src/app/core/entity/schema-datatypes/datatype-date-only.ts
+++ b/src/app/core/entity/schema-datatypes/datatype-date-only.ts
@@ -45,10 +45,15 @@ export const dateOnlyEntitySchemaDatatype: EntitySchemaDatatype = {
   },
 
   transformToObjectFormat: (value: string) => {
+    let date: Date;
     // new Date("2022-01-01") is interpreted as UTC time whereas new Date(2022, 0, 1) is local time
     // -> we want local time to represent the same day wherever used.
     const values = value.split("-").map((v) => Number(v));
-    const date = new Date(values[0], values[1] - 1, values[2]);
+    date = new Date(values[0], values[1] - 1, values[2]);
+    if (isNaN(date.getTime())) {
+      // fallback to legacy date parsing if format is unsupported
+      date = new Date(value);
+    }
     if (Number.isNaN(date.getTime())) {
       throw new Error("failed to convert data to Date object: " + value);
     }


### PR DESCRIPTION
After the recent fix for the `date-only` datatype a few errors popped up because some older users had dates in a different format stored. To still support these, a fallback is added to the date parsing.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
