### PR TITLE
fix: permissions are correctly applied in popup form

### DIFF
--- a/src/app/child-dev-project/schools/activities-overview/activities-overview.component.html
+++ b/src/app/child-dev-project/schools/activities-overview/activities-overview.component.html
@@ -1,5 +1,5 @@
 <app-entity-subrecord
-  [records]="records"
+  [(records)]="records"
   [columns]="columns"
   [getBackgroundColor]="null"
   [newRecordFactory]="generateNewRecordFactory()"

--- a/src/app/child-dev-project/schools/activities-overview/activities-overview.component.ts
+++ b/src/app/child-dev-project/schools/activities-overview/activities-overview.component.ts
@@ -24,28 +24,29 @@ export class ActivitiesOverviewComponent implements OnInitDynamicComponent {
   entity: Entity;
   records: RecurringActivity[] = [];
   listConfig: EntityListConfig;
-  activityConstructor = RecurringActivity;
 
   constructor(private entityMapper: EntityMapperService) {}
 
-  async onInitFromDynamicConfig(config: any) {
+  onInitFromDynamicConfig(config: any) {
     if (config?.config?.columns) {
       this.columns = config.config.columns;
     }
 
     this.entity = config.entity;
-    this.records = (
-      await this.entityMapper.loadType<RecurringActivity>(RecurringActivity)
-    ).filter((activity) => activity.linkedGroups.includes(this.entity.getId()));
+    this.initializeRelatedActivities();
     this.entityMapper
       .receiveUpdates(RecurringActivity)
       .subscribe((updateEntity) => {
         if (updateEntity.type === "update") {
-          this.records = this.records.filter((activity) =>
-            activity.linkedGroups.includes(this.entity.getId())
-          );
+          this.initializeRelatedActivities();
         }
       });
+  }
+
+  private async initializeRelatedActivities() {
+    this.records = (
+      await this.entityMapper.loadType<RecurringActivity>(RecurringActivity)
+    ).filter((activity) => activity.linkedGroups.includes(this.entity.getId()));
   }
 
   generateNewRecordFactory(): () => RecurringActivity {

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
@@ -1,8 +1,10 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   SimpleChanges,
   ViewChild,
 } from "@angular/core";
@@ -72,9 +74,9 @@ export class EntitySubrecordComponent<T extends Entity>
   _columns: FormFieldConfig[] = [];
   filteredColumns: FormFieldConfig[] = [];
 
-  /** data to be displayed */
+  /** data to be displayed, can also be used as two-way-binding */
   @Input()
-  set records(value: Array<T>) {
+  set records(value: T[]) {
     this._records = value;
     this.recordsDataSource.data = this._records.map((rec) => {
       return {
@@ -86,7 +88,9 @@ export class EntitySubrecordComponent<T extends Entity>
         new (this._records[0].getConstructor() as EntityConstructor<T>)();
     }
   }
-  private _records: Array<T> = [];
+  private _records: T[] = [];
+
+  @Output() recordsChange = new EventEmitter<T[]>();
 
   /**
    * factory method to create a new instance of the displayed Entity type
@@ -318,11 +322,13 @@ export class EntitySubrecordComponent<T extends Entity>
     this.records = this._records.filter(
       (rec) => rec.getId() !== deleted.getId()
     );
+    this.recordsChange.emit(this._records);
   }
 
   private addToTable(record: T) {
     // use setter so datasource is also updated
     this.records = [record].concat(this._records);
+    this.recordsChange.emit(this._records);
   }
 
   /**

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
@@ -60,16 +60,13 @@
   <button
     mat-raised-button
     (click)="save()"
-    *appDisabledEntityOperation="{
-      operation: 'update',
-      entity: data.entity
-    }"
     i18n="Save button for forms"
   >
     Save
   </button>
 
   <button
+    *ngIf="editMode === 'update'"
     mat-icon-button
     [matMenuTriggerFor]="additional"
   >

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
@@ -60,6 +60,7 @@
   <button
     mat-raised-button
     (click)="save()"
+    [disabled]="form.disabled"
     i18n="Save button for forms"
   >
     Save

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.spec.ts
@@ -16,6 +16,7 @@ import { EntitySubrecordModule } from "../entity-subrecord.module";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { EntityFormService } from "../../entity-form/entity-form.service";
 import { AlertService } from "../../../alerts/alert.service";
+import { EntityAbility } from "../../../permissions/ability/entity-ability";
 
 describe("RowDetailsComponent", () => {
   let component: RowDetailsComponent<any>;
@@ -37,6 +38,7 @@ describe("RowDetailsComponent", () => {
         { provide: MatDialogRef, useValue: {} },
       ],
     }).compileComponents();
+    spyOn(TestBed.inject(EntityAbility), "cannot").and.returnValue(true);
   });
 
   beforeEach(() => {
@@ -77,4 +79,8 @@ describe("RowDetailsComponent", () => {
     expect(alertSpy).toHaveBeenCalledWith(message);
     expect(closeSpy).not.toHaveBeenCalled();
   }));
+
+  it("should not disable the form when creating a new entity", () => {
+    expect(component.form.disabled).toBeFalsy();
+  });
 });

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.ts
@@ -12,6 +12,7 @@ import {
   RemoveResult,
 } from "../../../entity/entity-remove.service";
 import { AlertService } from "../../../alerts/alert.service";
+import { EntityAction } from "../../../permissions/permission-types";
 
 /**
  * Data interface that must be given when opening the dialog
@@ -38,6 +39,7 @@ export class RowDetailsComponent<E extends Entity> {
 
   viewOnlyColumns: FormFieldConfig[];
   tempEntity: Entity;
+  editMode: EntityAction = "update";
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DetailsComponentData<E>,
@@ -48,7 +50,13 @@ export class RowDetailsComponent<E extends Entity> {
     private alertService: AlertService
   ) {
     this.form = this.formService.createFormGroup(data.columns, data.entity);
-    if (this.ability.cannot("update", data.entity)) {
+    if (!this.data.entity._rev) {
+      this.editMode = "create";
+    }
+    if (
+      this.editMode === "update" &&
+      this.ability.cannot("update", data.entity)
+    ) {
       this.form.disable();
     }
     this.tempEntity = this.data.entity;


### PR DESCRIPTION
Currently the row details component evaluates `update` permissions on the input entity. When clicking the `+` button on a table a new entity is created which can result in the popup being in disabled mode (e.g. a entity needs to have a certain value for the user to have `update` permissions). 
This is fixed by detecting, whether the entity is currently being created or updated.

Also, I discovered a small but in the `ActivitiesOverviewComponent`:

1. Create a new activity in the component
2. Edit this activity
3. The activity disappears from the table

This happens because the newly created entity is not present in the `records` array of the `ActivitiesOverviewComponent`.

### Visible/Frontend Changes
- [x] `RowDetailsComponent` is never disabled when creating a entity

### Architectural/Backend Changes
--
