### PR TITLE
assets request still work with a locale in the path

### DIFF
--- a/build/default.conf
+++ b/build/default.conf
@@ -9,8 +9,10 @@ server {
 
     # Catch requests to the assets folder
     # These should not be forwarded to the index.html
-    location ~* ^/assets/ {
-        try_files $uri =404;
+    # This currently includes a fallback for previous requests including a locale
+    location ~* /assets/(.+)$ {
+        # $1 refers to everything after 'assets/'
+        try_files $uri /assets/$1 =404;
     }
 
     location / {


### PR DESCRIPTION
When updating an instance to the new master, the first login results in a broken state because `/en-US/assets/config.json` does not exist anymore. This can be solved by forwarding the relative asset requests to the single assets folder.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
