### PR TITLE
fix: entity select respects toStringAttributes

### DIFF
--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.spec.ts
@@ -16,7 +16,7 @@ import { mockEntityMapper } from "../../../entity/mock-entity-mapper-service";
 import { User } from "../../../user/user";
 import { Child } from "../../../../child-dev-project/children/model/child";
 import { FlexLayoutModule } from "@angular/flex-layout";
-import { Subscription } from "rxjs";
+import { firstValueFrom, Subscription } from "rxjs";
 import { EntitySchemaService } from "../../../entity/schema/entity-schema.service";
 import {
   EntityRegistry,
@@ -174,6 +174,28 @@ describe("EntitySelectComponent", () => {
     component.formControl.setValue("Ab");
     expectedLength = 1;
     component.formControl.setValue("Abc");
+  });
+
+  it("should use the configurable toStringAttributes for comparing values", async () => {
+    class Person extends Entity {
+      static toStringAttributes = ["firstname", "lastname"];
+
+      firstname: string;
+      lastname: string;
+    }
+
+    const p1 = Object.assign(new Person(), { firstname: "Aa", lastname: "bb" });
+    const p2 = Object.assign(new Person(), { firstname: "Aa", lastname: "cc" });
+    component.allEntities = [p1, p2];
+    component.loading.next(false);
+
+    let res = firstValueFrom(component.filteredEntities);
+    component.formControl.setValue("Aa");
+    await expectAsync(res).toBeResolvedTo([p1, p2]);
+
+    res = firstValueFrom(component.filteredEntities);
+    component.formControl.setValue("Aa b");
+    await expectAsync(res).toBeResolvedTo([p1]);
   });
 
   it("should add an unselected entity to the filtered entities array", (done) => {

--- a/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.ts
+++ b/src/app/core/entity-components/entity-utils/entity-select/entity-select.component.ts
@@ -64,6 +64,7 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
         );
       });
   }
+
   /** Underlying data-array */
   selectedEntities: E[] = [];
   /**
@@ -157,7 +158,7 @@ export class EntitySelectComponent<E extends Entity> implements OnChanges {
    * <br> Per default, this filters for the name. If the entity
    * has no name, this filters for the entity's id.
    */
-  @Input() accessor: (e: Entity) => string = (e) => e["name"] || e.getId();
+  @Input() accessor: (e: Entity) => string = (e) => e.toString();
 
   @Input() additionalFilter: (e: E) => boolean = (_) => true;
 


### PR DESCRIPTION
Currently, the entity select autocomplete does not working when for example working with firstname - lastname instead of just name. This is fixed by using the default `toString()` function which can be configured through the `toStringAttributes`.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] using `toString()` instead of hardcoded `name` to compare names
