### PR TITLE
Notes of schools and authors

### DIFF
--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -190,6 +190,31 @@ describe("ChildrenService", () => {
     const result = await service.queryActiveRelationsOf("child", "3");
     expect(result).toEqual(activeRelations);
   });
+
+  it("should return related notes", async () => {
+    const c1 = new Child("c1");
+    const c2 = new Child("c2");
+    const s1 = new School("s1");
+    const s2 = new School("s2");
+    const n1 = new Note("n1");
+    n1.addChild(c1);
+    n1.addChild(c2);
+    n1.schools.push(s1.getId());
+    const n2 = new Note("n2");
+    n2.addChild(c1);
+    const n3 = new Note("n3");
+    n3.schools.push(s2.getId());
+    await entityMapper.saveAll([n1, n2, n3]);
+
+    let res = await service.getNotesOf(c1);
+    expect(res).toEqual([n1, n2]);
+
+    res = await service.getNotesOf(s1);
+    expect(res).toEqual([n1]);
+
+    res = await service.getNotesOf(s2);
+    expect(res).toEqual([n3]);
+  });
 });
 
 function generateChildEntities(): Child[] {

--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -206,13 +206,13 @@ describe("ChildrenService", () => {
     n3.schools.push(s2.getId());
     await entityMapper.saveAll([n1, n2, n3]);
 
-    let res = await service.getNotesOf(c1);
+    let res = await service.getNotesOf(c1.getId(), "children");
     expect(res).toEqual([n1, n2]);
 
-    res = await service.getNotesOf(s1);
+    res = await service.getNotesOf(s1.getId(), "schools");
     expect(res).toEqual([n1]);
 
-    res = await service.getNotesOf(s2);
+    res = await service.getNotesOf(s2.getId(), "schools");
     expect(res).toEqual([n3]);
   });
 });

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -122,14 +122,12 @@ export class ChildrenService {
     );
   }
 
-  getNotesOfChild(childId: string): Observable<Note[]> {
-    const promise = this.dbIndexing.queryIndexDocs(
+  getNotesOfChild(childId: string): Promise<Note[]> {
+    return this.dbIndexing.queryIndexDocs(
       Note,
       "notes_index/by_child",
       childId
     );
-
-    return from(promise);
   }
 
   /**

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -123,20 +123,11 @@ export class ChildrenService {
     );
   }
 
-  getNotesOf(entity: Entity): Promise<Note[]> {
-    const entityType = entity.getType();
-    const relevantProperty = [...Note.schema.keys()].find(
-      (prop) => Note.schema.get(prop).additional === entityType
-    );
-    if (!relevantProperty) {
-      return Promise.reject(
-        `No related Note property for "${entityType}" found`
-      );
-    }
+  getNotesOf(entityId: string, noteProperty: string): Promise<Note[]> {
     return this.dbIndexing.queryIndexDocs(
       Note,
-      `notes_index/by_${relevantProperty}`,
-      entity.getId()
+      `notes_index/by_${noteProperty}`,
+      entityId
     );
   }
 

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
@@ -82,13 +82,13 @@ describe("NotesOfChildComponent", () => {
   });
 
   it("should sort notes by date", fakeAsync(() => {
+    // No date should come first
     const n1 = new Note();
-    n1.date = moment().subtract(1, "day").toDate();
     const n2 = new Note();
-    n2.date = moment().subtract(2, "days").toDate();
+    n2.date = moment().subtract(1, "day").toDate();
     const n3 = new Note();
-    n3.date = moment().subtract(3, "days").toDate();
-    mockChildrenService.getNotesOf.and.resolveTo([n1, n3, n2]);
+    n3.date = moment().subtract(2, "days").toDate();
+    mockChildrenService.getNotesOf.and.resolveTo([n3, n2, n1]);
 
     component.onInitFromDynamicConfig({ entity: new Child() });
     tick();

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.spec.ts
@@ -1,12 +1,24 @@
 import { NotesOfChildComponent } from "./notes-of-child.component";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from "@angular/core/testing";
 import { NotesModule } from "../notes.module";
 import { ChildrenService } from "../../children/children.service";
 import { Note } from "../model/note";
 import { Child } from "../../children/model/child";
-import { MockedTestingModule } from "../../../utils/mocked-testing.module";
-
-const allChildren: Array<Note> = [];
+import {
+  MockedTestingModule,
+  TEST_USER,
+} from "../../../utils/mocked-testing.module";
+import { ChildSchoolRelation } from "../../children/model/childSchoolRelation";
+import { PanelConfig } from "../../../core/entity-components/entity-details/EntityDetailsConfig";
+import { Entity } from "../../../core/entity/model/entity";
+import { School } from "../../schools/model/school";
+import { User } from "../../../core/user/user";
+import moment from "moment";
 
 describe("NotesOfChildComponent", () => {
   let component: NotesOfChildComponent;
@@ -15,9 +27,8 @@ describe("NotesOfChildComponent", () => {
   let mockChildrenService: jasmine.SpyObj<ChildrenService>;
 
   beforeEach(() => {
-    mockChildrenService = jasmine.createSpyObj("mockChildrenService", [
-      "getNotesOfChild",
-    ]);
+    mockChildrenService = jasmine.createSpyObj(["getNotesOf"]);
+    mockChildrenService.getNotesOf.and.resolveTo([]);
     TestBed.configureTestingModule({
       imports: [NotesModule, MockedTestingModule.withState()],
       providers: [{ provide: ChildrenService, useValue: mockChildrenService }],
@@ -27,7 +38,7 @@ describe("NotesOfChildComponent", () => {
   beforeEach(async () => {
     fixture = TestBed.createComponent(NotesOfChildComponent);
     component = fixture.componentInstance;
-    component.child = new Child("1");
+    component.entity = new Child("1");
     fixture.detectChanges();
   });
 
@@ -35,13 +46,53 @@ describe("NotesOfChildComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should load initial notes", async () => {
-    await fixture.whenStable();
-    expect(component.records).toEqual(allChildren);
+  it("should throw an error when a invalid entity is passed", () => {
+    const config: PanelConfig = { entity: new ChildSchoolRelation() };
+    expect(() => component.onInitFromDynamicConfig(config)).toThrowError();
   });
 
-  it("should create a new note", function () {
-    const newNoteFactory = component.generateNewRecordFactory();
-    expect(newNoteFactory).toBeDefined();
+  it("should use the attendance color function when passing a child", () => {
+    const note = new Note();
+    spyOn(note, "getColorForId");
+    const entity = new Child();
+    component.onInitFromDynamicConfig({ entity });
+
+    component.getColor(note);
+
+    expect(note.getColorForId).toHaveBeenCalledWith(entity.getId());
   });
+
+  it("should create a new note and fill it with the appropriate initial value", () => {
+    let entity: Entity = new Child();
+    component.onInitFromDynamicConfig({ entity });
+    let note = component.generateNewRecordFactory()();
+    expect(note.children).toEqual([entity.getId()]);
+    expect(note.authors).toEqual([TEST_USER]);
+
+    entity = new School();
+    component.onInitFromDynamicConfig({ entity });
+    note = component.generateNewRecordFactory()();
+    expect(note.schools).toEqual([entity.getId()]);
+    expect(note.authors).toEqual([TEST_USER]);
+
+    entity = new User();
+    component.onInitFromDynamicConfig({ entity });
+    note = component.generateNewRecordFactory()();
+    expect(note.authors).toEqual([entity.getId(), TEST_USER]);
+  });
+
+  it("should sort notes by date", fakeAsync(() => {
+    const n1 = new Note();
+    n1.date = moment().subtract(1, "day").toDate();
+    const n2 = new Note();
+    n2.date = moment().subtract(2, "days").toDate();
+    const n3 = new Note();
+    n3.date = moment().subtract(3, "days").toDate();
+    mockChildrenService.getNotesOf.and.resolveTo([n1, n3, n2]);
+
+    component.onInitFromDynamicConfig({ entity: new Child() });
+    tick();
+
+    expect(component.records).toEqual([n1, n2, n3]);
+  }));
 });

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
@@ -80,16 +80,18 @@ export class NotesOfChildComponent
   }
 
   private initNotesOfChild() {
-    this.childrenService.getNotesOf(this.entity).then((notes: Note[]) => {
-      notes.sort((a, b) => {
-        if (!a.date && b.date) {
-          // note without date should be first
-          return -1;
-        }
-        return moment(b.date).valueOf() - moment(a.date).valueOf();
+    this.childrenService
+      .getNotesOf(this.entity.getId(), this.noteProperty)
+      .then((notes: Note[]) => {
+        notes.sort((a, b) => {
+          if (!a.date && b.date) {
+            // note without date should be first
+            return -1;
+          }
+          return moment(b.date).valueOf() - moment(a.date).valueOf();
+        });
+        this.records = notes;
       });
-      this.records = notes;
-    });
   }
 
   generateNewRecordFactory() {

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
@@ -4,7 +4,6 @@ import { NoteDetailsComponent } from "../note-details/note-details.component";
 import { ChildrenService } from "../../children/children.service";
 import moment from "moment";
 import { SessionService } from "../../../core/session/session-service/session.service";
-import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Child } from "../../children/model/child";
 import { OnInitDynamicComponent } from "../../../core/view/dynamic-components/on-init-dynamic-component.interface";
 import { PanelConfig } from "../../../core/entity-components/entity-details/EntityDetailsConfig";
@@ -15,7 +14,6 @@ import { DynamicComponent } from "../../../core/view/dynamic-components/dynamic-
 /**
  * The component that is responsible for listing the Notes that are related to a certain child
  */
-@UntilDestroy()
 @DynamicComponent("NotesOfChild")
 @Component({
   selector: "app-notes-of-child",
@@ -23,7 +21,8 @@ import { DynamicComponent } from "../../../core/view/dynamic-components/dynamic-
   styleUrls: ["./notes-of-child.component.scss"],
 })
 export class NotesOfChildComponent
-  implements OnChanges, OnInitDynamicComponent {
+  implements OnChanges, OnInitDynamicComponent
+{
   @Input() child: Child;
   records: Array<Note> = [];
 
@@ -59,8 +58,7 @@ export class NotesOfChildComponent
   private initNotesOfChild() {
     this.childrenService
       .getNotesOfChild(this.child.getId())
-      .pipe(untilDestroyed(this))
-      .subscribe((notes: Note[]) => {
+      .then((notes: Note[]) => {
         notes.sort((a, b) => {
           if (!a.date && b.date) {
             // note without date should be first

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
@@ -56,18 +56,16 @@ export class NotesOfChildComponent
   }
 
   private initNotesOfChild() {
-    this.childrenService
-      .getNotesOfChild(this.child.getId())
-      .then((notes: Note[]) => {
-        notes.sort((a, b) => {
-          if (!a.date && b.date) {
-            // note without date should be first
-            return -1;
-          }
-          return moment(b.date).valueOf() - moment(a.date).valueOf();
-        });
-        this.records = notes;
+    this.childrenService.getNotesOf(this.child).then((notes: Note[]) => {
+      notes.sort((a, b) => {
+        if (!a.date && b.date) {
+          // note without date should be first
+          return -1;
+        }
+        return moment(b.date).valueOf() - moment(a.date).valueOf();
       });
+      this.records = notes;
+    });
   }
 
   generateNewRecordFactory() {

--- a/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
+++ b/src/app/child-dev-project/notes/notes-of-child/notes-of-child.component.ts
@@ -4,15 +4,17 @@ import { NoteDetailsComponent } from "../note-details/note-details.component";
 import { ChildrenService } from "../../children/children.service";
 import moment from "moment";
 import { SessionService } from "../../../core/session/session-service/session.service";
-import { Child } from "../../children/model/child";
 import { OnInitDynamicComponent } from "../../../core/view/dynamic-components/on-init-dynamic-component.interface";
 import { PanelConfig } from "../../../core/entity-components/entity-details/EntityDetailsConfig";
 import { FormFieldConfig } from "../../../core/entity-components/entity-form/entity-form/FormConfig";
 import { FormDialogService } from "../../../core/form-dialog/form-dialog.service";
 import { DynamicComponent } from "../../../core/view/dynamic-components/dynamic-component.decorator";
+import { Entity } from "../../../core/entity/model/entity";
 
 /**
  * The component that is responsible for listing the Notes that are related to a certain child
+ *
+ * TODO rename this to a more general name as this can also handle notes of schools and notes of authors
  */
 @DynamicComponent("NotesOfChild")
 @Component({
@@ -23,7 +25,8 @@ import { DynamicComponent } from "../../../core/view/dynamic-components/dynamic-
 export class NotesOfChildComponent
   implements OnChanges, OnInitDynamicComponent
 {
-  @Input() child: Child;
+  @Input() entity: Entity;
+  private noteProperty = "children";
   records: Array<Note> = [];
 
   columns: FormFieldConfig[] = [
@@ -33,6 +36,12 @@ export class NotesOfChildComponent
     { id: "authors", visibleFrom: "md" },
     { id: "warningLevel", visibleFrom: "md" },
   ];
+
+  /**
+   * returns the color for a note; passed to the entity subrecord component
+   * @param note note to get color for
+   */
+  getColor = (note: Note) => note?.getColor();
 
   constructor(
     private childrenService: ChildrenService,
@@ -51,12 +60,27 @@ export class NotesOfChildComponent
       this.columns = config.config.columns;
     }
 
-    this.child = config.entity as Child;
+    this.entity = config.entity;
+    const entityType = this.entity.getType();
+    this.noteProperty = [...Note.schema.keys()].find(
+      (prop) => Note.schema.get(prop).additional === entityType
+    );
+    if (!this.noteProperty) {
+      throw new Error(
+        `Could not load notes for related entity: "${entityType}"`
+      );
+    }
+
+    if (this.noteProperty === "children") {
+      // When displaying notes for a child, use attendance color highlighting
+      this.getColor = (note: Note) => note?.getColorForId(this.entity.getId());
+    }
+
     this.initNotesOfChild();
   }
 
   private initNotesOfChild() {
-    this.childrenService.getNotesOf(this.child).then((notes: Note[]) => {
+    this.childrenService.getNotesOf(this.entity).then((notes: Note[]) => {
       notes.sort((a, b) => {
         if (!a.date && b.date) {
           // note without date should be first
@@ -69,25 +93,24 @@ export class NotesOfChildComponent
   }
 
   generateNewRecordFactory() {
-    // define values locally because "this" is a different scope after passing a function as input to another component
     const user = this.sessionService.getCurrentUser().name;
-    const childId = this.child.getId();
+    const entityId = this.entity.getId();
 
     return () => {
       const newNote = new Note(Date.now().toString());
       newNote.date = new Date();
-      newNote.addChild(childId);
-      newNote.authors = [user];
+      if (this.noteProperty === "children") {
+        newNote.addChild(entityId);
+      } else {
+        newNote[this.noteProperty].push(entityId);
+      }
+      if (!newNote.authors.includes(user)) {
+        newNote.authors.push(user);
+      }
 
       return newNote;
     };
   }
-
-  /**
-   * returns the color for a note; passed to the entity subrecord component
-   * @param note note to get color for
-   */
-  getColor = (note: Note) => note?.getColorForId(this.child.getId());
 
   showNoteDetails(note: Note) {
     this.formDialog.openDialog(NoteDetailsComponent, note);


### PR DESCRIPTION
see #1423 

The current `NotesOfChild` component only allows to show notes that are linked to a child.
This component has been made more abstract to also support notes of a school or notes of an author.

Currently the component is still called `NotesOfChild`. This name should be changed in the future to something like `RelatedNotes`. I have left it for now because I want to get this PR out fast and a change of the name would require a migration of existing configs.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] `NotesOfChild` can be used in school and user details components
