### PR TITLE
Allow dates to be entered in different locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/forms": "^14.2.0",
         "@angular/localize": "^14.2.0",
         "@angular/material": "^14.2.0",
+        "@angular/material-moment-adapter": "^14.2.2",
         "@angular/platform-browser": "^14.2.0",
         "@angular/platform-browser-dynamic": "^14.2.0",
         "@angular/router": "^14.2.0",
@@ -108,7 +109,7 @@
         "ts-node": "^10.9.1",
         "tslint-config-prettier": "^1.18.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^4.7.4",
+        "typescript": "~4.7.4",
         "xliff": "^6.1.0"
       }
     },
@@ -560,9 +561,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.2.0.tgz",
-      "integrity": "sha512-rAeQXUSbOJSKLVizueRKoZmRb0An5qJUMigsF8wJwJjySUIcJ8uSIOMV+G1rxkvxVVY0HRAVi2rIkJbeq3+WKQ==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.2.2.tgz",
+      "integrity": "sha512-PXEnhX+QDOsmHVVnqTuoGaK7Wn9hFd5kWAmHTTU7lZr3XVu/AtDcEU+LB19wOFU0fY+kSYHMgN+BYo1TiR8vbw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -781,20 +782,33 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.2.0.tgz",
-      "integrity": "sha512-Lh7Ccc6zi5ClFnr5w1ZFVHb5QnOye1si0xWvS5nMQG3e0OPFAt0oOhjILFIBMK7n2jq4kv6erqNX2fLkyRvTQw==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.2.2.tgz",
+      "integrity": "sha512-jVCaESSTTkLjRvMzSQj294s0Lz1YMVFkl0svrMtWgkUMXHEfx2Vjw6FXdrVrBXlxEIrpfhkTEXVN2DC1kkAkQw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/animations": "^14.0.0 || ^15.0.0",
-        "@angular/cdk": "14.2.0",
+        "@angular/cdk": "14.2.2",
         "@angular/common": "^14.0.0 || ^15.0.0",
         "@angular/core": "^14.0.0 || ^15.0.0",
         "@angular/forms": "^14.0.0 || ^15.0.0",
         "@angular/platform-browser": "^14.0.0 || ^15.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material-moment-adapter": {
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-14.2.2.tgz",
+      "integrity": "sha512-EOnchBkcICJQXYcXEk+4FSgQXllhJAfE56rkeCDS0r0iFe+zdM4da6JseBQPIKMraYXcnuDnMC1Q2cjVMggn+A==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^14.0.0 || ^15.0.0",
+        "@angular/material": "14.2.2",
+        "moment": "^2.18.1"
       }
     },
     "node_modules/@angular/platform-browser": {
@@ -33264,9 +33278,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.2.0.tgz",
-      "integrity": "sha512-rAeQXUSbOJSKLVizueRKoZmRb0An5qJUMigsF8wJwJjySUIcJ8uSIOMV+G1rxkvxVVY0HRAVi2rIkJbeq3+WKQ==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.2.2.tgz",
+      "integrity": "sha512-PXEnhX+QDOsmHVVnqTuoGaK7Wn9hFd5kWAmHTTU7lZr3XVu/AtDcEU+LB19wOFU0fY+kSYHMgN+BYo1TiR8vbw==",
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^2.3.0"
@@ -33397,9 +33411,17 @@
       }
     },
     "@angular/material": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.2.0.tgz",
-      "integrity": "sha512-Lh7Ccc6zi5ClFnr5w1ZFVHb5QnOye1si0xWvS5nMQG3e0OPFAt0oOhjILFIBMK7n2jq4kv6erqNX2fLkyRvTQw==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.2.2.tgz",
+      "integrity": "sha512-jVCaESSTTkLjRvMzSQj294s0Lz1YMVFkl0svrMtWgkUMXHEfx2Vjw6FXdrVrBXlxEIrpfhkTEXVN2DC1kkAkQw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@angular/material-moment-adapter": {
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-14.2.2.tgz",
+      "integrity": "sha512-EOnchBkcICJQXYcXEk+4FSgQXllhJAfE56rkeCDS0r0iFe+zdM4da6JseBQPIKMraYXcnuDnMC1Q2cjVMggn+A==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@angular/forms": "^14.2.0",
     "@angular/localize": "^14.2.0",
     "@angular/material": "^14.2.0",
+    "@angular/material-moment-adapter": "^14.2.2",
     "@angular/platform-browser": "^14.2.0",
     "@angular/platform-browser-dynamic": "^14.2.0",
     "@angular/router": "^14.2.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -83,6 +83,15 @@ import {
   DEFAULT_LANGUAGE,
   LANGUAGE_LOCAL_STORAGE_KEY,
 } from "./core/language/language-statics";
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MAT_DATE_LOCALE,
+} from "@angular/material/core";
+import {
+  MAT_MOMENT_DATE_FORMATS,
+  MomentDateAdapter,
+} from "@angular/material-moment-adapter";
 
 /**
  * Main entry point of the application.
@@ -168,6 +177,15 @@ import {
       provide: LOCALE_ID,
       useValue:
         localStorage.getItem(LANGUAGE_LOCAL_STORAGE_KEY) ?? DEFAULT_LANGUAGE,
+    },
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE],
+    },
+    {
+      provide: MAT_DATE_FORMATS,
+      useValue: MAT_MOMENT_DATE_FORMATS,
     },
     AnalyticsService,
     Angulartics2Matomo,

--- a/src/app/child-dev-project/children/model/child.ts
+++ b/src/app/child-dev-project/children/model/child.ts
@@ -24,6 +24,7 @@ import { Photo } from "../child-photo-service/photo";
 import { BehaviorSubject } from "rxjs";
 import { SafeUrl } from "@angular/platform-browser";
 import { ChildPhotoService } from "../child-photo-service/child-photo.service";
+import moment from "moment";
 
 export type Center = ConfigurableEnumValue;
 @DatabaseEntity("Child")
@@ -118,7 +119,7 @@ export class Child extends Entity {
   phone: string;
 
   get age(): number {
-    return this.dateOfBirth ? calculateAge(this.dateOfBirth) : null;
+    return this.dateOfBirth ? calculateAge(moment(this.dateOfBirth)) : null;
   }
 
   get isActive(): boolean {

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-age/edit-age.component.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 import { EditComponent } from "../edit-component";
 import { calculateAge } from "../../../../../utils/utils";
 import { DynamicComponent } from "../../../../view/dynamic-components/dynamic-component.decorator";
+import moment from "moment";
 
 @DynamicComponent("EditAge")
 @Component({
@@ -11,6 +12,6 @@ import { DynamicComponent } from "../../../../view/dynamic-components/dynamic-co
 })
 export class EditAgeComponent extends EditComponent<Date> {
   getAge(selectedDateOfBirth: Date) {
-    return selectedDateOfBirth ? calculateAge(selectedDateOfBirth) : "";
+    return selectedDateOfBirth ? calculateAge(moment(selectedDateOfBirth)) : "";
   }
 }

--- a/src/app/utils/utils.spec.ts
+++ b/src/app/utils/utils.spec.ts
@@ -19,10 +19,10 @@ describe("Utils", () => {
 
   it("should calculate age correctly", () => {
     let dob = moment().subtract(9, "years");
-    let age = calculateAge(dob.toDate());
+    let age = calculateAge(dob);
     expect(age).toBe(9);
     dob = dob.add("1", "day");
-    age = calculateAge(dob.toDate());
+    age = calculateAge(dob);
     expect(age).toBe(8);
   });
 

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -4,6 +4,7 @@
  */
 import { Router } from "@angular/router";
 import { ConfigurableEnumValue } from "../core/configurable-enum/configurable-enum.interface";
+import moment, { Moment } from "moment";
 
 export function isValidDate(date: any): boolean {
   return (
@@ -44,14 +45,8 @@ export function groupBy<T>(
   );
 }
 
-export function calculateAge(dateOfBirth: Date): number {
-  const now = new Date();
-  let age = now.getFullYear() - dateOfBirth.getFullYear();
-  const m = now.getMonth() - dateOfBirth.getMonth();
-  if (m < 0 || (m === 0 && now.getDate() < dateOfBirth.getDate())) {
-    age--;
-  }
-  return age;
+export function calculateAge(dateOfBirth: Moment): number {
+  return moment().diff(dateOfBirth, "years");
 }
 
 export function sortByAttribute<OBJECT>(


### PR DESCRIPTION
see issue: #1429

### Architectural/Backend Changes
- [x] Dates can now be entered in any locale supported by moment (a lot)

This change uses the `MomentDateAdapter` from `moment.js`. At some point, we want to get rid of `moment.js` altogether and replace it with something that is long-term supported. However, this change is very tedious and lots of caution needs to be taken to correctly replace the `moment.js` dependency with something different. Therefore, I propose to use this date-adaptor and when the time comes to replace moment, we can also replace the adaptor together with moment.
