### PR TITLE
fix: error when no date is selected but data is received

### DIFF
--- a/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.ts
+++ b/src/app/child-dev-project/attendance/attendance-calendar/attendance-calendar.component.ts
@@ -58,7 +58,7 @@ export class AttendanceCalendarComponent implements OnChanges {
       .pipe(untilDestroyed(this))
       .subscribe((newNotes) => {
         this.records = applyUpdate(this.records, newNotes);
-        this.selectDay(this.selectedDate.toDate());
+        this.selectDay(this.selectedDate?.toDate());
       });
   }
 


### PR DESCRIPTION
When not selecting a date but receiving updates for the `EventNote` entity, a error is thrown because `this.selectedDate` is undefined in this case.
### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
