### PR TITLE
fix: passwords are correctly checked

### DIFF
--- a/src/app/core/session/session-service/local-session.ts
+++ b/src/app/core/session/session-service/local-session.ts
@@ -50,9 +50,7 @@ export class LocalSession extends SessionService {
    * @param password Password
    */
   public async login(username: string, password: string): Promise<LoginState> {
-    const user: LocalUser = JSON.parse(
-      window.localStorage.getItem(username.trim().toLowerCase())
-    );
+    const user = this.getStoredUser(username);
     if (user) {
       if (passwordEqualsEncrypted(password, user.encryptedPassword)) {
         await this.handleSuccessfulLogin(user);
@@ -63,6 +61,11 @@ export class LocalSession extends SessionService {
       this.loginState.next(LoginState.UNAVAILABLE);
     }
     return this.loginState.value;
+  }
+
+  private getStoredUser(username: string): LocalUser {
+    const stored = window.localStorage.getItem(username.trim().toLowerCase());
+    return JSON.parse(stored);
   }
 
   public async handleSuccessfulLogin(userObject: DatabaseUser) {
@@ -142,7 +145,7 @@ export class LocalSession extends SessionService {
   }
 
   public checkPassword(username: string, password: string): boolean {
-    const user: LocalUser = JSON.parse(window.localStorage.getItem(username));
+    const user = this.getStoredUser(username);
     return user && passwordEqualsEncrypted(password, user.encryptedPassword);
   }
 

--- a/src/app/core/session/session-service/synced-session.service.spec.ts
+++ b/src/app/core/session/session-service/synced-session.service.spec.ts
@@ -263,6 +263,13 @@ describe("SyncedSessionService", () => {
     localStorage.removeItem("my@email.com");
   });
 
+  it("should correctly check the password", () => {
+    localSession.saveUser({ name: "TestUser", roles: [] }, TEST_PASSWORD);
+
+    expect(sessionService.checkPassword("TestUser", TEST_PASSWORD)).toBeTrue();
+    expect(sessionService.checkPassword("TestUser", "wrongPW")).toBeFalse();
+  });
+
   testSessionServiceImplementation(() => Promise.resolve(sessionService));
 
   function passRemoteLogin(response: DatabaseUser = { name: "", roles: [] }) {


### PR DESCRIPTION
After we recently changed the usernames not to be case-sensitive, we forgot to adapt the `checkPassword` function. This function was still using the exact username. This has been fixed.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Check password uses the same logic as the login method for loading the local user object
