### PR TITLE
fix(UI): add explanation to text-with-autocomplete field

### DIFF
--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -20,7 +20,7 @@
       ></app-display-entity>
     </mat-option>
   </mat-autocomplete>
-  <mat-hint>
+  <mat-hint *ngIf="!autocompleteDisabled">
     <span *ngIf="!selectedEntity">Create new record.</span>
     <span *ngIf="selectedEntity">Edit loaded existing record.</span>
   </mat-hint>

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -21,7 +21,7 @@
     </mat-option>
   </mat-autocomplete>
   <mat-hint *ngIf="!autocompleteDisabled">
-    <span *ngIf="!selectedEntity">Create new record.</span>
+    <span *ngIf="!selectedEntity" i18n>Creating new record.</span>
     <span *ngIf="selectedEntity">Edit loaded existing record.</span>
   </mat-hint>
   <mat-error

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -33,6 +33,7 @@
 </mat-form-field>
 
 <fa-icon
+  *ngIf="!autocompleteDisabled"
   (click)="tooltipElement.show()"
   #tooltipElement="matTooltip"
   icon="cogs"

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -22,7 +22,7 @@
   </mat-autocomplete>
   <mat-hint *ngIf="!autocompleteDisabled">
     <span *ngIf="!selectedEntity" i18n>Creating new record.</span>
-    <span *ngIf="selectedEntity">Edit loaded existing record.</span>
+    <span *ngIf="selectedEntity" i18n>Editing existing record.</span>
   </mat-hint>
   <mat-error
     *ngIf="formControl.errors?.required"

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="parent">
+<mat-form-field [formGroup]="parent" class="form-field-with-tooltip-suffix">
   <mat-label>{{ label }}</mat-label>
   <input
     matInput
@@ -20,7 +20,10 @@
       ></app-display-entity>
     </mat-option>
   </mat-autocomplete>
-
+  <mat-hint>
+    <span *ngIf="!selectedEntity">Create new record.</span>
+    <span *ngIf="selectedEntity">Edit loaded existing record.</span>
+  </mat-hint>
   <mat-error
     *ngIf="formControl.errors?.required"
     i18n="Error message for any input"
@@ -28,3 +31,13 @@
     This field is required
   </mat-error>
 </mat-form-field>
+
+<fa-icon
+  (click)="tooltipElement.show()"
+  #tooltipElement="matTooltip"
+  icon="cogs"
+  [matTooltip]="'You can create a new or load an existing record. Start to type an existing name and then select it from the dropdown to edit the existing record. Type any new text to create a new record.'"
+  class="tooltip-suffix"
+></fa-icon>
+
+

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.scss
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.scss
@@ -1,0 +1,7 @@
+.form-field-with-tooltip-suffix {
+  width: calc(95% - 24px)
+}
+
+.tooltip-suffix {
+  margin-left: 4px;
+}

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
@@ -15,6 +15,7 @@ import { EntityMapperService } from "../../../../entity/entity-mapper.service";
 import { EntityUtilsModule } from "../../entity-utils.module";
 import { EditTextWithAutocompleteComponent } from "./edit-text-with-autocomplete.component";
 import { By } from "@angular/platform-browser";
+import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 
 describe("EditTextWithAutocompleteComponent", () => {
   let component: EditTextWithAutocompleteComponent;
@@ -24,7 +25,7 @@ describe("EditTextWithAutocompleteComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [EditTextWithAutocompleteComponent],
-      imports: [EntityUtilsModule, MockedTestingModule.withState()],
+      imports: [EntityUtilsModule, MockedTestingModule.withState(), FontAwesomeTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditTextWithAutocompleteComponent);

--- a/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
+++ b/src/app/core/entity-components/entity-utils/dynamic-form-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
@@ -31,6 +31,7 @@ import { ConfirmationDialogService } from "app/core/confirmation-dialog/confirma
 @DynamicComponent("EditTextWithAutocomplete")
 @Component({
   selector: "app-edit-text-with-autocomplete",
+  styleUrls: ["./edit-text-with-autocomplete.component.scss"],
   templateUrl: "./edit-text-with-autocomplete.component.html",
 })
 export class EditTextWithAutocompleteComponent extends EditComponent<string> {


### PR DESCRIPTION
add explanation to text-with-autocomplete field in the UI about how existing records are loaded or new records are created