### PR TITLE
fix: login attempt is correctly detected as unauthorised

### DIFF
--- a/src/app/core/session/auth/keycloak/account-page/account-page.component.html
+++ b/src/app/core/session/auth/keycloak/account-page/account-page.component.html
@@ -41,9 +41,5 @@
         Update email
       </button>
     </p>
-    <p *ngIf="showSuccessMessage" i18n="Success message after email has been updated">
-      <fa-icon icon="check"></fa-icon>
-      Successfully updated email address
-    </p>
   </form>
 </div>

--- a/src/app/core/session/auth/keycloak/account-page/account-page.component.spec.ts
+++ b/src/app/core/session/auth/keycloak/account-page/account-page.component.spec.ts
@@ -12,11 +12,13 @@ import { of, throwError } from "rxjs";
 import { SessionModule } from "../../../session.module";
 import { MockedTestingModule } from "../../../../../utils/mocked-testing.module";
 import { HttpErrorResponse } from "@angular/common/http";
+import { AlertService } from "../../../../alerts/alert.service";
 
 describe("AccountPageComponent", () => {
   let component: AccountPageComponent;
   let fixture: ComponentFixture<AccountPageComponent>;
   let mockAuthService: jasmine.SpyObj<KeycloakAuthService>;
+  let mockAlerts: jasmine.SpyObj<AlertService>;
 
   beforeEach(async () => {
     mockAuthService = jasmine.createSpyObj([
@@ -25,9 +27,13 @@ describe("AccountPageComponent", () => {
       "setEmail",
     ]);
     mockAuthService.getUserinfo.and.returnValue(throwError(() => new Error()));
+    mockAlerts = jasmine.createSpyObj(["addInfo"]);
     await TestBed.configureTestingModule({
       imports: [SessionModule, MockedTestingModule.withState()],
-      providers: [{ provide: AuthService, useValue: {} }],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: AlertService, useValue: mockAlerts },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AccountPageComponent);
@@ -69,7 +75,7 @@ describe("AccountPageComponent", () => {
 
     expect(mockAuthService.setEmail).toHaveBeenCalledWith(validEmail);
     tick();
-    expect(component.showSuccessMessage).toBeTrue();
+    expect(mockAlerts.addInfo).toHaveBeenCalled();
   }));
 
   it("should show error message if email couldn't be set", fakeAsync(() => {
@@ -84,7 +90,6 @@ describe("AccountPageComponent", () => {
     component.setEmail();
     tick();
 
-    expect(component.showSuccessMessage).toBeFalse();
     expect(component.email.errors).toEqual({ other: errorMessage });
   }));
 });

--- a/src/app/core/session/auth/keycloak/account-page/account-page.component.ts
+++ b/src/app/core/session/auth/keycloak/account-page/account-page.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from "@angular/core";
 import { AuthService } from "../../auth.service";
 import { KeycloakAuthService } from "../keycloak-auth.service";
 import { FormControl, Validators } from "@angular/forms";
+import { AlertService } from "../../../../alerts/alert.service";
 
 @Component({
   selector: "app-account-page",
@@ -11,9 +12,8 @@ export class AccountPageComponent implements OnInit {
   @Input() disabled: boolean;
   keycloakAuthService: KeycloakAuthService;
   email = new FormControl("", [Validators.required, Validators.email]);
-  showSuccessMessage = false;
 
-  constructor(authService: AuthService) {
+  constructor(authService: AuthService, private alertService: AlertService) {
     if (authService instanceof KeycloakAuthService) {
       this.keycloakAuthService = authService;
     }
@@ -29,14 +29,15 @@ export class AccountPageComponent implements OnInit {
   }
 
   setEmail() {
-    this.showSuccessMessage = false;
-
     if (this.email.invalid) {
       return;
     }
 
     this.keycloakAuthService.setEmail(this.email.value).subscribe({
-      next: () => (this.showSuccessMessage = true),
+      next: () =>
+        this.alertService.addInfo(
+          $localize`Please click the link in the email we sent you to verify your email address.`
+        ),
       error: (err) => this.email.setErrors({ other: err.error.message }),
     });
   }

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
@@ -129,7 +129,7 @@ describe("KeycloakAuthService", () => {
     service.logout();
   }));
 
-  it("should throw a unauthorized exception if account is disabled", (done) => {
+  it("should throw a unauthorized exception if invalid_grant is returned", (done) => {
     mockHttpClient.post.and.returnValue(
       throwError(
         () =>

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
@@ -81,7 +81,8 @@ export class KeycloakAuthService extends AuthService {
         )
         .pipe(
           catchError((err) => {
-            if (err.error.error_description === "Account disabled") {
+            // treat all invalid grants as unauthorized
+            if (err.error.error === "invalid_grant") {
               const status = HttpStatusCode.Unauthorized;
               throw new HttpErrorResponse({ status });
             } else {


### PR DESCRIPTION
When a user has changed its email but did not yet verify the email address, then the user is not able to log-in anymore.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
