### PR TITLE
fix: GitHub API can be used again

### DIFF
--- a/src/app/core/latest-changes/latest-changes.service.ts
+++ b/src/app/core/latest-changes/latest-changes.service.ts
@@ -20,8 +20,9 @@ import { Injectable } from "@angular/core";
 import { Observable, throwError } from "rxjs";
 import { Changelog } from "./changelog";
 import { AlertService } from "../alerts/alert.service";
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpContext } from "@angular/common/http";
 import { environment } from "../../../environments/environment";
+import { AUTH_ENABLED } from "../session/auth/keycloak/auth-interceptor.service";
 
 /**
  * Manage the changelog information and display it to the user
@@ -116,7 +117,8 @@ export class LatestChangesService {
   ): Observable<Changelog[]> {
     return this.http
       .get<any[]>(
-        LatestChangesService.GITHUB_API + environment.repositoryId + "/releases"
+        `${LatestChangesService.GITHUB_API}${environment.repositoryId}/releases`,
+        { context: new HttpContext().set(AUTH_ENABLED, false) }
       )
       .pipe(
         map(excludePrereleases),

--- a/src/app/core/session/auth/keycloak/auth-interceptor.service.ts
+++ b/src/app/core/session/auth/keycloak/auth-interceptor.service.ts
@@ -4,9 +4,21 @@ import {
   HttpHandler,
   HttpEvent,
   HttpInterceptor,
+  HttpContextToken,
 } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { AuthService } from "../auth.service";
+
+/**
+ * This context can be used to prevent the Bearer token to be set by this interceptor.
+ * This can be useful when a request goes to a 3rd party service e.g. GitHub.
+ *
+ * Usage:
+ * ```javascript
+ * this.httpClient.get(`...`, { context: new HttpContext().set(AUTH_ENABLED, false) });
+ * ```
+ */
+export const AUTH_ENABLED = new HttpContextToken(() => true);
 
 /**
  * This interceptor adds the required auth headers to all outgoing requests of the HttpClient service.
@@ -20,9 +32,12 @@ export class AuthInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>,
     next: HttpHandler
   ): Observable<HttpEvent<unknown>> {
-    // The request needs to be cloned as they are immutable
-    const headers = {} as any;
-    this.authService.addAuthHeader(headers);
-    return next.handle(request.clone({ setHeaders: headers }));
+    if (request.context.get(AUTH_ENABLED)) {
+      const headers = {} as any;
+      this.authService.addAuthHeader(headers);
+      // The request needs to be cloned as they are immutable
+      request = request.clone({ setHeaders: headers });
+    }
+    return next.handle(request);
   }
 }

--- a/src/app/core/session/auth/keycloak/auth.interceptor.spec.ts
+++ b/src/app/core/session/auth/keycloak/auth.interceptor.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from "@angular/core/testing";
 
-import { AuthInterceptor } from "./auth-interceptor.service";
+import { AUTH_ENABLED, AuthInterceptor } from "./auth-interceptor.service";
 import { AuthService } from "../auth.service";
+import { HttpContext } from "@angular/common/http";
 
 describe("AuthInterceptor", () => {
   let mockAuthService: jasmine.SpyObj<AuthService>;
@@ -22,7 +23,10 @@ describe("AuthInterceptor", () => {
   });
 
   it("should add an auth header to a request", () => {
-    const request = { clone: jasmine.createSpy() };
+    const request = {
+      clone: jasmine.createSpy(),
+      context: new HttpContext().set(AUTH_ENABLED, true),
+    };
     mockAuthService.addAuthHeader.and.callFake(
       (obj) => (obj["Authorization"] = "my-auth-header")
     );

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
@@ -117,12 +117,14 @@ export class KeycloakAuthService extends AuthService {
   }
 
   addAuthHeader(headers: any) {
-    if (headers.set && typeof headers.set === "function") {
-      // PouchDB headers are set as a map
-      headers.set("Authorization", "Bearer " + this.accessToken);
-    } else {
-      // Interceptor headers are set as a simple object
-      headers["Authorization"] = "Bearer " + this.accessToken;
+    if (this.accessToken) {
+      if (headers.set && typeof headers.set === "function") {
+        // PouchDB headers are set as a map
+        headers.set("Authorization", "Bearer " + this.accessToken);
+      } else {
+        // Interceptor headers are set as a simple object
+        headers["Authorization"] = "Bearer " + this.accessToken;
+      }
     }
   }
 


### PR DESCRIPTION
Currently the GitHub API requests fail because we sent a Bearer token with the request which is not valid for GitHub. 
This change allows to disable the setting of the Bearer token for special requests.

### Visible/Frontend Changes
- [x] Latest changes are shown again

### Architectural/Backend Changes
- [x] Auth Interceptor can be disabled