### PR TITLE
fix: using initial username as id and preventing later edits

### DIFF
--- a/src/app/core/entity/model/entity.ts
+++ b/src/app/core/entity/model/entity.ts
@@ -139,12 +139,13 @@ export class Entity {
     let indices = [];
 
     // default indices generated from "name" property
-    if (this.hasOwnProperty("name")) {
+    if (typeof this["name"] === "string") {
       indices = this["name"].split(" ");
     }
 
     return indices;
   }
+
   set searchIndices(value) {
     // do nothing, always generated on the fly
     // searchIndices is only saved to database so it can be used internally for database indexing

--- a/src/app/core/permissions/ability/ability.service.spec.ts
+++ b/src/app/core/permissions/ability/ability.service.spec.ts
@@ -212,8 +212,9 @@ describe("AbilityService", () => {
     const userEntity = new User();
     userEntity.name = user.name;
     expect(ability.can("manage", userEntity)).toBeTrue();
-    userEntity.name = "another user";
-    expect(ability.cannot("manage", userEntity)).toBeTrue();
+    const anotherUser = new User();
+    anotherUser.name = "another user";
+    expect(ability.cannot("manage", anotherUser)).toBeTrue();
   });
 
   it("should allow to check conditions with complex data types", fakeAsync(() => {

--- a/src/app/core/user/user.spec.ts
+++ b/src/app/core/user/user.spec.ts
@@ -20,11 +20,20 @@ import { testEntitySubclass } from "../entity/model/entity.spec";
 
 describe("User", () => {
   testEntitySubclass("User", User, {
-    _id: "User:some-id",
+    _id: "User:tester",
 
     name: "tester",
     paginatorSettingsPageSize: {},
 
     searchIndices: ["tester"],
+  });
+
+  it("should not allow to change the name after initialization and set it as the ID", () => {
+    const user = new User();
+    user.name = "test-name";
+
+    expect(user.name).toBe("test-name");
+    expect(user.getId()).toBe("test-name");
+    expect(() => (user.name = "another-name")).toThrowError();
   });
 });

--- a/src/app/core/user/user.ts
+++ b/src/app/core/user/user.ts
@@ -34,7 +34,23 @@ export class User extends Entity {
     label: $localize`:Label of username:Username`,
     validators: { required: true },
   })
-  name: string;
+  set name(value: string) {
+    if (this._name) {
+      // Throwing error if trying to change existing username
+      const label = User.schema.get("name").label;
+      throw new Error(
+        $localize`:Error message when trying to change the username|e.g. username cannot be changed after initialization:${label} cannot be changed after initialization`
+      );
+    }
+    this.entityId = value;
+    this._name = value;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  private _name: string;
 
   /**
    * settings for the mat-paginator for tables.


### PR DESCRIPTION
When creating new user they currently get a UUID (like all other entities). The problem is we need the user's id to match the username of the Keycloak user. This is important in order to assign users to entities and then later match them with actually logged in users.

This approach initially overwrites the entity id when the first time a username is saved but afterwards does not allow to change the username anymore. This way we ensure that user entities can be matched with the usernames.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] When creating a `User` entity, the name is used as `entityId`
- [x] When trying to change the name of a existing user, an error is thrown
