### PR TITLE
fix: users can be edited again

### DIFF
--- a/src/app/core/user/user.spec.ts
+++ b/src/app/core/user/user.spec.ts
@@ -36,4 +36,11 @@ describe("User", () => {
     expect(user.getId()).toBe("test-name");
     expect(() => (user.name = "another-name")).toThrowError();
   });
+
+  it("should not fail when name is actually the same", () => {
+    const user = new User();
+    user.name = "test-name";
+
+    expect(() => (user.name = "test-name")).not.toThrowError();
+  });
 });

--- a/src/app/core/user/user.ts
+++ b/src/app/core/user/user.ts
@@ -35,7 +35,7 @@ export class User extends Entity {
     validators: { required: true },
   })
   set name(value: string) {
-    if (this._name) {
+    if (this._name && value !== this._name) {
       // Throwing error if trying to change existing username
       const label = User.schema.get("name").label;
       throw new Error(


### PR DESCRIPTION
see issue: #1510 

### Visible/Frontend Changes
- [x] User form can be saved if username was not changed

### Architectural/Backend Changes
--
