### PR TITLE
fix(ui): add padding to entity details tabs again

### DIFF
--- a/src/app/core/entity-components/entity-details/entity-details.component.html
+++ b/src/app/core/entity-components/entity-details/entity-details.component.html
@@ -78,7 +78,7 @@
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
     </div>
 
-    <div *ngFor="let componentConfig of panelConfig.components; let j = index">
+    <div *ngFor="let componentConfig of panelConfig.components; let j = index" class="padding-top-large">
       <h3 *ngIf="componentConfig.title && componentConfig.title !== ''">
         {{ componentConfig.title }}
       </h3>


### PR DESCRIPTION
add padding to entity details tabs again that went missing with previous ui fix
