### PR TITLE
fix: styling of disabled create button

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.html
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.html
@@ -56,7 +56,7 @@
     <th mat-header-cell *matHeaderCellDef [class.remove-padding-left]="editable">
       <ng-container *ngIf="editable">
         <button
-          mat-ripple
+          mat-icon-button
           *appDisabledEntityOperation="{
             entity: getEntityConstructor(),
             operation: 'create'
@@ -65,6 +65,7 @@
           (click)="create()"
         >
           <fa-icon
+            style="vertical-align: initial"
             class="standard-icon"
             aria-label="add"
             icon="plus-circle"

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.scss
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.scss
@@ -3,26 +3,9 @@
 @use "@angular/material" as mat;
 
 .table-action-button {
-  font-size: 115%;
-  color: mat.get-color-from-palette(theme.$accent);
   border: 1px solid lightgrey;
   border-radius: 4px;
   margin: sizes.$small;
-  cursor: pointer;
-  background-color: initial;
-
-  &:hover {
-    background-color: mat.get-color-from-palette(mat.$grey-palette, 50);
-  }
-
-  padding: 4px 8px;
-
-  // CSS Magic that ensures the button is centered in all browsers
-
-  > fa-icon {
-    display: grid;
-    font-size: 1.25em;
-  }
 }
 
 .mat-column-actions {

--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.scss
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.scss
@@ -6,6 +6,7 @@
   border: 1px solid lightgrey;
   border-radius: 4px;
   margin: sizes.$small;
+  color: mat.get-color-from-palette(theme.$accent);
 }
 
 .mat-column-actions {


### PR DESCRIPTION
When the create button in entity subrecord is disbled, it still looks like it can be used.

### Visible/Frontend Changes
- [x] 'plus' button looks disabled if permissions are missing

### Architectural/Backend Changes
--
