### PR TITLE
fix: change detection is correctly triggered to build new filters

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -90,12 +90,14 @@ export class RollCallSetupComponent implements OnInit {
       }
     }
 
-    for (const activity of this.visibleActivities) {
-      const newEvent = await this.createEventForActivity(activity);
-      if (newEvent) {
-        this.existingEvents.push(newEvent);
-      }
-    }
+    const newEvents = await Promise.all(
+      this.visibleActivities.map((activity) =>
+        this.createEventForActivity(activity)
+      )
+    );
+    this.existingEvents = this.existingEvents.concat(
+      ...newEvents.filter((e) => !!e)
+    );
   }
 
   async showMore() {


### PR DESCRIPTION
see issue: #1570 
As the additional events were only pushed to the existing array, no new change detection was triggered. Instead, we now correctly create a new array once all the additional events were created.

### Visible/Frontend Changes
- [x] Filters in roll call setup show all available options

### Architectural/Backend Changes
--
