### PR TITLE
fix: clicking plus buttons also triggers external display logic

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
@@ -371,6 +371,7 @@ export class EntitySubrecordComponent<T extends Entity>
    */
   create() {
     const newRecord = this.newRecordFactory();
+    this.rowClick.emit(newRecord);
     this.showEntity(newRecord);
     this.analyticsService.eventTrack("subrecord_add_new", {
       category: newRecord.getType(),


### PR DESCRIPTION
Currently, when `clickMode` is set to `none` nothing happens when the plus button is clicked. This is solved by emitting the same event as when a row is clicked.

Generally, I am not very happy with the current design. In my feeling there are ways to configure the entity subrecord component that don't make much sense (at least for now):

- When listening to the `rowClick` event emitter, it is possible to still make the component navigate to another screen at the same time. At the moment we **only** listen to this event emitter in combination with `clickMode="none"` and I don't see a use case where this would be different.
- When setting `clickMode` to `navigate`, then this would also happen when clicking the plus button. This does not make sense as the entity created with the `newRecordFactory` has not been saved yet and therefore can't be navigated to.

We currently only have the following scenarios:
- The outside component handles displaying of existing and new entities -> the subrecord sould only forward these events
- The subrecord should navigate to the clicked entity, a plus button is not visible
- The subrecord handles all clicks using the popup form

Therefore, I think the current way of configuring the entity subrecord component is not very suitable as it requires more complexity than necessary and also can lead to errors when wrongly configured.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
