### PR TITLE
Notify on incorrect email, automatically trim whitespaces

### DIFF
--- a/src/app/core/user/user-security/user-security.component.html
+++ b/src/app/core/user/user-security/user-security.component.html
@@ -80,6 +80,12 @@
       <mat-form-field>
         <mat-label i18n="label of email input">Email</mat-label>
         <input matInput type="text" formControlName="email">
+        <mat-error *ngIf="form.hasError('email', 'email')" i18n>
+          Please enter a valid email
+        </mat-error>
+        <mat-error *ngIf="form.hasError('required', 'email')" i18n>
+          This field is required
+        </mat-error>
       </mat-form-field>
     </div>
 

--- a/src/app/core/user/user-security/user-security.component.html
+++ b/src/app/core/user/user-security/user-security.component.html
@@ -73,6 +73,9 @@
       <mat-form-field>
         <mat-label i18n="label of username input">Username</mat-label>
         <input matInput type="text" formControlName="username">
+        <mat-error *ngIf="form.hasError('required', 'username')" i18n>
+          This field is required
+        </mat-error>
       </mat-form-field>
     </div>
 

--- a/src/app/core/user/user-security/user-security.component.spec.ts
+++ b/src/app/core/user/user-security/user-security.component.spec.ts
@@ -181,6 +181,18 @@ describe("UserSecurityComponent", () => {
     flush();
   }));
 
+  it("Automatically trims whitespaces on the email input", fakeAsync(() => {
+    initComponent();
+
+    component.form.get("email").setValue("some_copied_email@mail.com  ");
+    tick();
+
+    expect(component.form.errors).toBeNull();
+    expect(component.form.get("email")).toHaveValue(
+      "some_copied_email@mail.com"
+    );
+  }));
+
   function initComponent(keycloakResult = of(keycloakUser)) {
     mockHttp.get.and.returnValue(keycloakResult);
     component.onInitFromDynamicConfig({ entity: user });

--- a/src/app/core/user/user-security/user-security.component.ts
+++ b/src/app/core/user/user-security/user-security.component.ts
@@ -47,6 +47,12 @@ export class UserSecurityComponent implements OnInitDynamicComponent {
     ) {
       this.userIsPermitted = true;
     }
+    // automatically skip trailing and leading whitespaces when the form changes
+    this.form.valueChanges.subscribe((next) => {
+      if (next.email.startsWith(" ") || next.email.endsWith(" ")) {
+        this.form.get("email").setValue(next.email.trim());
+      }
+    });
     if (authService instanceof KeycloakAuthService) {
       this.keycloak = authService;
       this.keycloak


### PR DESCRIPTION
see issue: #1626 

### Visible/Frontend Changes
- [x] An error will be shown when the entered email is not valid or when the field is empty
- [x] The email field will automatically be trimmed

The current implementation is quite 'aggressive' in that it doesn't even allow a user to enter leading or trailing whitespaces. I think that this is fine since there is no valid email that starts or ends with a whitespace.
