### PR TITLE
added static references to all database entities

### DIFF
--- a/src/app/child-dev-project/attendance/attendance.module.ts
+++ b/src/app/child-dev-project/attendance/attendance.module.ts
@@ -18,9 +18,13 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../../dynamic-components";
 import { attendanceComponents } from "./attendance-components";
+import { RecurringActivity } from "./model/recurring-activity";
+import { EventNote } from "./model/event-note";
 
 @NgModule({})
 export class AttendanceModule {
+  static databaseEntities = [RecurringActivity, EventNote];
+
   constructor(components: ComponentRegistry) {
     components.addAll(attendanceComponents);
   }

--- a/src/app/child-dev-project/children/children.module.ts
+++ b/src/app/child-dev-project/children/children.module.ts
@@ -20,9 +20,22 @@ import { EntitySchemaService } from "../../core/entity/schema/entity-schema.serv
 import { PhotoDatatype } from "./child-photo-service/datatype-photo";
 import { ComponentRegistry } from "../../dynamic-components";
 import { childrenComponents } from "./children-components";
+import { Aser } from "./aser/model/aser";
+import { EducationalMaterial } from "./educational-material/model/educational-material";
+import { HealthCheck } from "./health-checkup/model/health-check";
+import { Child } from "./model/child";
+import { ChildSchoolRelation } from "./model/childSchoolRelation";
 
 @NgModule({})
 export class ChildrenModule {
+  static databaseEntities = [
+    Aser,
+    EducationalMaterial,
+    HealthCheck,
+    Child,
+    ChildSchoolRelation,
+  ];
+
   constructor(
     entitySchemaService: EntitySchemaService,
     components: ComponentRegistry

--- a/src/app/child-dev-project/notes/notes.module.ts
+++ b/src/app/child-dev-project/notes/notes.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../../dynamic-components";
 import { notesComponents } from "./notes-components";
+import { Note } from "./model/note";
 
 @NgModule({})
 export class NotesModule {
+  static databaseEntities = [Note];
+
   constructor(components: ComponentRegistry) {
     components.addAll(notesComponents);
   }

--- a/src/app/child-dev-project/schools/schools.module.ts
+++ b/src/app/child-dev-project/schools/schools.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../../dynamic-components";
 import { schoolsComponents } from "./schools-components";
+import { School } from "./model/school";
 
 @NgModule({})
 export class SchoolsModule {
+  static databaseEntities = [School];
+
   constructor(components: ComponentRegistry) {
     components.addAll(schoolsComponents);
   }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,9 +1,13 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../dynamic-components";
 import { coreComponents } from "./core-components";
+import { User } from "./user/user";
+import { Config } from "./config/config";
 
 @NgModule({})
 export class CoreModule {
+  static databaseEntities = [User, Config];
+
   constructor(components: ComponentRegistry) {
     components.addAll(coreComponents);
   }

--- a/src/app/features/historical-data/historical-data.module.ts
+++ b/src/app/features/historical-data/historical-data.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../../dynamic-components";
 import { historicalDataComponents } from "./historical-data-components";
+import { HistoricalEntityData } from "./model/historical-entity-data";
 
 @NgModule({})
 export class HistoricalDataModule {
+  static databaseEntities = [HistoricalEntityData];
+
   constructor(components: ComponentRegistry) {
     components.addAll(historicalDataComponents);
   }

--- a/src/app/features/progress-dashboard-widget/progress-dashboard-widget.module.ts
+++ b/src/app/features/progress-dashboard-widget/progress-dashboard-widget.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from "@angular/core";
 import { ComponentRegistry } from "../../dynamic-components";
 import { progressDashboardWidgetComponents } from "./progress-dashboard-widget-components";
+import { ProgressDashboardConfig } from "./progress-dashboard/progress-dashboard-config";
 
 @NgModule({})
 export class ProgressDashboardWidgetModule {
+  static databaseEntities = [ProgressDashboardConfig];
+
   constructor(components: ComponentRegistry) {
     components.addAll(progressDashboardWidgetComponents);
   }


### PR DESCRIPTION
see issue: #1634 
As mentioned in #1635, a simple callback for newly registered entities is not sufficient as entities can also be used without a static reference in the code.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Each module has a static map with database entities
