### PR TITLE
fix(demo): demo data is only created after login

### DIFF
--- a/e2e/integration/RecordingAttendanceOfChild.cy.ts
+++ b/e2e/integration/RecordingAttendanceOfChild.cy.ts
@@ -22,7 +22,7 @@ describe("Scenario: Recording attendance of a child - E2E test", function () {
     cy.get('[placeholder="Search"]')
       .focus()
       .type(this.childName)
-      .wait(500)
+      .wait(1500)
       .type("{downArrow}")
       .type("{enter}");
     cy.get("#mat-tab-label-0-2").click();

--- a/src/app/core/demo-data/demo-data-initializer.service.spec.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.spec.ts
@@ -83,7 +83,7 @@ describe("DemoDataInitializerService", () => {
     );
   });
 
-  it("it should publish the demo data after loging in the default user", fakeAsync(() => {
+  it("it should publish the demo data after logging in the default user", fakeAsync(() => {
     service.run();
 
     expect(mockSessionService.login).toHaveBeenCalled();
@@ -111,17 +111,6 @@ describe("DemoDataInitializerService", () => {
     tick();
 
     expect(closeSpy).toHaveBeenCalled();
-  }));
-
-  it("should initialize the database before publishing", fakeAsync(() => {
-    const database = TestBed.inject(Database) as PouchDatabase;
-    expect(database.getPouchDB()).toBeUndefined();
-
-    service.run();
-    tick();
-
-    expect(database.getPouchDB()).toBeDefined();
-    expect(database.getPouchDB().name).toBe(demoUserDBName);
   }));
 
   it("should sync with existing demo data when another user logs in", fakeAsync(() => {

--- a/src/app/core/demo-data/demo-data-initializer.service.spec.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.spec.ts
@@ -83,18 +83,19 @@ describe("DemoDataInitializerService", () => {
     );
   });
 
-  it("it should login the default user after publishing the demo data", fakeAsync(() => {
+  it("it should publish the demo data after loging in the default user", fakeAsync(() => {
     service.run();
 
-    expect(mockDemoDataService.publishDemoData).toHaveBeenCalled();
-    expect(mockSessionService.login).not.toHaveBeenCalled();
-
-    tick();
-
+    expect(mockSessionService.login).toHaveBeenCalled();
     expect(mockSessionService.login).toHaveBeenCalledWith(
       DemoUserGeneratorService.DEFAULT_USERNAME,
       DemoUserGeneratorService.DEFAULT_PASSWORD
     );
+    expect(mockDemoDataService.publishDemoData).not.toHaveBeenCalled();
+
+    tick();
+
+    expect(mockDemoDataService.publishDemoData).toHaveBeenCalled();
   }));
 
   it("should show a dialog while generating demo data", fakeAsync(() => {
@@ -112,15 +113,16 @@ describe("DemoDataInitializerService", () => {
     expect(closeSpy).toHaveBeenCalled();
   }));
 
-  it("should initialize the database before publishing", () => {
+  it("should initialize the database before publishing", fakeAsync(() => {
     const database = TestBed.inject(Database) as PouchDatabase;
     expect(database.getPouchDB()).toBeUndefined();
 
     service.run();
+    tick();
 
     expect(database.getPouchDB()).toBeDefined();
     expect(database.getPouchDB().name).toBe(demoUserDBName);
-  });
+  }));
 
   it("should sync with existing demo data when another user logs in", fakeAsync(() => {
     service.run();

--- a/src/app/core/demo-data/demo-data-initializer.service.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.ts
@@ -54,7 +54,6 @@ export class DemoDataInitializerService {
       DemoUserGeneratorService.DEFAULT_PASSWORD
     );
 
-    this.initializeDefaultDatabase();
     await this.demoDataService.publishDemoData();
 
     dialogRef.close();
@@ -121,15 +120,6 @@ export class DemoDataInitializerService {
     if (this.liveSyncHandle) {
       this.liveSyncHandle.cancel();
       this.liveSyncHandle = undefined;
-    }
-  }
-
-  private initializeDefaultDatabase() {
-    const dbName = `${DemoUserGeneratorService.DEFAULT_USERNAME}-${AppSettings.DB_NAME}`;
-    if (environment.session_type === SessionType.mock) {
-      this.pouchDatabase.initInMemoryDB(dbName);
-    } else {
-      this.pouchDatabase.initIndexedDB(dbName);
     }
   }
 }

--- a/src/app/core/demo-data/demo-data-initializer.service.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.ts
@@ -49,15 +49,16 @@ export class DemoDataInitializerService {
     }
     this.registerDemoUsers();
 
+    await this.localSession.login(
+      DemoUserGeneratorService.DEFAULT_USERNAME,
+      DemoUserGeneratorService.DEFAULT_PASSWORD
+    );
+
     this.initializeDefaultDatabase();
     await this.demoDataService.publishDemoData();
 
     dialogRef.close();
 
-    await this.localSession.login(
-      DemoUserGeneratorService.DEFAULT_USERNAME,
-      DemoUserGeneratorService.DEFAULT_PASSWORD
-    );
     this.syncDatabaseOnUserChange();
   }
 

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -57,9 +57,9 @@ export class AbilityService {
     const userRules = this.getRulesForUser(rules);
     if (userRules.length === 0 || userRules.length === rules.default?.length) {
       // No rules or only default rules defined
-      const { name, roles } = this.sessionService.getCurrentUser();
+      const user = this.sessionService.getCurrentUser();
       this.logger.warn(
-        `no rules found for user "${name}" with roles "${roles}"`
+        `no rules found for user "${user?.name}" with roles "${user?.roles}"`
       );
     }
     this.updateAbilityWithRules(userRules);


### PR DESCRIPTION
Because the database is initialised before the user is logged in, the ability service currently initialises the permissions too early. This has been changed, now the user is first logged in and then the database initialised and demo data published.
Also an error is fixed which happens if no rules are found for a user and no user is logged in. This can happen e.g. when there is not public rules.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
