### PR TITLE
fix: removed not yet implemented date filters for todos

### DIFF
--- a/src/app/core/config/config-fix.ts
+++ b/src/app/core/config/config-fix.ts
@@ -1138,10 +1138,7 @@ export const defaultJsonConfig = {
         {
           "id": "due-status",
           "type": "prebuilt"
-        },
-        { "id": "deadline" },
-        { "id": "deadline" },
-        { "id": "startDate" }
+        }
       ]
     }
   }


### PR DESCRIPTION
Currently, the demo setup is showing errors, this should only be adde once the default date range filters are available, see #1448 
### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
