### PR TITLE
fix: buttons in sidenav take up full width

### DIFF
--- a/src/app/core/ui/ui/ui.component.html
+++ b/src/app/core/ui/ui/ui.component.html
@@ -80,13 +80,13 @@
             mat-button
             routerLink="user-account"
             i18n="Navigate to user profile page"
-            class="footer-cell"
+            class="footer-cell width-1-2"
           >
             <fa-icon icon="user"></fa-icon>
             Profile
           </button>
 
-          <button mat-button (click)="logout()" i18n="Sign out of the app" class="footer-cell">
+          <button mat-button (click)="logout()" i18n="Sign out of the app" class="footer-cell width-1-2">
             <fa-icon icon="sign-out-alt"></fa-icon>
             Sign out
           </button>

--- a/src/app/core/ui/ui/ui.component.scss
+++ b/src/app/core/ui/ui/ui.component.scss
@@ -113,6 +113,7 @@ mat-sidenav-container {
   display: flex;
   place-content: center;
   place-items: center;
+  min-width: fit-content;
 
   &:not(:last-child) {
     border-right: solid 1px rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
see issue: #1676 

### Visible/Frontend Changes
- [x] Buttons at least take up enough space to not wrap
- [x] If more space is available they take up the space evenly

### Architectural/Backend Changes
--
