### PR TITLE
fix: better automatic resolution of remote changes while editing forms

### DIFF
--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.spec.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.spec.ts
@@ -7,7 +7,7 @@ import { EntityMapperService } from "../../../entity/entity-mapper.service";
 import { ConfirmationDialogService } from "../../../confirmation-dialog/confirmation-dialog.service";
 import { EntityFormService } from "../entity-form.service";
 
-fdescribe("EntityFormComponent", () => {
+describe("EntityFormComponent", () => {
   let component: EntityFormComponent<Child>;
   let fixture: ComponentFixture<EntityFormComponent<Child>>;
 
@@ -83,7 +83,7 @@ fdescribe("EntityFormComponent", () => {
     );
   });
 
-  fit("should overwrite without popup for changes affecting untouched fields", async () => {
+  it("should overwrite without popup for changes affecting untouched fields", async () => {
     const originalEntity = { projectNumber: "p1" };
     const formValues = { projectNumber: "p2" };
     const remoteValues = {
@@ -119,10 +119,7 @@ fdescribe("EntityFormComponent", () => {
       component.form.get(c).markAsDirty();
     }
     const updatedChild = new Child(component.entity.getId());
-    for (const c in remoteChanges) {
-      console.log("c", c, remoteChanges[c]);
-      updatedChild[c] = remoteChanges[c];
-    }
+    Object.assign(updatedChild, remoteChanges);
 
     const entityMapper = TestBed.inject(EntityMapperService);
     await entityMapper.save(updatedChild);

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -88,8 +88,10 @@ export class EntityFormComponent<T extends Entity = Entity>
   }
 
   private async applyChanges(entity: T) {
+    console.log("apply", entity);
     if (this.formIsUpToDate(entity)) {
       // this is the component that currently saves the values -> no need to apply changes.
+      Object.assign(this.entity, entity as any);
       return;
     }
     if (
@@ -101,6 +103,7 @@ export class EntityFormComponent<T extends Entity = Entity>
     ) {
       Object.assign(this.initialFormValues, entity);
       this.form.patchValue(entity as any);
+      Object.assign(this.entity, entity as any);
     }
   }
 
@@ -122,6 +125,7 @@ export class EntityFormComponent<T extends Entity = Entity>
         // keep our pending form field changes
         delete updatedEntity[key];
       } else {
+        console.log(key, updatedEntity[key], this.initialFormValues[key]);
         // dirty form field has conflicting change
         return false;
       }


### PR DESCRIPTION
one test still fails - I have no clue why the projectNumber is not coming in from the updatedEntity event but instead shows as undefined ...