### PR TITLE
fix: memory leaks across app due to unsubscribed subscriptions

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -4,6 +4,8 @@ import {
   OnInit,
   Output,
   ViewChild,
+  OnDestroy,
+  HostListener,
 } from "@angular/core";
 import { AttendanceService } from "../../attendance.service";
 import { Note } from "../../../notes/model/note";
@@ -28,6 +30,9 @@ import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { ActivityCardComponent } from "../../activity-card/activity-card.component";
 import { MatButtonModule } from "@angular/material/button";
 
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
+
 @Component({
   selector: "app-roll-call-setup",
   templateUrl: "./roll-call-setup.component.html",
@@ -47,7 +52,8 @@ import { MatButtonModule } from "@angular/material/button";
   ],
   standalone: true,
 })
-export class RollCallSetupComponent implements OnInit {
+export class RollCallSetupComponent implements OnInit, OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   date = new Date();
 
   existingEvents: NoteForActivitySetup[] = [];
@@ -188,7 +194,7 @@ export class RollCallSetupComponent implements OnInit {
 
     this.formDialog
       .openDialog(NoteDetailsComponent, newNote)
-      .afterClosed()
+      .afterClosed().pipe(takeUntil(this.destroy$))
       .subscribe((createdNote: Note) => {
         if (createdNote) {
           this.existingEvents.push(createdNote);
@@ -210,6 +216,12 @@ export class RollCallSetupComponent implements OnInit {
         AlertDisplay.TEMPORARY
       );
     }
+  }
+
+  @HostListener('unloaded')
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }
 

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild } from "@angular/core";
+import { Component, Input, ViewChild, OnDestroy, HostListener } from "@angular/core";
 import { Note } from "../model/note";
 import { ShowsEntity } from "../../../core/form-dialog/shows-entity.interface";
 import { EntityConstructor } from "../../../core/entity/model/entity";
@@ -30,6 +30,9 @@ import { EntitySelectComponent } from "../../../core/entity-components/entity-se
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { ChildMeetingNoteAttendanceComponent } from "./child-meeting-attendance/child-meeting-note-attendance.component";
 
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
+
 /**
  * Component responsible for displaying the Note creation/view window
  */
@@ -59,7 +62,8 @@ import { ChildMeetingNoteAttendanceComponent } from "./child-meeting-attendance/
   ],
   standalone: true,
 })
-export class NoteDetailsComponent implements ShowsEntity<Note> {
+export class NoteDetailsComponent implements ShowsEntity<Note>, OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   @Input() entity: Note;
   @ViewChild("dialogForm", { static: true })
   formDialogWrapper: FormDialogWrapperComponent<Note>;
@@ -99,7 +103,7 @@ export class NoteDetailsComponent implements ShowsEntity<Note> {
       config: EntityListConfig;
     }>("view:note").config.exportConfig;
     this.screenWidthObserver
-      .platform()
+      .platform().pipe(takeUntil(this.destroy$))
       .subscribe((isDesktop) => (this.mobile = !isDesktop));
   }
 
@@ -115,5 +119,11 @@ export class NoteDetailsComponent implements ShowsEntity<Note> {
 
   private getPlaceholder(label: string): string {
     return $localize`:Placeholder for input to add entities|context Add User(s):Add ${label}`;
+  }
+
+  @HostListener('unloaded')
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }

--- a/src/app/core/common-components/template-tooltip/template-tooltip.directive.ts
+++ b/src/app/core/common-components/template-tooltip/template-tooltip.directive.ts
@@ -15,6 +15,9 @@ import {
 import { ComponentPortal } from "@angular/cdk/portal";
 import { TemplateTooltipComponent } from "./template-tooltip.component";
 
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
+
 /**
  * A directive that can be used to render a custom tooltip that may contain HTML code.
  * When a tooltip is only a string, the {@code MatTooltip} should be used instead.
@@ -36,6 +39,7 @@ import { TemplateTooltipComponent } from "./template-tooltip.component";
   standalone: true,
 })
 export class TemplateTooltipDirective implements OnInit, OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   /**
    * Whether to disable the tooltip, so it won't ever be shown
    */
@@ -106,6 +110,8 @@ export class TemplateTooltipDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.destroy$.next(true);
+    this.destroy$.complete();
     this.hide();
   }
 
@@ -148,8 +154,8 @@ export class TemplateTooltipDirective implements OnInit, OnDestroy {
           new ComponentPortal(TemplateTooltipComponent)
         );
         tooltipRef.instance.contentTemplate = this.contentTemplate;
-        tooltipRef.instance.hide.subscribe(() => this.hide());
-        tooltipRef.instance.show.subscribe(() => this.show());
+        tooltipRef.instance.hide.pipe(takeUntil(this.destroy$)).subscribe(() => this.hide());
+        tooltipRef.instance.show.pipe(takeUntil(this.destroy$)).subscribe(() => this.show());
       }
     }, this.delayShow);
   }

--- a/src/app/core/session/auth/keycloak/password-reset/password-reset.component.ts
+++ b/src/app/core/session/auth/keycloak/password-reset/password-reset.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy, HostListener } from "@angular/core";
 import { AuthService } from "../../auth.service";
 import { KeycloakAuthService } from "../keycloak-auth.service";
 import { FormControl, ReactiveFormsModule, Validators } from "@angular/forms";
@@ -8,6 +8,9 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { Angulartics2Module } from "angulartics2";
+
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
 
 @Component({
   selector: "app-password-reset",
@@ -22,7 +25,8 @@ import { Angulartics2Module } from "angulartics2";
   ],
   standalone: true
 })
-export class PasswordResetComponent {
+export class PasswordResetComponent implements OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   keycloakAuth: KeycloakAuthService;
   passwordResetActive = false;
   email = new FormControl("", [Validators.required, Validators.email]);
@@ -42,7 +46,7 @@ export class PasswordResetComponent {
       return;
     }
 
-    this.keycloakAuth.forgotPassword(this.email.value).subscribe({
+    this.keycloakAuth.forgotPassword(this.email.value).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.snackbar.open(
           `Password reset email sent to ${this.email.value}`,
@@ -53,5 +57,11 @@ export class PasswordResetComponent {
       },
       error: (err) => this.email.setErrors({ notFound: err.error.message }),
     });
+  }
+
+  @HostListener('unloaded')
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of ndb-core, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some subscriptions causing the memory to leak (screenshots below).

[before]
<img width="1109" alt="Screen Shot 2023-02-04 at 10 39 38 PM" src="https://user-images.githubusercontent.com/56495631/216778811-effd1d2e-256f-4245-bac9-eff7c3a66a31.png">
<br />
Hence we added the fix by unsubscribing the subscriptions in destructors, and you can see the heap size and # of leaks reducing noticeably:
<br />
<img width="995" alt="Screen Shot-after-subscription-fix" src="https://user-images.githubusercontent.com/56495631/216779434-6f863be0-07f4-4365-9128-99236166718b.png">

Note: Host listener is used to ensure that ngOnDestroy is called not only when the class destroy, but also when the page refreshes, tab or browser closes or the user navigates away from the page[1]

We ran the test suite before and after the patches and it executed 1031 of 1038 (skipped 7) successfully.
We also ensured all files pass linting after the fixes.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[ndb-core-scenario-memlab.txt](https://github.com/Aam-Digital/ndb-core/files/10609105/ndb-core-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.

References:
[1] https://wesleygrimes.com/angular/2019/03/29/making-upgrades-to-angular-ngondestroy.html