### PR TITLE
fix: enum service loads enums immediately

### DIFF
--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/db": {
-    "target": "https://dev.aam-digital.net/db",
+    "target": "https://qm.aam-digital.com/db",
     "secure": true,
     "logLevel": "debug",
     "changeOrigin": true,

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -69,12 +69,12 @@ describe("RollCallComponent", () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(RollCallComponent);
     component = fixture.componentInstance;
     component.eventEntity = Note.create(new Date());
     fixture.detectChanges();
-  });
+  }));
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   EventEmitter,
+  Injectable,
   Input,
   OnChanges,
   Output,
@@ -34,6 +35,7 @@ import Hammer from "hammerjs";
 import { ConfigurableEnumService } from "../../../../core/configurable-enum/configurable-enum.service";
 
 // Only allow horizontal swiping
+@Injectable()
 class HorizontalHammerConfig extends HammerGestureConfig {
   overrides = {
     swipe: { direction: Hammer.DIRECTION_HORIZONTAL },

--- a/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.spec.ts
+++ b/src/app/core/configurable-enum/configurable-enum-datatype/configurable-enum-datatype.spec.ts
@@ -51,7 +51,7 @@ describe("ConfigurableEnumDatatype", () => {
   let enumService: jasmine.SpyObj<ConfigurableEnumService>;
 
   beforeEach(waitForAsync(() => {
-    enumService = jasmine.createSpyObj(["getEnumValues"]);
+    enumService = jasmine.createSpyObj(["getEnumValues", "preLoadEnums"]);
     enumService.getEnumValues.and.returnValue(TEST_CONFIG);
 
     TestBed.configureTestingModule({

--- a/src/app/core/configurable-enum/configurable-enum-testing.ts
+++ b/src/app/core/configurable-enum/configurable-enum-testing.ts
@@ -35,8 +35,10 @@ export function createTestingConfigurableEnumService() {
     {
       receiveUpdates: () => NEVER,
       loadType: () => Promise.resolve(demoEnums),
+      save: () => Promise.resolve(),
     } as any,
     { can: () => true } as any
   );
+  service.preLoadEnums();
   return service;
 }

--- a/src/app/core/configurable-enum/configurable-enum-testing.ts
+++ b/src/app/core/configurable-enum/configurable-enum-testing.ts
@@ -6,7 +6,7 @@ import {
 } from "../../child-dev-project/children/aser/model/skill-levels";
 import { ConfigurableEnum } from "./configurable-enum";
 import { ConfigurableEnumService } from "./configurable-enum.service";
-import { NEVER, of } from "rxjs";
+import { NEVER } from "rxjs";
 import { defaultInteractionTypes } from "../config/default-config/default-interaction-types";
 import { warningLevels } from "../../child-dev-project/warning-levels";
 import { ratingAnswers } from "../../features/historical-data/model/rating-answers";

--- a/src/app/core/configurable-enum/configurable-enum-testing.ts
+++ b/src/app/core/configurable-enum/configurable-enum-testing.ts
@@ -36,7 +36,7 @@ export function createTestingConfigurableEnumService() {
       receiveUpdates: () => NEVER,
       loadType: () => Promise.resolve(demoEnums),
     } as any,
-    { configUpdates: of(undefined) } as any
+    { can: () => true } as any
   );
   return service;
 }

--- a/src/app/core/configurable-enum/configurable-enum.module.ts
+++ b/src/app/core/configurable-enum/configurable-enum.module.ts
@@ -53,5 +53,6 @@ export class ConfigurableEnumModule {
     this.entitySchemaService.registerSchemaDatatype(
       new ConfigurableEnumDatatype(enumService)
     );
+    enumService.preLoadEnums();
   }
 }

--- a/src/app/core/configurable-enum/configurable-enum.service.ts
+++ b/src/app/core/configurable-enum/configurable-enum.service.ts
@@ -1,25 +1,25 @@
 import { Injectable } from "@angular/core";
-import { ConfigService } from "../config/config.service";
 import { ConfigurableEnum } from "./configurable-enum";
 import { EntityMapperService } from "../entity/entity-mapper.service";
 import { ConfigurableEnumValue } from "./configurable-enum.interface";
 import { Entity } from "../entity/model/entity";
+import { EntityAbility } from "../permissions/ability/entity-ability";
 
 @Injectable({ providedIn: "root" })
 export class ConfigurableEnumService {
-  private enums = new Map<string, ConfigurableEnum>();
+  private enums: Map<string, ConfigurableEnum>;
 
   constructor(
     private entityMapper: EntityMapperService,
-    configService: ConfigService
+    private ability: EntityAbility
   ) {
-    configService.configUpdates.subscribe(() => this.preLoadEnums());
     this.entityMapper
       .receiveUpdates(ConfigurableEnum)
       .subscribe(({ entity }) => this.cacheEnum(entity));
   }
 
   async preLoadEnums() {
+    this.enums = new Map();
     const allEnums = await this.entityMapper.loadType(ConfigurableEnum);
     allEnums.forEach((entity) => this.cacheEnum(entity));
   }
@@ -35,8 +35,14 @@ export class ConfigurableEnumService {
   }
 
   getEnum(id: string): ConfigurableEnum {
+    if (!this.enums) {
+      return;
+    }
     const entityId = Entity.createPrefixedId(ConfigurableEnum.ENTITY_TYPE, id);
-    if (!this.enums.has(entityId)) {
+    if (
+      !this.enums.has(entityId) &&
+      this.ability.can("create", ConfigurableEnum)
+    ) {
       const newEnum = new ConfigurableEnum(id);
       this.cacheEnum(newEnum);
       this.entityMapper.save(newEnum);

--- a/src/app/core/configurable-enum/configurable-enum.service.ts
+++ b/src/app/core/configurable-enum/configurable-enum.service.ts
@@ -19,8 +19,8 @@ export class ConfigurableEnumService {
   }
 
   async preLoadEnums() {
-    this.enums = new Map();
     const allEnums = await this.entityMapper.loadType(ConfigurableEnum);
+    this.enums = new Map();
     allEnums.forEach((entity) => this.cacheEnum(entity));
   }
 

--- a/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.spec.ts
+++ b/src/app/core/configurable-enum/edit-configurable-enum/edit-configurable-enum.component.spec.ts
@@ -5,8 +5,6 @@ import { FormControl, FormGroup } from "@angular/forms";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
 import { Entity } from "../../entity/model/entity";
-import { ConfigurableEnumService } from "../configurable-enum.service";
-import { ConfigurableEnum } from "../configurable-enum";
 
 describe("EditConfigurableEnumComponent", () => {
   let component: EditConfigurableEnumComponent;
@@ -15,12 +13,6 @@ describe("EditConfigurableEnumComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditConfigurableEnumComponent, MockedTestingModule.withState()],
-      providers: [
-        {
-          provide: ConfigurableEnumService,
-          useValue: { getEnum: () => new ConfigurableEnum() },
-        },
-      ],
     }).compileComponents();
   });
 

--- a/src/app/core/configurable-enum/enum-dropdown/enum-dropdown.component.spec.ts
+++ b/src/app/core/configurable-enum/enum-dropdown/enum-dropdown.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { EnumDropdownComponent } from "./enum-dropdown.component";
 import { FormControl } from "@angular/forms";
 import { SimpleChange } from "@angular/core";
-import { ConfigurableEnumService } from "../configurable-enum.service";
 import { ConfigurableEnum } from "../configurable-enum";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { EntityMapperService } from "../../entity/entity-mapper.service";
@@ -18,13 +17,7 @@ describe("EnumDropdownComponent", () => {
     mockDialog = jasmine.createSpyObj(["open"]);
     await TestBed.configureTestingModule({
       imports: [EnumDropdownComponent, MockedTestingModule.withState()],
-      providers: [
-        {
-          provide: ConfigurableEnumService,
-          useValue: { getEnum: () => new ConfigurableEnum() },
-        },
-        { provide: MatDialog, useValue: mockDialog },
-      ],
+      providers: [{ provide: MatDialog, useValue: mockDialog }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EnumDropdownComponent);


### PR DESCRIPTION
see issue: #1694 
It seems like there was a problem because the enums were loaded too late.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] configurable enums are loaded immediately
