### PR TITLE
fix: failed remote login correctly logs-out user

### DIFF
--- a/src/app/core/session/auth/auth.interceptor.spec.ts
+++ b/src/app/core/session/auth/auth.interceptor.spec.ts
@@ -97,4 +97,24 @@ describe("AuthInterceptor", () => {
       },
     });
   });
+
+  it("should throw initial error auth attempt fails", (done) => {
+    const initialError = new HttpErrorResponse({
+      status: HttpStatusCode.Unauthorized,
+    });
+    const authError = new HttpErrorResponse({ status: 400 });
+    const handle = jasmine
+      .createSpy()
+      .and.returnValues(throwError(() => initialError));
+    mockAuthService.autoLogin.and.rejectWith(authError);
+
+    interceptor.intercept(mockRequest, { handle }).subscribe({
+      error: (res) => {
+        expect(res).toEqual(initialError);
+        expect(mockAuthService.autoLogin).toHaveBeenCalled();
+        expect(handle).toHaveBeenCalledTimes(1);
+        done();
+      },
+    });
+  });
 });

--- a/src/app/core/session/auth/auth.interceptor.ts
+++ b/src/app/core/session/auth/auth.interceptor.ts
@@ -43,6 +43,10 @@ export class AuthInterceptor implements HttpInterceptor {
       catchError((err: HttpErrorResponse) => {
         if (err.status === HttpStatusCode.Unauthorized && authEnabled) {
           return from(this.authService.autoLogin()).pipe(
+            catchError(() => {
+              // re-throw initial error
+              throw err;
+            }),
             concatMap(() => next.handle(this.getRequestWithAuth(request)))
           );
         } else {

--- a/src/app/core/session/session-service/synced-session.service.spec.ts
+++ b/src/app/core/session/session-service/synced-session.service.spec.ts
@@ -171,7 +171,7 @@ describe("SyncedSessionService", () => {
     // Initially the user is logged in
     expectAsync(result).toBeResolvedTo(LoginState.LOGGED_IN);
     // After remote session fails the user is logged out again
-    expect(sessionService.loginState.value).toBe(LoginState.LOGIN_FAILED);
+    expect(sessionService.loginState.value).toBe(LoginState.LOGGED_OUT);
     flush();
   }));
 


### PR DESCRIPTION
Currently, the case where the password is changed remotely and the user logs in with the old password, does **not** result in the user being logged out. This has been fixed. The user is now correctly logged out and the old password does not work anymore to log-in offline.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] Auth interceptor returns initial error if authentication fails
- [x] Synced session uses logout flow if remote login fails
