### PR TITLE
fix: reports only show actual participants of events

### DIFF
--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
@@ -27,10 +27,10 @@ describe("RollCallSetupComponent", () => {
     mockChildrenService = jasmine.createSpyObj(["queryActiveRelationsOf"]);
     mockChildrenService.queryActiveRelationsOf.and.resolveTo([]);
     mockAttendanceService = jasmine.createSpyObj([
-      "getEventsOnDate",
+      "getEventsWithUpdatedParticipants",
       "createEventForActivity",
     ]);
-    mockAttendanceService.getEventsOnDate.and.resolveTo([]);
+    mockAttendanceService.getEventsWithUpdatedParticipants.and.resolveTo([]);
 
     TestBed.configureTestingModule({
       imports: [RollCallSetupComponent, MockedTestingModule.withState()],

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -88,9 +88,8 @@ export class RollCallSetupComponent implements OnInit {
 
   private async initAvailableEvents() {
     this.isLoading = true;
-    this.existingEvents = await this.attendanceService.getEventsOnDate(
-      this.date
-    );
+    this.existingEvents =
+      await this.attendanceService.getEventsWithUpdatedParticipants(this.date);
     await this.loadActivities();
     this.sortEvents();
     this.filteredExistingEvents = this.existingEvents;

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -116,7 +116,9 @@ describe("AttendanceService", () => {
     testNoteWithSchool.category = meetingInteractionCategory;
     await entityMapper.save(testNoteWithSchool);
 
-    const actualEvents = await service.getEventsOnDate(new Date("2021-01-01"));
+    const actualEvents = await service.getEventsWithUpdatedParticipants(
+      new Date("2021-01-01")
+    );
     expect(actualEvents).toHaveSize(1);
     expect(actualEvents[0].children).toEqual(
       jasmine.arrayWithExactContents(["1", "2", "3"])

--- a/src/app/child-dev-project/attendance/attendance.service.spec.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.spec.ts
@@ -109,23 +109,22 @@ describe("AttendanceService", () => {
   it("gets events and loads additional participants from linked schools", async () => {
     const linkedSchoolId = "test_school";
     await createChildrenInSchool(linkedSchoolId, ["2", "3"]);
+    const date = new Date();
 
-    const testNoteWithSchool = Note.create(new Date("2021-01-01"));
+    const testNoteWithSchool = Note.create(date);
     testNoteWithSchool.children = ["1", "2"];
     testNoteWithSchool.schools = [linkedSchoolId];
     testNoteWithSchool.category = meetingInteractionCategory;
     await entityMapper.save(testNoteWithSchool);
 
-    const actualEvents = await service.getEventsWithUpdatedParticipants(
-      new Date("2021-01-01")
-    );
+    const actualEvents = await service.getEventsWithUpdatedParticipants(date);
     expect(actualEvents).toHaveSize(1);
     expect(actualEvents[0].children).toEqual(
       jasmine.arrayWithExactContents(["1", "2", "3"])
     );
   });
 
-  it("gets active participants and removes those explicitly excluded", async () => {
+  it("should create an event without the excluded participants", async () => {
     const linkedSchoolId = "test_school";
     await createChildrenInSchool(linkedSchoolId, ["excluded", "member"]);
 
@@ -134,10 +133,8 @@ describe("AttendanceService", () => {
     activity.excludedParticipants = ["excluded"];
     activity.participants = ["direct", "excluded"];
 
-    const actualParticipants = await service.getActiveParticipantsOfActivity(
-      activity
-    );
-    expect(actualParticipants).toEqual(
+    const event = await service.createEventForActivity(activity, new Date());
+    expect(event.children).toEqual(
       jasmine.arrayWithExactContents(["member", "direct"])
     );
   });
@@ -288,12 +285,14 @@ describe("AttendanceService", () => {
 
     const directlyAddedChild = new Child();
     activity.participants.push(directlyAddedChild.getId());
+    const date = new Date();
 
-    const event = await service.createEventForActivity(activity, new Date());
+    const event = await service.createEventForActivity(activity, date);
 
     expect(mockQueryRelationsOf).toHaveBeenCalledWith(
       "school",
-      linkedSchool.getId()
+      linkedSchool.getId(),
+      date
     );
     expect(event.children).toHaveSize(2);
     expect(event.children).toContain(directlyAddedChild.getId());

--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -106,16 +106,18 @@ export class AttendanceService {
       .then((notes) => notes.filter((n) => n.category.isMeeting));
 
     const allResults = await Promise.all([eventNotes, relevantNormalNotes]);
-    const existingEvents = allResults[0].concat(allResults[1]);
+    return allResults[0].concat(allResults[1]);
+  }
 
-    for (const event of existingEvents) {
+  async getEventsWithUpdatedParticipants(date: Date) {
+    const events = await this.getEventsOnDate(date, date);
+    for (const event of events) {
       const participants = await this.loadParticipantsOfGroups(event.schools);
       for (const newParticipant of participants) {
         event.addChild(newParticipant);
       }
     }
-
-    return existingEvents;
+    return events;
   }
 
   /**

--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -112,7 +112,10 @@ export class AttendanceService {
   async getEventsWithUpdatedParticipants(date: Date) {
     const events = await this.getEventsOnDate(date, date);
     for (const event of events) {
-      const participants = await this.loadParticipantsOfGroups(event.schools);
+      const participants = await this.loadParticipantsOfGroups(
+        event.schools,
+        date
+      );
       for (const newParticipant of participants) {
         event.addChild(newParticipant);
       }
@@ -249,18 +252,23 @@ export class AttendanceService {
     const instance = new EventNote();
     instance.date = date;
     instance.subject = activity.title;
-    instance.children = await this.getActiveParticipantsOfActivity(activity);
+    instance.children = await this.getActiveParticipantsOfActivity(
+      activity,
+      date
+    );
     instance.schools = activity.linkedGroups;
     instance.relatesTo = activity.getId(true);
     instance.category = activity.type;
     return instance;
   }
 
-  async getActiveParticipantsOfActivity(
-    activity: RecurringActivity
+  private async getActiveParticipantsOfActivity(
+    activity: RecurringActivity,
+    date: Date
   ): Promise<string[]> {
     const schoolParticipants = await this.loadParticipantsOfGroups(
-      activity.linkedGroups
+      activity.linkedGroups,
+      date
     );
 
     return [
@@ -271,19 +279,21 @@ export class AttendanceService {
   /**
    * Load all participants' ids for the given list of groups
    * @param linkedGroups
+   * @param date on which the participants should be part of the group
    */
   private async loadParticipantsOfGroups(
-    linkedGroups: string[]
+    linkedGroups: string[],
+    date: Date
   ): Promise<string[]> {
     const childIdPromises = linkedGroups.map((groupId) =>
       this.childrenService
-        .queryActiveRelationsOf("school", groupId)
+        .queryActiveRelationsOf("school", groupId, date)
         .then((relations) =>
           relations.map((r) => r.childId).filter((id) => !!id)
         )
     );
     const allParticipants = await Promise.all(childIdPromises);
     // flatten and remove duplicates
-    return Array.from(new Set([].concat.apply([], allParticipants)));
+    return Array.from(new Set([].concat(...allParticipants)));
   }
 }

--- a/src/app/child-dev-project/children/children.service.spec.ts
+++ b/src/app/child-dev-project/children/children.service.spec.ts
@@ -214,6 +214,22 @@ describe("ChildrenService", () => {
     expect(result).toEqual(activeRelations);
   });
 
+  it("should return active relations for a given date", async () => {
+    let relations = await service.queryActiveRelationsOf(
+      "school",
+      "1",
+      new Date("2010-01-01")
+    );
+    expect(relations).toHaveSize(1);
+
+    relations = await service.queryActiveRelationsOf(
+      "school",
+      "1",
+      new Date("2016-10-01")
+    );
+    expect(relations).toHaveSize(2);
+  });
+
   it("should return related notes", async () => {
     const c1 = new Child("c1");
     const c2 = new Child("c2");

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -100,10 +100,11 @@ export class ChildrenService {
 
   queryActiveRelationsOf(
     queryType: "child" | "school",
-    id: string
+    id: string,
+    date = new Date()
   ): Promise<ChildSchoolRelation[]> {
     return this.queryRelationsOf(queryType, id).then((relations) =>
-      relations.filter((rel) => rel.isActive)
+      relations.filter((rel) => rel.isActiveAt(date))
     );
   }
 


### PR DESCRIPTION
In our logic to load notes, we currently always also update the participants list with new people that joined the group. This is useful in the roll call setup where you might want to also record their attendance stats. In other places where we only report the attendance without the option to modify it, this is not very useful as it will just add empty information (e.g. reports, dashboard components). This functionality has now been split up into two functions, one just loading the notes and one where the new participants are also added.

Another problem that I discovered is that the active participants are added based on the active status of today, not for the actual day where e.g. the roll call is conducted. This means also participants that have a start date of today would then be included when doing a roll call yesterday. This has also been fixed.
### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
