### PR TITLE
fix: forms have better visibility on iPhone

### DIFF
--- a/e2e/integration/MarkingChildAsDropout.cy.ts
+++ b/e2e/integration/MarkingChildAsDropout.cy.ts
@@ -1,7 +1,8 @@
 describe("Scenario: Marking a child as dropout - E2E test", function () {
   before("GIVEN I am on the details page of a specific child", function () {
-    // go to the url with the Child
-    cy.visit("child/1");
+    // go to a child
+    cy.visit("child");
+    cy.get("tr").eq(2).click();
     // save the name of this Child to the variable
     cy.get(".mat-title > .remove-margin-bottom").invoke("text").as("childName");
   });
@@ -15,9 +16,7 @@ describe("Scenario: Marking a child as dropout - E2E test", function () {
     cy.get('[aria-label="Open calendar"]').filter(":visible").click();
     cy.get(".mat-calendar-body-active:visible").click();
     // click on button with the content "Save"
-    cy.get(".form-buttons-wrapper:visible", { timeout: 10000 })
-      .contains("button", "Save")
-      .click();
+    cy.get(".form-buttons-wrapper:visible").contains("button", "Save").click();
   });
 
   it("THEN I should not see this child in the list of all children at first", function () {

--- a/src/styles/resets/_mat-input.scss
+++ b/src/styles/resets/_mat-input.scss
@@ -1,12 +1,10 @@
 @use "@angular/material" as mat;
 
 /* display disabled form values in black for better readability as we disable forms by default */
-.mat-mdc-input-element:disabled {
+.mat-mdc-select-disabled .mat-mdc-select-value, .mat-mdc-input-element:disabled {
   color: mat.get-color-from-palette(mat.$light-theme-foreground-palette, text) !important;
-}
-
-.mat-mdc-select-disabled .mat-mdc-select-value {
-  color: mat.get-color-from-palette(mat.$light-theme-foreground-palette, text) !important;
+  -webkit-text-fill-color: black;
+  opacity: 1;
 }
 
 .mdc-text-field--filled {


### PR DESCRIPTION
On Safari and especially on iPhone, the disabled forms are a little transparent and not fully black.

### Visible/Frontend Changes
- [x] Disabled forms are better readable on iPhone and Safari
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
