### PR TITLE
Removed various unnecessary logs

### DIFF
--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -77,14 +77,6 @@ export class ConfigService {
   private async detectLegacyConfig(config: Config): Promise<Config> {
     // ugly but easy ... could use https://www.npmjs.com/package/jsonpath-plus in future
     const configString = JSON.stringify(config);
-    if (
-      configString.includes("EditEntityArray") ||
-      configString.includes("EditSingleEntity")
-    ) {
-      this.logger.warn(
-        "Legacy Config: EditEntityArray/EditSingleEntity found - you should use dataType instead"
-      );
-    }
 
     if (configString.includes("ImportantNotesComponent")) {
       this.logger.warn(

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
@@ -148,7 +148,9 @@ export class ListPaginatorComponent<E>
   private async ensureUserIsLoaded(): Promise<boolean> {
     if (!this.user) {
       const currentUser = this.sessionService.getCurrentUser();
-      this.user = await this.entityMapperService.load(User, currentUser.name);
+      this.user = await this.entityMapperService
+        .load(User, currentUser.name)
+        .catch(() => undefined);
     }
     return !!this.user;
   }

--- a/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/list-paginator/list-paginator.component.ts
@@ -148,13 +148,7 @@ export class ListPaginatorComponent<E>
   private async ensureUserIsLoaded(): Promise<boolean> {
     if (!this.user) {
       const currentUser = this.sessionService.getCurrentUser();
-      try {
-        this.user = await this.entityMapperService.load(User, currentUser.name);
-      } catch (e) {
-        this.loggingService.warn(
-          `Could not load user entity for ${currentUser.name}`
-        );
-      }
+      this.user = await this.entityMapperService.load(User, currentUser.name);
     }
     return !!this.user;
   }

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -55,7 +55,7 @@ export class AbilityService {
 
   private updateAbilityWithUserRules(rules: DatabaseRules): Promise<any> {
     const userRules = this.getRulesForUser(rules);
-    if (userRules.length === 0 || userRules.length === rules.default?.length) {
+    if (userRules.length === 0) {
       // No rules or only default rules defined
       const user = this.sessionService.getCurrentUser();
       this.logger.warn(


### PR DESCRIPTION
- Currently, a warning is logged if a user only has default rules. As this is often the expected behaviour, these warnings are turned off. Now a warning is only shown if a user has no rules at all.
- removed the warning for `EditSingleEntity` and `EditEntityArray` as this sometimes is also ok to be used
- removed warning if a user entity is not found. With the user management, it is not possible to create a user without a entity first besides the admin accounts. For the admin accounts this error is not necessary though. Therefore, I don't see this error to still be relevant.
