### PR TITLE
fix: missing queries don't throw errors

### DIFF
--- a/src/app/core/export/query.service.spec.ts
+++ b/src/app/core/export/query.service.spec.ts
@@ -621,7 +621,7 @@ describe("QueryService", () => {
   it("does not throw an error if no query is provided", () => {
     return expectAsync(
       service.queryData(undefined, new Date(), new Date())
-    ).toBeResolved();
+    ).toBeResolvedTo({});
   });
 
   async function createChild(

--- a/src/app/core/export/query.service.spec.ts
+++ b/src/app/core/export/query.service.spec.ts
@@ -618,6 +618,12 @@ describe("QueryService", () => {
     expect(result).toEqual([maleChild.gender]);
   });
 
+  it("does not throw an error if no query is provided", () => {
+    return expectAsync(
+      service.queryData(undefined, new Date(), new Date())
+    ).toBeResolved();
+  });
+
   async function createChild(
     gender: "M" | "F" = "F",
     religion?: "muslim" | "christian"

--- a/src/app/core/export/query.service.ts
+++ b/src/app/core/export/query.service.ts
@@ -167,7 +167,7 @@ export class QueryService {
     return this.queryStringMap
       .filter(([matcher]) =>
         // matches query string without any alphanumeric characters before or after (e.g. so Child does not match ChildSchoolRelation)
-        query.match(new RegExp(`(^|\\W)${matcher}(\\W|$)`))
+        query?.match(new RegExp(`(^|\\W)${matcher}(\\W|$)`))
       )
       .map(([_, entity]) => entity)
       .filter((entity) => {


### PR DESCRIPTION
It's possible to make a row without actually defining a query on it (e.g. to group further queries) this however currently throws error.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
