### PR TITLE
fix: state leaks in matching component

### DIFF
--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
@@ -13,6 +13,7 @@ import { BehaviorSubject, of } from "rxjs";
 import { FormFieldConfig } from "../../../core/entity-components/entity-form/entity-form/FormConfig";
 import { Coordinates } from "../../location/coordinates";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
+import { School } from "../../../child-dev-project/schools/model/school";
 
 describe("MatchingEntitiesComponent", () => {
   let component: MatchingEntitiesComponent;
@@ -389,6 +390,29 @@ describe("MatchingEntitiesComponent", () => {
     expect(component.mapVisible).toBeTrue();
 
     Child.schema.delete("address");
+  });
+
+  it("should not alter the config object", async () => {
+    const config: MatchingEntitiesConfig = {
+      columns: [
+        ["name", "name"],
+        ["projectNumber", "distance"],
+      ],
+      rightSide: { entityType: "School", columns: ["name", "distance"] },
+      leftSide: { entityType: "Child", columns: ["name", "distance"] },
+    };
+    Child.schema.set("address", { dataType: "location" });
+    School.schema.set("address", { dataType: "location" });
+
+    const configCopy = JSON.parse(JSON.stringify(config));
+    mockActivatedRoute.data = of({ config: configCopy });
+
+    await component.ngOnInit();
+
+    expect(configCopy).toEqual(config);
+
+    Child.schema.delete("address");
+    School.schema.delete("address");
   });
 });
 

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
@@ -145,10 +145,15 @@ export class MatchingEntitiesComponent
    * @private
    */
   private initConfig(config: MatchingEntitiesConfig, entity?: Entity) {
-    const defaultConfig = this.configService.getConfig<MatchingEntitiesConfig>(
-      MatchingEntitiesComponent.DEFAULT_CONFIG_KEY
+    const defaultConfig =
+      this.configService.getConfig<MatchingEntitiesConfig>(
+        MatchingEntitiesComponent.DEFAULT_CONFIG_KEY
+      ) ?? {};
+    config = Object.assign(
+      {},
+      JSON.parse(JSON.stringify(defaultConfig)),
+      JSON.parse(JSON.stringify(config))
     );
-    config = Object.assign({}, defaultConfig, config);
 
     this.columns = config.columns ?? this.columns;
     this.matchActionLabel = config.matchActionLabel ?? this.matchActionLabel;


### PR DESCRIPTION
The config of the matching component is currently leaking state as modifications happen directly on the config object and are therefore affecting visits of the same site in one session.
This has been fixed by making a deep copy using `JSON.parse` and `JSON.stringify`.

Can be reproduced by 

1. go to `/matching`
2. Select both entities with a distance
3. Navigate away and back to `/matching`
4. See that the distance form before is still shown in the tables and when the entity is selected. Also the distance is not updated when selecting different entities.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
