### PR TITLE
Better buttons

### DIFF
--- a/src/app/core/entity-components/entity-details/form/form.component.html
+++ b/src/app/core/entity-components/entity-details/form/form.component.html
@@ -2,6 +2,7 @@
   <button
     *ngIf="form?.enabled"
     mat-raised-button
+    color="accent"
     (click)="saveClicked()"
     i18n="Save button for forms"
   >
@@ -10,7 +11,7 @@
 
   <button
     *ngIf="form?.enabled"
-    mat-raised-button
+    mat-stroked-button
     (click)="cancelClicked()"
     i18n="Cancel button for forms"
   >

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
@@ -31,11 +31,20 @@
 <mat-dialog-actions>
   <button
     mat-raised-button
+    color="accent"
     (click)="save()"
     [disabled]="form.disabled"
     i18n="Save button for forms"
   >
     Save
+  </button>
+
+  <button
+    mat-stroked-button
+    mat-dialog-close
+    i18n="Generic cancel button"
+  >
+    Cancel
   </button>
 
   <button

--- a/src/app/core/form-dialog/form-dialog-wrapper/form-dialog-wrapper.component.html
+++ b/src/app/core/form-dialog/form-dialog-wrapper/form-dialog-wrapper.component.html
@@ -8,7 +8,8 @@
 
 <mat-dialog-actions *ngIf="!readonly && ('update' | able: entity)">
   <button
-    mat-stroked-button
+    mat-raised-button
+    color="accent"
     [disabled]="!contentForm.form.dirty"
     (click)="save()"
     angulartics2On="click"

--- a/src/app/core/user/user-security/user-security.component.html
+++ b/src/app/core/user/user-security/user-security.component.html
@@ -22,7 +22,7 @@
   <div class="padding-bottom-small flex-row gap-small align-self-end flex-wrap" *ngIf="user">
     <button
       *ngIf="editing && user?.enabled"
-      mat-raised-button
+      mat-stroked-button
       color="warn"
       (click)="toggleAccount(false)"
       matTooltip="User will not be able to login again, no information will be lost"
@@ -33,6 +33,7 @@
     <button
       *ngIf="editing && !user?.enabled"
       mat-raised-button
+      color="accent"
       (click)="toggleAccount(true)"
       matTooltip="User can login again with the previously used credentials"
       i18n="button to enable a user"
@@ -42,6 +43,7 @@
     <button
       *ngIf="editing && user?.enabled"
       mat-raised-button
+      color="accent"
       class="action-button"
       (click)="updateAccount()"
       i18n="Save button for forms"
@@ -50,7 +52,7 @@
     </button>
     <button
       *ngIf="editing"
-      mat-raised-button
+      mat-stroked-button
       class="action-button"
       (click)="disableForm()"
       i18n="Cancel button for forms"

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.html
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.html
@@ -31,7 +31,7 @@
 </div>
 
 <div class="margin-bottom-large flex-column gap-small">
-  <button mat-stroked-button color="accent" style="width: 100%"
+  <button mat-raised-button color="accent" style="width: 100%"
           (click)="createMatch()"
           [disabled]="!sideDetails?.[0].selected || !sideDetails?.[1].selected || lockedMatching">
     {{ matchActionLabel }}

--- a/src/app/features/progress-dashboard-widget/edit-progress-dashboard/edit-progress-dashboard.component.html
+++ b/src/app/features/progress-dashboard-widget/edit-progress-dashboard/edit-progress-dashboard.component.html
@@ -36,7 +36,7 @@
       </mat-error>
     </mat-form-field>
 
-    <button mat-button color="accent" (click)="removePart(index)">
+    <button mat-icon-button color="accent" (click)="removePart(index)">
       <fa-icon
         class="button-icon"
         aria-label="remove element"
@@ -110,7 +110,8 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <button
-    mat-stroked-button
+    mat-raised-button
+    color="accent"
     [mat-dialog-close]="outputData.value"
     [disabled]="outputData.invalid"
   >
@@ -119,7 +120,7 @@
       [matTooltipDisabled]="outputData.valid"
       i18n-matTooltip="Shown when there are errors that prevent saving"
       i18n
-      >Save</span
+    >Save</span
     >
   </button>
   <button mat-stroked-button mat-dialog-close i18n>Cancel</button>

--- a/src/app/features/todos/todo-details/todo-details.component.html
+++ b/src/app/features/todos/todo-details/todo-details.component.html
@@ -32,11 +32,11 @@
 
 <mat-dialog-actions class="gap-regular">
   <!-- TODO: move these form actions into a reusable component (taking the entity + form as input)? -->
-  <button mat-raised-button (click)="save()" i18n="Save button for forms">
+  <button mat-raised-button color="accent" (click)="save()" i18n="Save button for forms">
     Save
   </button>
 
-  <button mat-raised-button i18n="Cancel button for forms" mat-dialog-close="">
+  <button mat-stroked-button i18n="Cancel button for forms" mat-dialog-close="">
     Cancel
   </button>
 


### PR DESCRIPTION
see issue: #1743 

These changes should generally highlight the action that is most likely to be used (saving) to make this more visible and also make the general styling of the save and cancel buttons more common across all screens.

### Visible/Frontend Changes
- [x] Matching button is highlighted (raised)
- [x] Save buttons are always highlighted (blue and raised)
- [x] Cancel buttons are less visible (stroked) but always at same place

### Architectural/Backend Changes
- [x] 
- [ ] 
