### PR TITLE
fix: roll call setup shows all activities if none match the current user

### DIFF
--- a/e2e/integration/MarkingChildAsDropout.cy.ts
+++ b/e2e/integration/MarkingChildAsDropout.cy.ts
@@ -13,11 +13,10 @@ describe("Scenario: Marking a child as dropout - E2E test", function () {
     // click on button with the content "Edit" in Dropout menu.
     cy.get(".form-buttons-wrapper:visible").contains("button", "Edit").click();
     // select today as the dropout date (which is initially marked as active)
-    cy.get('[aria-label="Open calendar"]')
-      .filter(":visible")
-      .click()
-      .get(".mat-calendar-body-active:visible")
-      .click();
+    cy.get('[aria-label="Open calendar"]').filter(":visible").click();
+    // without wait, sometimes the panel is still open after clicking
+    cy.wait(100);
+    cy.get(".mat-calendar-body-active:visible").click();
     // click on button with the content "Save"
     cy.get(".form-buttons-wrapper:visible").contains("button", "Save").click();
   });

--- a/e2e/integration/MarkingChildAsDropout.cy.ts
+++ b/e2e/integration/MarkingChildAsDropout.cy.ts
@@ -13,8 +13,11 @@ describe("Scenario: Marking a child as dropout - E2E test", function () {
     // click on button with the content "Edit" in Dropout menu.
     cy.get(".form-buttons-wrapper:visible").contains("button", "Edit").click();
     // select today as the dropout date (which is initially marked as active)
-    cy.get('[aria-label="Open calendar"]').filter(":visible").click();
-    cy.get(".mat-calendar-body-active:visible").click();
+    cy.get('[aria-label="Open calendar"]')
+      .filter(":visible")
+      .click()
+      .get(".mat-calendar-body-active:visible")
+      .click();
     // click on button with the content "Save"
     cy.get(".form-buttons-wrapper:visible").contains("button", "Save").click();
   });

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.spec.ts
@@ -31,6 +31,7 @@ describe("RollCallSetupComponent", () => {
       "createEventForActivity",
     ]);
     mockAttendanceService.getEventsWithUpdatedParticipants.and.resolveTo([]);
+    mockAttendanceService.createEventForActivity.and.resolveTo(new EventNote());
 
     TestBed.configureTestingModule({
       imports: [RollCallSetupComponent, MockedTestingModule.withState()],
@@ -80,5 +81,18 @@ describe("RollCallSetupComponent", () => {
     flush();
 
     expect(component.existingEvents).toHaveSize(1);
+  }));
+
+  it("should show all activities if none are assigned to the current user or unassigned", fakeAsync(() => {
+    const activity = new RecurringActivity();
+    activity.assignedTo = ["otherUser"];
+    const entityMapper = TestBed.inject(EntityMapperService);
+    spyOn(entityMapper, "loadType").and.resolveTo([activity]);
+
+    component.ngOnInit();
+    flush();
+
+    expect(component.filteredExistingEvents).toHaveSize(1);
+    expect(component.showingAll).toBeTrue();
   }));
 });

--- a/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
+++ b/src/app/child-dev-project/attendance/add-day-attendance/roll-call-setup/roll-call-setup.component.ts
@@ -112,6 +112,10 @@ export class RollCallSetupComponent implements OnInit {
           (a) => a.assignedTo.length === 0
         );
       }
+      if (this.visibleActivities.length === 0) {
+        this.visibleActivities = this.allActivities;
+        this.showingAll = true;
+      }
     }
 
     const newEvents = await Promise.all(


### PR DESCRIPTION
see issue: #1745 

### Visible/Frontend Changes
- [x] If no activity matches the current user and also no activity is unassigned, then all activities are shown

### Architectural/Backend Changes
- [x] 
- [ ] 
