### PR TITLE
fix: add button to navigate to details page if available

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.html
@@ -37,9 +37,19 @@
   >
     Save
   </button>
+  <button
+    *ngIf="detailsRoute"
+    mat-raised-button
+    [routerLink]="detailsRoute"
+    mat-dialog-close
+    [disabled]="form.disabled"
+    i18n="Button to navigate to details page of entity"
+  >
+    Go to details
+  </button>
 
   <button
-    *ngIf="data.entity.isNew"
+    *ngIf="!data.entity.isNew"
     mat-icon-button
     [matMenuTriggerFor]="additional"
   >

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.spec.ts
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.spec.ts
@@ -15,16 +15,19 @@ import { MockedTestingModule } from "../../../../utils/mocked-testing.module";
 import { EntityFormService } from "../../entity-form/entity-form.service";
 import { AlertService } from "../../../alerts/alert.service";
 import { EntityAbility } from "../../../permissions/ability/entity-ability";
+import { Child } from "../../../../child-dev-project/children/model/child";
+import { Router } from "@angular/router";
 
 describe("RowDetailsComponent", () => {
   let component: RowDetailsComponent;
   let fixture: ComponentFixture<RowDetailsComponent>;
-  const detailsComponentData: DetailsComponentData = {
-    entity: new Entity(),
-    columns: [],
-  };
+  let detailsComponentData: DetailsComponentData;
 
   beforeEach(async () => {
+    detailsComponentData = {
+      entity: new Entity(),
+      columns: [],
+    };
     await TestBed.configureTestingModule({
       imports: [RowDetailsComponent, MockedTestingModule.withState()],
       providers: [
@@ -35,17 +38,19 @@ describe("RowDetailsComponent", () => {
     spyOn(TestBed.inject(EntityAbility), "cannot").and.returnValue(true);
   });
 
-  beforeEach(() => {
+  function initComponent() {
     fixture = TestBed.createComponent(RowDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
   it("should create", () => {
+    initComponent();
     expect(component).toBeTruthy();
   });
 
   it("should close the dialog when saving is successful", fakeAsync(() => {
+    initComponent();
     const formService = TestBed.inject(EntityFormService);
     const result = new Entity();
     spyOn(formService, "saveChanges").and.resolveTo(result);
@@ -59,6 +64,7 @@ describe("RowDetailsComponent", () => {
   }));
 
   it("should show an alert when saving fails", fakeAsync(() => {
+    initComponent();
     const formService = TestBed.inject(EntityFormService);
     const message = "Error message";
     spyOn(formService, "saveChanges").and.rejectWith(new Error(message));
@@ -75,6 +81,20 @@ describe("RowDetailsComponent", () => {
   }));
 
   it("should not disable the form when creating a new entity", () => {
+    initComponent();
     expect(component.form.disabled).toBeFalsy();
+  });
+
+  it("should create the details route", () => {
+    const child = new Child();
+    child._rev = "existing";
+    detailsComponentData.entity = child;
+    TestBed.inject(Router).resetConfig([
+      { path: "child/:id", redirectTo: "/" },
+    ]);
+
+    initComponent();
+
+    expect(component.detailsRoute).toBe(`${Child.route}/${child.getId()}`);
   });
 });

--- a/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/row-details/row-details.component.ts
@@ -29,6 +29,7 @@ import { Angulartics2Module } from "angulartics2";
 import { DisableEntityOperationDirective } from "../../../permissions/permission-directive/disable-entity-operation.directive";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Router, RouterLink } from "@angular/router";
 
 /**
  * Data interface that must be given when opening the dialog
@@ -63,6 +64,7 @@ export interface DetailsComponentData {
     Angulartics2Module,
     DisableEntityOperationDirective,
     MatTooltipModule,
+    RouterLink,
   ],
   standalone: true,
 })
@@ -72,6 +74,7 @@ export class RowDetailsComponent {
 
   viewOnlyColumns: FormFieldConfig[];
   tempEntity: Entity;
+  detailsRoute: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DetailsComponentData,
@@ -79,7 +82,8 @@ export class RowDetailsComponent {
     private formService: EntityFormService,
     private ability: EntityAbility,
     private entityRemoveService: EntityRemoveService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private router: Router
   ) {
     this.form = this.formService.createFormGroup(data.columns, data.entity);
     this.columns = data.columns.map((col) => [col]);
@@ -92,6 +96,19 @@ export class RowDetailsComponent {
       this.tempEntity = Object.assign(new dynamicConstructor(), value);
     });
     this.viewOnlyColumns = data.viewOnlyColumns;
+    if (!this.data.entity.isNew) {
+      this.initializeDetailsRouteIfAvailable();
+    }
+  }
+
+  private initializeDetailsRouteIfAvailable() {
+    let route = this.data.entity.getConstructor().route;
+    if (
+      route &&
+      this.router.config.some((r) => "/" + r.path === route + "/:id")
+    ) {
+      this.detailsRoute = route + "/" + this.data.entity.getId();
+    }
   }
 
   save() {


### PR DESCRIPTION
see issue: #1695 

### Visible/Frontend Changes
- [x] Added navigation button in popup of entity subrecord (see School > Activities)
### Architectural/Backend Changes
- [x] 
- [ ] 
