### PR TITLE
Sync restart on errors

### DIFF
--- a/src/app/core/session/session-service/synced-session.service.ts
+++ b/src/app/core/session/session-service/synced-session.service.ts
@@ -228,11 +228,12 @@ export class SyncedSessionService extends SessionService {
       })
       .on("error", (err) => {
         // totally unhandled error (shouldn't happen)
-        this.loggingService.error("sync failed" + err);
+        this.loggingService.error("sync failed " + err);
         this.syncState.next(SyncState.FAILED);
       })
       .on("complete", (info) => {
         // replication was canceled!
+        this.loggingService.warn("sync completed " + info);
         this._liveSyncHandle = null;
       });
   }


### PR DESCRIPTION
Trying to solve the `Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.` which sometimes causes the sync to stop and some data not being synchronised. At the moment this can only be solved by calling the `/db/admin/clear_local/app` endpoint (which triggers a check of all revs at source and target).

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] Sync restarts after complete or error callbacks are called
- [x] `complete` events are logged
