### PR TITLE
fix: broken status when using multiple select

### DIFF
--- a/src/app/child-dev-project/children/model/child.ts
+++ b/src/app/child-dev-project/children/model/child.ts
@@ -85,7 +85,7 @@ export class Child extends Entity {
   @DatabaseField({
     label: $localize`:Label for the status of a child:Status`,
   })
-  status: string = "";
+  status: string;
 
   @DatabaseField({
     label: $localize`:Label for the dropout date of a child:Dropout Date`,


### PR DESCRIPTION
At one instance, the child's status property has been overwritten to be a multi select, which led to issues when the default value `""` was assigned in the child class.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
--
