### PR TITLE
fix: months are sorted descending

### DIFF
--- a/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
+++ b/src/app/core/entity-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
@@ -313,7 +313,7 @@ export class EntitySubrecordComponent<T extends Entity> implements OnChanges {
     let sortDirection: SortDirection = "asc";
     if (
       sortByColumn?.view === "DisplayDate" ||
-      sortByColumn?.edit === "EditDate"
+      sortByColumn?.view === "DisplayMonth"
     ) {
       // flip default sort order for dates (latest first)
       sortDirection = "desc";


### PR DESCRIPTION
see issue: #XX

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
