### PR TITLE
Smaller fixes

### DIFF
--- a/src/app/child-dev-project/attendance/attendance.service.ts
+++ b/src/app/child-dev-project/attendance/attendance.service.ts
@@ -103,7 +103,7 @@ export class AttendanceService {
 
     const relevantNormalNotes = this.childrenService
       .getNotesInTimespan(start, end)
-      .then((notes) => notes.filter((n) => n.category.isMeeting));
+      .then((notes) => notes.filter((n) => n.category?.isMeeting));
 
     const allResults = await Promise.all([eventNotes, relevantNormalNotes]);
     return allResults[0].concat(allResults[1]);

--- a/src/app/child-dev-project/children/children.service.ts
+++ b/src/app/child-dev-project/children/children.service.ts
@@ -184,10 +184,11 @@ export class ChildrenService {
       // TODO: filter notes to only include them if the given child is marked "present"
 
       for (const entityId of note[noteProperty]) {
+        const trimmedId = Entity.extractEntityIdFromId(entityId);
         const daysSinceNote = moment().diff(note.date, "days");
-        const previousValue = results.get(entityId);
+        const previousValue = results.get(trimmedId);
         if (previousValue > daysSinceNote) {
-          results.set(entityId, daysSinceNote);
+          results.set(trimmedId, daysSinceNote);
         }
       }
     }

--- a/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.ts
+++ b/src/app/child-dev-project/notes/dashboard-widgets/notes-dashboard/notes-dashboard.component.ts
@@ -184,14 +184,3 @@ function statsToEntityWithRecentNoteInfo(
     };
   }
 }
-
-/**
- * Config for the Notes Dashboard
- * For more information see the property comments in this class
- */
-interface NotesDashboardConfig {
-  sinceDays?: number;
-  fromBeginningOfWeek?: boolean;
-  mode?: "with-recent-notes" | "without-recent-notes";
-  entity?: string;
-}

--- a/src/app/child-dev-project/notes/model/note.ts
+++ b/src/app/child-dev-project/notes/model/note.ts
@@ -111,7 +111,7 @@ export class Note extends Entity {
     dataType: "configurable-enum",
     innerDataType: INTERACTION_TYPE_CONFIG_ID,
   })
-  category: InteractionType = { id: "", label: "" };
+  category: InteractionType;
 
   /**
    * id referencing a different entity (e.g. a recurring activity) this note is related to

--- a/src/app/child-dev-project/notes/model/note.ts
+++ b/src/app/child-dev-project/notes/model/note.ts
@@ -162,7 +162,7 @@ export class Note extends Entity {
   public getColor() {
     const actualLevel = this.getWarningLevel();
     if (actualLevel === WarningLevel.OK || actualLevel === WarningLevel.NONE) {
-      return this.category.color;
+      return this.category?.color;
     } else {
       return super.getColor();
     }
@@ -170,7 +170,7 @@ export class Note extends Entity {
 
   public getColorForId(childId: string): string {
     if (
-      this.category.isMeeting &&
+      this.category?.isMeeting &&
       this.childrenAttendance.get(childId)?.status.countAs ===
         AttendanceLogicalStatus.ABSENT
     ) {

--- a/src/app/child-dev-project/notes/model/note.ts
+++ b/src/app/child-dev-project/notes/model/note.ts
@@ -38,6 +38,7 @@ import { Ordering } from "../../../core/configurable-enum/configurable-enum-orde
 
 @DatabaseEntity("Note")
 export class Note extends Entity {
+  static toStringAttributes = ["subject"];
   static label = $localize`:label for entity:Note`;
   static labelPlural = $localize`:label (plural) for entity:Notes`;
 
@@ -92,12 +93,12 @@ export class Note extends Entity {
   @DatabaseField({ label: $localize`:Label for the date of a note:Date` })
   date: Date;
   @DatabaseField({ label: $localize`:Label for the subject of a note:Subject` })
-  subject: string = "";
+  subject: string;
   @DatabaseField({
     label: $localize`:Label for the actual notes of a note:Notes`,
     editComponent: "EditLongText",
   })
-  text: string = "";
+  text: string;
   /** IDs of users that authored this note */
   @DatabaseField({
     label: $localize`:Label for the social worker(s) who created the note:SW`,

--- a/src/app/child-dev-project/notes/note-details/note-details.component.html
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.html
@@ -74,7 +74,7 @@
       [exportConfig]="exportConfig"
       [filename]="
         'event_' +
-        entity.subject.replace(' ', '-') +
+        entity.subject?.replace(' ', '-') +
         '_' +
         (entity.date | date : 'YYYY-MM-dd')
       "

--- a/src/app/child-dev-project/notes/note-details/note-details.component.html
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.html
@@ -74,7 +74,7 @@
       [exportConfig]="exportConfig"
       [filename]="
         'event_' +
-        entity.subject?.replace(' ', '-') +
+        entity.toString()?.replace(' ', '-') +
         '_' +
         (entity.date | date : 'YYYY-MM-dd')
       "

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -72,10 +72,15 @@ export class NoteDetailsComponent implements OnInit {
     this.exportConfig = this.configService.getConfig<{
       config: EntityListConfig;
     }>("view:note").config.exportConfig;
-    const formConfig = this.configService.getConfig("appConfig:note-details");
-    ["topForm", "middleForm", "bottomForm"].forEach((form) => {
+    const formConfig = this.configService.getConfig<any>(
+      "appConfig:note-details"
+    );
+    this.topForm =
+      formConfig?.topForm?.map((field) => [toFormFieldConfig(field)]) ??
+      this.topForm;
+    ["middleForm", "bottomForm"].forEach((form) => {
       this[form] =
-        formConfig?.[form]?.map((field) => [toFormFieldConfig(field)]) ??
+        formConfig?.[form]?.map((field) => toFormFieldConfig(field)) ??
         this[form];
     });
   }

--- a/src/app/core/configurable-enum/configure-enum-popup/configure-enum-popup.component.ts
+++ b/src/app/core/configurable-enum/configure-enum-popup/configure-enum-popup.component.ts
@@ -50,9 +50,12 @@ export class ConfigureEnumPopupComponent {
     private confirmationService: ConfirmationDialogService,
     private entities: EntityRegistry
   ) {
-    this.dialog
-      .afterClosed()
-      .subscribe(() => this.entityMapper.save(this.enumEntity));
+    const initialValues = JSON.stringify(enumEntity.values);
+    this.dialog.afterClosed().subscribe(() => {
+      if (JSON.stringify(this.enumEntity.values) !== initialValues) {
+        this.entityMapper.save(this.enumEntity);
+      }
+    });
   }
 
   drop(event: CdkDragDrop<string[]>) {

--- a/src/app/core/entity-components/entity-select/display-entity/display-entity.component.spec.ts
+++ b/src/app/core/entity-components/entity-select/display-entity/display-entity.component.spec.ts
@@ -10,6 +10,10 @@ import {
   entityRegistry,
 } from "../../../entity/database-entity.decorator";
 import { Router } from "@angular/router";
+import {
+  componentRegistry,
+  ComponentRegistry,
+} from "../../../../dynamic-components";
 
 describe("DisplayEntityComponent", () => {
   let component: DisplayEntityComponent;
@@ -25,10 +29,8 @@ describe("DisplayEntityComponent", () => {
       imports: [DisplayEntityComponent],
       providers: [
         { provide: EntityMapperService, useValue: mockEntityMapper },
-        {
-          provide: EntityRegistry,
-          useValue: entityRegistry,
-        },
+        { provide: EntityRegistry, useValue: entityRegistry },
+        { provide: ComponentRegistry, useValue: componentRegistry },
         { provide: Router, useValue: mockRouter },
       ],
     }).compileComponents();

--- a/src/app/core/entity-components/entity-select/display-entity/display-entity.component.ts
+++ b/src/app/core/entity-components/entity-select/display-entity/display-entity.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
 import { Entity, EntityConstructor } from "../../../entity/model/entity";
 import { ViewDirective } from "../../entity-utils/view-components/view.directive";
 import { DynamicComponent } from "../../../view/dynamic-components/dynamic-component.decorator";
@@ -34,7 +34,8 @@ export class DisplayEntityComponent
 
   constructor(
     private entityMapper: EntityMapperService,
-    private router: Router
+    private router: Router,
+    private changeDetector: ChangeDetectorRef
   ) {
     super();
   }
@@ -47,6 +48,7 @@ export class DisplayEntityComponent
         this.entityType,
         this.entityId
       );
+      this.changeDetector.detectChanges();
     }
     if (this.entityToDisplay) {
       this.entityBlockComponent = this.entityToDisplay

--- a/src/app/core/entity-components/entity-utils/entity-property-view/entity-property-view.component.ts
+++ b/src/app/core/entity-components/entity-utils/entity-property-view/entity-property-view.component.ts
@@ -46,6 +46,7 @@ export class EntityPropertyViewComponent<E extends Entity = Entity>
       }
       this.label = schema?.label ?? this.property;
       this.propertyName = this.property;
+      this.additional = schema.additional;
     } else {
       this.component = this.property.view;
       this.additional = this.property.additional;

--- a/src/app/core/entity-components/entity-utils/entity-property-view/entity-property-view.component.ts
+++ b/src/app/core/entity-components/entity-utils/entity-property-view/entity-property-view.component.ts
@@ -46,7 +46,7 @@ export class EntityPropertyViewComponent<E extends Entity = Entity>
       }
       this.label = schema?.label ?? this.property;
       this.propertyName = this.property;
-      this.additional = schema.additional;
+      this.additional = schema?.additional;
     } else {
       this.component = this.property.view;
       this.additional = this.property.additional;


### PR DESCRIPTION
### Visible/Frontend Changes
- [x] The middle & bottom form currently can't be configured because it has the wrong format (should be a 1d array instead of 2d)
- [x] remove assignment of empty enum to category as this leads to `[invalid option]` when nothing is selected and the empty enum value does not exist
- [x] Recent notes dashboard works with the `relatedEntities` property (with full IDs)
- [x] Enum entity is only saved if values have been changed
- [x] Linked entities are correctly visualised in the comparison table of the matching component
- [x] Note has default `toString` using the `subject` property

### Architectural/Backend Changes
--
