### PR TITLE
fix: display entity component does not try to load undefined entities

### DIFF
--- a/src/app/core/entity-components/entity-select/display-entity/display-entity.component.ts
+++ b/src/app/core/entity-components/entity-select/display-entity/display-entity.component.ts
@@ -43,6 +43,9 @@ export class DisplayEntityComponent
     if (!this.entityToDisplay) {
       this.entityType = this.entityType ?? this.config;
       this.entityId = this.entityId ?? this.value;
+      if (!this.entityType || !this.entityId) {
+        return;
+      }
       this.entityToDisplay = await this.entityMapper.load(
         this.entityType,
         this.entityId


### PR DESCRIPTION
Currently, when a single entity is supposed to be displayed but not set (undefined) then an error is logged.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
