### PR TITLE
fix: editing entity array correctly marks a form as dirty

### DIFF
--- a/src/app/core/entity-components/entity-select/edit-entity-array/edit-entity-array.component.html
+++ b/src/app/core/entity-components/entity-select/edit-entity-array/edit-entity-array.component.html
@@ -1,7 +1,7 @@
 <app-entity-select
   [entityType]="entityName"
   [selection]="formControl.value"
-  (selectionChange)="formControl.setValue($event)"
+  (selectionChange)="formControl.setValue($event); formControl.markAsDirty()"
   [disabled]="formControl.disabled"
   [label]="label"
   [placeholder]="placeholder"


### PR DESCRIPTION
Save button is disabled in note details if only an entity-array field is changed.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
