### PR TITLE
Change detection improvements

### DIFF
--- a/src/app/core/common-components/template-tooltip/template-tooltip.component.ts
+++ b/src/app/core/common-components/template-tooltip/template-tooltip.component.ts
@@ -1,9 +1,10 @@
 import {
   Component,
+  ElementRef,
   EventEmitter,
   HostBinding,
-  HostListener,
   Input,
+  NgZone,
   Output,
   TemplateRef,
 } from "@angular/core";
@@ -65,14 +66,11 @@ export class TemplateTooltipComponent {
 
   @Output() show = new EventEmitter<void>();
 
-  @HostListener("mouseenter")
-  onMouseEnter() {
-    this.show.emit();
-  }
-
-  @HostListener("mouseleave")
-  onMouseLeave() {
-    this.hide.emit();
+  constructor(zone: NgZone, el: ElementRef<HTMLElement>) {
+    zone.runOutsideAngular(() => {
+      el.nativeElement.addEventListener("mouseenter", () => this.show.emit());
+      el.nativeElement.addEventListener("mouseleave", (ev) => this.hide.emit());
+    });
   }
 
   @HostBinding("@appear") animation = true;

--- a/src/app/core/language/language-select/language-select.component.ts
+++ b/src/app/core/language/language-select/language-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Inject } from "@angular/core";
 import { LanguageService } from "../language.service";
 import { LOCATION_TOKEN } from "../../../utils/di-tokens";
 import { LANGUAGE_LOCAL_STORAGE_KEY } from "../language-statics";
@@ -16,6 +16,7 @@ import { NgForOf } from "@angular/common";
   styleUrls: ["./language-select.component.scss"],
   imports: [MatButtonModule, MatIconModule, MatMenuModule, NgForOf],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LanguageSelectComponent {
   /**

--- a/src/app/core/latest-changes/app-version/app-version.component.ts
+++ b/src/app/core/latest-changes/app-version/app-version.component.ts
@@ -15,7 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
 import { LatestChangesDialogService } from "../latest-changes-dialog.service";
 
 /**
@@ -26,6 +26,7 @@ import { LatestChangesDialogService } from "../latest-changes-dialog.service";
   selector: "app-version",
   templateUrl: "./app-version.component.html",
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppVersionComponent implements OnInit {
   /** the current app version */

--- a/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/app/core/navigation/navigation/navigation.component.ts
@@ -41,9 +41,9 @@ import { FaDynamicIconComponent } from "../../view/fa-dynamic-icon/fa-dynamic-ic
     NgForOf,
     Angulartics2Module,
     RouterLink,
-    FaDynamicIconComponent
+    FaDynamicIconComponent,
   ],
-  standalone: true
+  standalone: true,
 })
 export class NavigationComponent {
   /** The menu-item link (not the actual router link) that is currently active */
@@ -113,15 +113,10 @@ export class NavigationComponent {
    * Load menu items from config file
    */
   private initMenuItemsFromConfig() {
-    this.menuItems = [];
     const config: NavigationMenuConfig =
       this.configService.getConfig<NavigationMenuConfig>(this.CONFIG_ID);
-    for (const configItem of config.items) {
-      if (this.userRoleGuard.checkRoutePermissions(configItem.link)) {
-        this.menuItems.push(
-          new MenuItem(configItem.name, configItem.icon, configItem.link)
-        );
-      }
-    }
+    this.menuItems = config.items
+      .filter(({ link }) => this.userRoleGuard.checkRoutePermissions(link))
+      .map(({ name, icon, link }) => new MenuItem(name, icon, link));
   }
 }

--- a/src/app/core/pwa-install/pwa-install.component.ts
+++ b/src/app/core/pwa-install/pwa-install.component.ts
@@ -1,4 +1,9 @@
-import { Component, TemplateRef, ViewChild } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  TemplateRef,
+  ViewChild,
+} from "@angular/core";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { PwaInstallService, PWAInstallType } from "./pwa-install.service";
 import { NgIf } from "@angular/common";
@@ -10,13 +15,9 @@ import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
   selector: "app-pwa-install",
   templateUrl: "./pwa-install.component.html",
   styleUrls: ["./pwa-install.component.scss"],
-  imports: [
-    NgIf,
-    MatButtonModule,
-    Angulartics2Module,
-    FontAwesomeModule
-  ],
-  standalone: true
+  imports: [NgIf, MatButtonModule, Angulartics2Module, FontAwesomeModule],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PwaInstallComponent {
   @ViewChild("iOSInstallInstructions")

--- a/src/app/core/sync-status/sync-status/sync-status.component.ts
+++ b/src/app/core/sync-status/sync-status/sync-status.component.ts
@@ -15,7 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { SessionService } from "../../session/session-service/session.service";
 import { SyncState } from "../../session/session-states/sync-state.enum";
 import { DatabaseIndexingService } from "../../entity/database-indexing/database-indexing.service";
@@ -38,6 +38,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
   templateUrl: "./sync-status.component.html",
   imports: [BackgroundProcessingIndicatorComponent],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SyncStatusComponent {
   private indexingProcesses: BackgroundProcessState[];

--- a/src/app/core/ui/primary-action/primary-action.component.ts
+++ b/src/app/core/ui/primary-action/primary-action.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { Note } from "../../../child-dev-project/notes/model/note";
 import { SessionService } from "../../session/session-service/session.service";
 import { NoteDetailsComponent } from "../../../child-dev-project/notes/note-details/note-details.component";
@@ -25,6 +25,7 @@ import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
     FontAwesomeModule,
   ],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PrimaryActionComponent {
   noteConstructor = Note;

--- a/src/app/core/ui/search/search.component.ts
+++ b/src/app/core/ui/search/search.component.ts
@@ -1,4 +1,8 @@
-import { Component, ViewEncapsulation } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from "@angular/core";
 import { Entity } from "../../entity/model/entity";
 import { Observable } from "rxjs";
 import { concatMap, debounceTime, tap } from "rxjs/operators";
@@ -39,6 +43,7 @@ import { SearchService } from "./search.service";
     AsyncPipe,
   ],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchComponent {
   static INPUT_DEBOUNCE_TIME_MS = 400;

--- a/src/app/core/ui/ui/ui.component.ts
+++ b/src/app/core/ui/ui/ui.component.ts
@@ -35,7 +35,6 @@ import { LanguageSelectComponent } from "../../language/language-select/language
 import { NavigationComponent } from "../../navigation/navigation/navigation.component";
 import { PwaInstallComponent } from "../../pwa-install/pwa-install.component";
 import { AppVersionComponent } from "../../latest-changes/app-version/app-version.component";
-import { LoginComponent } from "../../session/login/login.component";
 import { PrimaryActionComponent } from "../primary-action/primary-action.component";
 
 /**
@@ -62,7 +61,6 @@ import { PrimaryActionComponent } from "../primary-action/primary-action.compone
     PwaInstallComponent,
     AppVersionComponent,
     RouterOutlet,
-    LoginComponent,
     PrimaryActionComponent,
   ],
   standalone: true,

--- a/src/app/core/view/fa-dynamic-icon/fa-dynamic-icon.component.ts
+++ b/src/app/core/view/fa-dynamic-icon/fa-dynamic-icon.component.ts
@@ -1,15 +1,15 @@
-import { Component, Input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Input } from "@angular/core";
 import {
   IconDefinition,
   IconName,
   IconPrefix,
 } from "@fortawesome/fontawesome-svg-core";
 import {
-  faChartLine,
-  faQuestionCircle,
-  faCalendarCheck,
-  faFileAlt,
   faCalendarAlt,
+  faCalendarCheck,
+  faChartLine,
+  faFileAlt,
+  faQuestionCircle,
   faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -41,6 +41,7 @@ const iconAliases = new Map<string, IconDefinition>([
   template: ` <fa-icon *ngIf="_icon" [icon]="_icon"></fa-icon>`,
   imports: [FontAwesomeModule, NgIf],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaDynamicIconComponent {
   /** The fallback icon if the given icon is neither known (inside the internal map)


### PR DESCRIPTION
see issue: #1586 

This PR uses two approaches to improve the performance of change detection.

### Reduce change detection cycles
One reason for a lot of (unnecessary) change detection cycles is the use of event listeners in child components. These events trigger change detection on all ancestor components (see [here](https://medium.com/angular-in-depth/deep-dive-into-the-onpush-change-detection-strategy-in-angular-fab5e4da1d69#4072)). E.g. when using `@HostListener("mouseover")` change detection for all ancestor components up to the `app-component` is triggered whenever the mouse moves over the element. This can be prevented by moving the subscription to the event outside of the `NgZone` and only enter the zone again if the UI should be manipulated. Unfortunately the `MatTooltip` and `MatSort` directive also have this problem (see [issue](https://github.com/angular/components/issues/10306)).

### Reduce the time needed for a change detection cycle
The fewer components are affected by the change detection, the quicker it is. Components can be excluded from change detection if the are set to `OnPush`. This will only trigger the change detection (and forward it to all children) if any `@Input` changes.

### Visible/Frontend Changes
--

### Architectural/Backend Changes
- [x] Reduce change detection cycles in `TemplateTooltipDirective` by working outside `NgZone`
- [x] Add `OnPush` to static components in `UiComponent` (search, language select, ...)
- [x] Add `OnPush` to `FaDynamicIconComponent` (`FaIconComponent` seems to take a lot of the time)
