### PR TITLE
fix: reset password button does not reload app

### DIFF
--- a/src/app/core/session/auth/keycloak/password-reset/password-reset.component.html
+++ b/src/app/core/session/auth/keycloak/password-reset/password-reset.component.html
@@ -4,13 +4,20 @@
   style="float: right"
   (click)="toggleEmailForm()"
   i18n="Login button"
+  type="button"
 >
   Forgot password?
 </button>
 
-<form *ngIf="passwordResetActive" style="margin-top: 20px">
+<div *ngIf="passwordResetActive" style="margin-top: 20px">
   <mat-form-field style="width: 70%">
-    <input [formControl]="email" type="email" placeholder="Your email address" matInput>
+    <input
+      [formControl]="email"
+      type="email"
+      placeholder="Your email address"
+      matInput
+      (keyup.enter)="sendEmail()"
+    >
     <mat-error *ngIf="email.errors?.notFound">{{ email.errors.notFound }}</mat-error>
     <mat-error
       *ngIf="email.errors?.email || email.errors?.required"
@@ -26,7 +33,8 @@
     angularticsAction="password_reset"
     angularticsCategory="User"
     (click)="sendEmail()"
+    type="button"
   >
     Send mail
   </button>
-</form>
+</div>

--- a/src/app/core/session/auth/keycloak/password-reset/password-reset.component.html
+++ b/src/app/core/session/auth/keycloak/password-reset/password-reset.component.html
@@ -29,9 +29,6 @@
   <button
     mat-raised-button
     style="margin-left: 10px"
-    angulartics2On="click"
-    angularticsAction="password_reset"
-    angularticsCategory="User"
     (click)="sendEmail()"
     type="button"
   >

--- a/src/app/core/session/auth/keycloak/password-reset/password-reset.component.ts
+++ b/src/app/core/session/auth/keycloak/password-reset/password-reset.component.ts
@@ -7,7 +7,7 @@ import { NgIf } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { Angulartics2Module } from "angulartics2";
+import { AnalyticsService } from "../../../../analytics/analytics.service";
 
 @Component({
   selector: "app-password-reset",
@@ -18,7 +18,6 @@ import { Angulartics2Module } from "angulartics2";
     MatFormFieldModule,
     ReactiveFormsModule,
     MatInputModule,
-    Angulartics2Module,
   ],
   standalone: true,
 })
@@ -27,7 +26,11 @@ export class PasswordResetComponent {
   passwordResetActive = false;
   email = new FormControl("", [Validators.required, Validators.email]);
 
-  constructor(authService: AuthService, private snackbar: MatSnackBar) {
+  constructor(
+    authService: AuthService,
+    private snackbar: MatSnackBar,
+    private analytics: AnalyticsService
+  ) {
     if (authService instanceof KeycloakAuthService) {
       this.keycloakAuth = authService;
     }
@@ -41,6 +44,7 @@ export class PasswordResetComponent {
     if (this.email.invalid) {
       return;
     }
+    this.analytics.eventTrack("password_reset", { category: "User" });
 
     this.keycloakAuth.forgotPassword(this.email.value).subscribe({
       next: () => {

--- a/src/app/core/session/login/login.component.html
+++ b/src/app/core/session/login/login.component.html
@@ -52,6 +52,7 @@
             required
             name="password"
             autocomplete="current-password"
+            (keydown.enter)="login()"
           />
           <fa-icon
             [icon]="passwordVisible ? 'eye-slash' : 'eye'"
@@ -66,7 +67,7 @@
       <p>
         <button
           mat-raised-button
-          type="submit"
+          type="button"
           [disabled]="loginInProgress"
           (click)="login()"
           i18n="Login button"


### PR DESCRIPTION
Currently the app automatically reloads when clicking the reset password button. 

-  ~Matomo is not yet working on the reset password button~ (we only initialise after login as it needs the config)
- [x] Login is still triggered when pressing `enter`
- [x] Check how it works on the phone