### PR TITLE
fix: date-only field does not trigger confirm changes popup

### DIFF
--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.spec.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.spec.ts
@@ -6,6 +6,7 @@ import { MockedTestingModule } from "../../../../utils/mocked-testing.module";
 import { EntityMapperService } from "../../../entity/entity-mapper.service";
 import { ConfirmationDialogService } from "../../../confirmation-dialog/confirmation-dialog.service";
 import { EntityFormService } from "../entity-form.service";
+import { DateWithAge } from "../../../../child-dev-project/children/model/dateWithAge";
 
 describe("EntityFormComponent", () => {
   let component: EntityFormComponent<Child>;
@@ -14,7 +15,12 @@ describe("EntityFormComponent", () => {
   let mockConfirmation: jasmine.SpyObj<ConfirmationDialogService>;
 
   const testColumns = [
-    [{ id: "name" }, { id: "projectNumber" }, { id: "photo" }],
+    [
+      { id: "name" },
+      { id: "projectNumber" },
+      { id: "photo" },
+      { id: "dateOfBirth" },
+    ],
   ];
 
   beforeEach(waitForAsync(() => {
@@ -102,6 +108,15 @@ describe("EntityFormComponent", () => {
         _rev: "new rev",
       }
     );
+  });
+
+  it("should not show popup if date was saved as day-only", async () => {
+    const form = { dateOfBirth: new DateWithAge() };
+    const dateOnly = new DateWithAge();
+    dateOnly.setHours(0, 0, 0, 0);
+    const remoteValues = { dateOfBirth: dateOnly };
+
+    await expectApplyChangesPopup("not-shown", form, form, remoteValues, form);
   });
 
   async function expectApplyChangesPopup(

--- a/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/entity-components/entity-form/entity-form/entity-form.component.ts
@@ -18,6 +18,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { Subscription } from "rxjs";
+import moment from "moment";
 
 /**
  * A general purpose form component for displaying and editing entities.
@@ -136,13 +137,15 @@ export class EntityFormComponent<T extends Entity = Entity>
   }
 
   private formIsUpToDate(entity: T): boolean {
-    return Object.entries(this.form.getRawValue()).every(([key, value]) => {
-      return this.entityEqualsFormValue(entity[key], value);
-    });
+    return Object.entries(this.form.getRawValue()).every(([key, value]) =>
+      this.entityEqualsFormValue(entity[key], value)
+    );
   }
 
   private entityEqualsFormValue(entityValue, formValue) {
     return (
+      (entityValue instanceof Date &&
+        moment(entityValue).isSame(formValue, "day")) ||
       (entityValue === undefined && formValue === null) ||
       entityValue === formValue ||
       JSON.stringify(entityValue) === JSON.stringify(formValue)


### PR DESCRIPTION
Creating a new note (without changing the date) currently triggers the save changes popup.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
