### PR TITLE
ci: master push triggers percy

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -80,4 +80,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # pass the project ID from the secrets through environment variable
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+  run-visual-regression-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: npm
+      - run: npm ci
+      - run: npm run percy-storybook
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 


### PR DESCRIPTION
The visual regression tests are not executed on the master branch yet and therefore no comparison can be made.
