### PR TITLE
fix: app reset does not get stuck on support screen

### DIFF
--- a/src/app/core/support/support/support.component.spec.ts
+++ b/src/app/core/support/support/support.component.spec.ts
@@ -37,7 +37,7 @@ describe("SupportComponent", () => {
       serviceWorker: { getRegistrations: () => [], ready: Promise.resolve() },
     },
   };
-  let mockLocation: jasmine.SpyObj<Location>;
+  let mockLocation: any;
 
   beforeEach(async () => {
     localStorage.clear();
@@ -49,7 +49,7 @@ describe("SupportComponent", () => {
     mockDB.getPouchDB.and.returnValue({
       info: () => Promise.resolve({ doc_count: 1, update_seq: 2 }),
     } as any);
-    mockLocation = jasmine.createSpyObj(["reload"]);
+    mockLocation = {};
     await TestBed.configureTestingModule({
       imports: [
         SupportComponent,
@@ -118,7 +118,7 @@ describe("SupportComponent", () => {
     expect(mockDB.destroy).toHaveBeenCalled();
     expect(unregisterSpy).toHaveBeenCalled();
     expect(localStorage.getItem("someItem")).toBeNull();
-    expect(mockLocation.reload).toHaveBeenCalled();
+    expect(mockLocation.pathname).toBe("");
   });
 
   it("should display the service worker logs after they are available", fakeAsync(() => {

--- a/src/app/core/support/support/support.component.ts
+++ b/src/app/core/support/support/support.component.ts
@@ -160,7 +160,7 @@ export class SupportComponent implements OnInit {
     const unregisterPromises = registrations.map((reg) => reg.unregister());
     await Promise.all(unregisterPromises);
     localStorage.clear();
-    this.location.reload();
+    this.location.pathname = "";
   }
 
   async downloadLocalDatabase() {


### PR DESCRIPTION
The report screen reloads the app but after that the user is stuck in the report screen without a way to navigate to the login page.
This change will forward the user to the normal login screen after the app has been reset.

### Visible/Frontend Changes
- [x] 
- [ ] 

### Architectural/Backend Changes
- [x] 
- [ ] 
