### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # Latest release-replace plugin fails https://github.com/jpoehnelt/semantic-release-replace-plugin/issues/223
           extra_plugins: |
-            @google/semantic-release-replace-plugin@1.2.0
+            semantic-release-replace-plugin@1.2.0
             @semantic-release/git
             @semantic-release/github
             semantic-release-slack-bot

--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@google/semantic-release-replace-plugin", {
+    ["semantic-release-replace-plugin", {
       "replacements": [
         {
           "files": ["src/environments/environment.ts", "src/environments/environment.prod.ts"],


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).