### PR TITLE
fix: missing enums are not immediately saved

### DIFF
--- a/src/app/core/configurable-enum/configurable-enum.service.spec.ts
+++ b/src/app/core/configurable-enum/configurable-enum.service.spec.ts
@@ -8,11 +8,7 @@ describe("ConfigurableEnumService", () => {
   let service: ConfigurableEnumService;
   let mockEntityMapper: jasmine.SpyObj<EntityMapperService>;
   beforeEach(async () => {
-    mockEntityMapper = jasmine.createSpyObj([
-      "save",
-      "loadType",
-      "receiveUpdates",
-    ]);
+    mockEntityMapper = jasmine.createSpyObj(["loadType", "receiveUpdates"]);
     mockEntityMapper.receiveUpdates.and.returnValue(NEVER);
     mockEntityMapper.loadType.and.resolveTo([]);
     await TestBed.configureTestingModule({
@@ -34,7 +30,6 @@ describe("ConfigurableEnumService", () => {
 
     expect(newEnum.getId()).toEqual("new-id");
     expect(newEnum.values).toEqual([]);
-    expect(mockEntityMapper.save).toHaveBeenCalledWith(newEnum);
     // returns same enum in consecutive calls
     expect(service.getEnum("new-id")).toBe(newEnum);
   });
@@ -42,6 +37,5 @@ describe("ConfigurableEnumService", () => {
   it("should not creat a new enum if the user is missing permissions", () => {
     spyOn(TestBed.inject(EntityAbility), "can").and.returnValue(false);
     expect(service.getEnum("new-id")).toBeUndefined();
-    expect(mockEntityMapper.save).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/configurable-enum/configurable-enum.service.ts
+++ b/src/app/core/configurable-enum/configurable-enum.service.ts
@@ -45,7 +45,6 @@ export class ConfigurableEnumService {
     ) {
       const newEnum = new ConfigurableEnum(id);
       this.cacheEnum(newEnum);
-      this.entityMapper.save(newEnum);
     }
     return this.enums.get(entityId);
   }


### PR DESCRIPTION
Currently it sometimes happens that users end up with a (new) empty enum object and the database has conflicts on enum documents.

This can happen when

- The user just started to sync
- The enum is requested before the configurable enums are synced

Then a new enum is created and saved which will conflict with the existing enum once it is synced.
To prevent this we are not saving the empty enum immediately. 
This means the enum is only saved if new options are added.
Once the existing enum is synced the newly created one will just be discarded.