### PR TITLE
build: allow CSP reporting in CSP rules

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -79,9 +79,10 @@ ENV CSP_REPORT_URI=""
 # overwrite the Content-Security-Policy rules (report-uri is added automatically)
 ## default includes all required whitelists for production server
 ## to disable any CSP blocking, set to "default-src *  data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval'"
-ENV CSP="default-src 'self' 'unsafe-eval' data: https://sentry.io https://*.tile.openstreetmap.org/ https://matomo.aam-digital.org  https://*.aam-digital.com https://api.github.com/repos/Aam-Digital/ 'sha256-Sh1PNRUktjifFwuOicavxmlAcFpZMbUqQGiCIoKhDI8='; style-src 'self' 'unsafe-inline'"
+ENV CSP="default-src 'self' 'unsafe-eval' data: https://*.tile.openstreetmap.org/ https://matomo.aam-digital.org  https://*.aam-digital.com https://api.github.com/repos/Aam-Digital/ https://sentry.io https://o167951.ingest.sentry.io/api/1242399/security/ 'sha256-Sh1PNRUktjifFwuOicavxmlAcFpZMbUqQGiCIoKhDI8='; style-src 'self' 'unsafe-inline'"
 ### 'sha256-Sh1PNRUktjifFwuOicavxmlAcFpZMbUqQGiCIoKhDI8=' for index.html writing browser details
 ### 'unsafe-eval' required for pouchdb https://github.com/pouchdb/pouchdb/issues/7853#issuecomment-535020600
+### https://o167951.ingest.sentry.io/api/1242399/security/ to allow reporting of CSP violations to the Aam Digital standard sentry.io endpoint
 
 # variables are inserted into the nginx config
 CMD envsubst '$$PORT $$COUCHDB_URL $$NOMINATIM_URL $$CSP $$CSP_REPORT_URI' < /etc/nginx/templates/default.conf > /etc/nginx/conf.d/default.conf &&\


### PR DESCRIPTION
CSP is blocking connections also to the defined reporting-uri by default. Allowing our standard sentry endpoint for this in the default rules now. Custom deployments that use a different reporting-uri will have to overwrite the rules and add that to be allowed as a connect-src