### PR TITLE
feat(core): link any permitted relatedEntities to newly generated Note

### DIFF
--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
@@ -87,9 +87,9 @@ describe("NotesRelatedToEntityComponent", () => {
   });
 
   it("should create a new note and fill it with indirectly related references (2-hop) of the types allowed for note.relatedEntities", () => {
-    @DatabaseEntity("TestNewNoteRelatedRefsEntity")
-    class TestNewNoteRelatedRefsEntity extends Entity {
-      static ENTITY_TYPE = "TestNewNoteRelatedRefsEntity";
+    @DatabaseEntity("EntityWithRelations")
+    class EntityWithRelations extends Entity {
+      static ENTITY_TYPE = "EntityWithRelations";
 
       @DatabaseField({
         dataType: "entity-array",
@@ -103,7 +103,7 @@ describe("NotesRelatedToEntityComponent", () => {
       })
       childrenLink;
     }
-    let customEntity = new TestNewNoteRelatedRefsEntity();
+    const customEntity = new EntityWithRelations();
     customEntity.links = [
       "Child:1",
       "School:not-a-type-for-note.relatedEntities",
@@ -112,12 +112,12 @@ describe("NotesRelatedToEntityComponent", () => {
 
     Note.schema.get("relatedEntities").additional = [
       Child.ENTITY_TYPE,
-      TestNewNoteRelatedRefsEntity.ENTITY_TYPE,
+      EntityWithRelations.ENTITY_TYPE,
     ];
     component.entity = customEntity;
     component.ngOnInit();
 
-    let newNote = component.generateNewRecordFactory()();
+    const newNote = component.generateNewRecordFactory()();
 
     expect(newNote.relatedEntities).toContain(customEntity.getId(true));
     expect(newNote.relatedEntities).toContain(customEntity.links[0]);

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -169,3 +169,11 @@ export function serviceProvider<T>(
     deps: [Injector],
   };
 }
+
+/**
+ * Convert wrap a value in an array if it is not already an array.
+ * @param x
+ */
+export function asArray<T>(x: T | T[]): T[] {
+  return Array.isArray(x) ? x : [x];
+}


### PR DESCRIPTION
by checking any referenced entities in properties of the current entity for those that match the entity types allowed in Note.relatedEntities schema

-> a step towards more generalized ChildSchoolRelation