### PR TITLE
feat(import): import address by lookup of location data

### DIFF
--- a/src/app/features/location/location.datatype.spec.ts
+++ b/src/app/features/location/location.datatype.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from "@angular/core/testing";
+import { of } from "rxjs";
+import { LocationDatatype } from "./location.datatype";
+import { GeoResult, GeoService } from "./geo.service";
+
+describe("Schema data type: location", () => {
+  let service: LocationDatatype;
+  let mockGeoService: jasmine.SpyObj<GeoService>;
+
+  beforeEach(() => {
+    mockGeoService = jasmine.createSpyObj(["lookup"]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: GeoService, useValue: mockGeoService },
+        LocationDatatype,
+      ],
+    });
+
+    service = TestBed.inject(LocationDatatype);
+  });
+
+  async function testImportMapping(
+    importedValue: string,
+    mockedLookup: GeoResult[],
+    expectedResult,
+  ) {
+    mockGeoService.lookup.and.returnValue(of(mockedLookup));
+
+    const actualResult = await service.importMapFunction(importedValue, null);
+
+    expect(mockGeoService.lookup).toHaveBeenCalledWith(importedValue);
+    expect(actualResult).toEqual(expectedResult);
+  }
+
+  it("should import lookup location data when importing address string", async () => {
+    const importedAddress = "21 MyStreet, MyCity";
+    const locationResult: GeoResult = {
+      lat: 1,
+      lon: 2,
+      display_name: importedAddress,
+    };
+
+    await testImportMapping(importedAddress, [locationResult], locationResult);
+  });
+
+  it("should import first lookup location when importing address string resulting in multiple results", async () => {
+    const importedAddress = "21 MyStreet, MyCity";
+    const locationResult: GeoResult = {
+      lat: 1,
+      lon: 2,
+      display_name: importedAddress,
+    };
+
+    await testImportMapping(
+      importedAddress,
+      [locationResult, { display_name: "other result", lat: 0, lon: 0 }],
+      locationResult,
+    );
+  });
+
+  it("should import nothing when importing address that isn't found with lookup", async () => {
+    const importedAddress = "21 MyStreet, MyCity";
+
+    // TODO: when implementing #1844, extend this to import only custom address string without location object
+    await testImportMapping(importedAddress, [], undefined);
+  });
+
+  it("should not lookup empty address when importing", async () => {
+    const res1 = await service.importMapFunction(undefined, null);
+    expect(res1).toBeUndefined();
+    expect(mockGeoService.lookup).not.toHaveBeenCalled();
+
+    const res2 = await service.importMapFunction("", null);
+    expect(res2).toBeUndefined();
+    expect(mockGeoService.lookup).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/features/location/location.datatype.spec.ts
+++ b/src/app/features/location/location.datatype.spec.ts
@@ -67,11 +67,11 @@ describe("Schema data type: location", () => {
   });
 
   it("should not lookup empty address when importing", async () => {
-    const res1 = await service.importMapFunction(undefined, null);
+    const res1 = await service.importMapFunction(undefined);
     expect(res1).toBeUndefined();
     expect(mockGeoService.lookup).not.toHaveBeenCalled();
 
-    const res2 = await service.importMapFunction("", null);
+    const res2 = await service.importMapFunction("");
     expect(res2).toBeUndefined();
     expect(mockGeoService.lookup).not.toHaveBeenCalled();
   });

--- a/src/app/features/location/location.datatype.spec.ts
+++ b/src/app/features/location/location.datatype.spec.ts
@@ -27,7 +27,7 @@ describe("Schema data type: location", () => {
   ) {
     mockGeoService.lookup.and.returnValue(of(mockedLookup));
 
-    const actualResult = await service.importMapFunction(importedValue, null);
+    const actualResult = await service.importMapFunction(importedValue);
 
     expect(mockGeoService.lookup).toHaveBeenCalledWith(importedValue);
     expect(actualResult).toEqual(expectedResult);

--- a/src/app/features/location/location.datatype.ts
+++ b/src/app/features/location/location.datatype.ts
@@ -1,9 +1,29 @@
 import { DefaultDatatype } from "../../core/entity/schema/default.datatype";
 import { Injectable } from "@angular/core";
+import { EntitySchemaField } from "../../core/entity/schema/entity-schema-field";
+import { GeoResult, GeoService } from "./geo.service";
+import { lastValueFrom } from "rxjs";
 
 @Injectable()
-export class LocationDatatype extends DefaultDatatype {
+export class LocationDatatype extends DefaultDatatype<GeoResult, GeoResult> {
   static dataType = "location";
   editComponent = "EditLocation";
   viewComponent = "ViewLocation";
+
+  constructor(private geoService: GeoService) {
+    super();
+  }
+
+  async importMapFunction(
+    val: any,
+    schemaField: EntitySchemaField,
+    additional?: any,
+  ): Promise<any> {
+    if (!val) {
+      return undefined;
+    }
+
+    const geoResults = await lastValueFrom(this.geoService.lookup(val));
+    return geoResults[0];
+  }
 }

--- a/src/app/features/location/location.datatype.ts
+++ b/src/app/features/location/location.datatype.ts
@@ -16,9 +16,7 @@ export class LocationDatatype extends DefaultDatatype<GeoResult, GeoResult> {
 
   async importMapFunction(
     val: any,
-    schemaField: EntitySchemaField,
-    additional?: any,
-  ): Promise<any> {
+  ): Promise<GeoResult> {
     if (!val) {
       return undefined;
     }


### PR DESCRIPTION
closes #1957 

Implemented basic use case without a configuration UI or user feedback. Looking into #1844 to enable any address information to be imported without data loss.