### PR TITLE
fix(forms): display label for photo fields

### DIFF
--- a/src/app/child-dev-project/children/model/child.ts
+++ b/src/app/child-dev-project/children/model/child.ts
@@ -109,7 +109,7 @@ export class Child extends Entity {
 
   @DatabaseField({
     dataType: "file",
-    label: $localize`:Label for the filename of a photo of a child:Photo Filename`,
+    label: $localize`:Label for the file field of a photo of a child:Photo`,
     editComponent: "EditPhoto",
   })
   photo: string;

--- a/src/app/features/file/edit-photo/edit-photo.component.html
+++ b/src/app/features/file/edit-photo/edit-photo.component.html
@@ -1,18 +1,8 @@
-<input
-  type="file"
-  style="display: none"
-  (change)="onFileSelected($event.target['files'][0])"
-  accept="image/*"
-  #fileUpload
-/>
-<img
-  [src]="imgPath"
-  alt="Image"
-  class="image"
-  (click)="openPopup()"
-/>
+<img [src]="imgPath" alt="Image" class="image" (click)="openPopup()" />
+
 <div class="img-controls">
-  <p>{{ label }}</p>
+  <label class="img-label">{{ label }}</label>
+
   <button
     *ngIf="formControl.value && formControl.enabled"
     type="button"
@@ -33,4 +23,11 @@
   >
     <fa-icon icon="upload"></fa-icon>
   </button>
+  <input
+    type="file"
+    style="display: none"
+    (change)="onFileSelected($event.target['files'][0])"
+    accept="image/*"
+    #fileUpload
+  />
 </div>

--- a/src/app/features/file/edit-photo/edit-photo.component.html
+++ b/src/app/features/file/edit-photo/edit-photo.component.html
@@ -5,13 +5,22 @@
   accept="image/*"
   #fileUpload
 />
-<img
-  [src]="imgPath"
-  alt="profile photo"
-  class="child-pic"
-  (click)="openPopup()"
-/>
-<div>
+
+<mat-form-field
+  floatLabel="always"
+  [class.form-field-disabled]="!formControl.enabled"
+>
+  <mat-label>{{ label }}</mat-label>
+
+  <img
+    [src]="imgPath"
+    alt="profile photo"
+    class="image"
+    (click)="openPopup()"
+  />
+  <input matInput readonly style="display: none" [formControl]="formControl" />
+
+  <!-- edit mode -->
   <button
     *ngIf="formControl.value && formControl.enabled"
     type="button"
@@ -32,4 +41,8 @@
   >
     <fa-icon icon="upload"></fa-icon>
   </button>
-</div>
+
+  <mat-error>
+    <app-error-hint [form]="formControl"></app-error-hint>
+  </mat-error>
+</mat-form-field>

--- a/src/app/features/file/edit-photo/edit-photo.component.html
+++ b/src/app/features/file/edit-photo/edit-photo.component.html
@@ -5,22 +5,14 @@
   accept="image/*"
   #fileUpload
 />
-
-<mat-form-field
-  floatLabel="always"
-  [class.form-field-disabled]="!formControl.enabled"
->
-  <mat-label>{{ label }}</mat-label>
-
-  <img
-    [src]="imgPath"
-    alt="profile photo"
-    class="image"
-    (click)="openPopup()"
-  />
-  <input matInput readonly style="display: none" [formControl]="formControl" />
-
-  <!-- edit mode -->
+<img
+  [src]="imgPath"
+  alt="Image"
+  class="image"
+  (click)="openPopup()"
+/>
+<div class="img-controls">
+  <p>{{ label }}</p>
   <button
     *ngIf="formControl.value && formControl.enabled"
     type="button"
@@ -41,8 +33,4 @@
   >
     <fa-icon icon="upload"></fa-icon>
   </button>
-
-  <mat-error>
-    <app-error-hint [form]="formControl"></app-error-hint>
-  </mat-error>
-</mat-form-field>
+</div>

--- a/src/app/features/file/edit-photo/edit-photo.component.scss
+++ b/src/app/features/file/edit-photo/edit-photo.component.scss
@@ -19,3 +19,8 @@
   align-items: end;
   height: 48px;
 }
+
+.img-label {
+  margin: auto;
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/features/file/edit-photo/edit-photo.component.scss
+++ b/src/app/features/file/edit-photo/edit-photo.component.scss
@@ -1,13 +1,14 @@
-.child-pic {
+.image {
   width: 150px;
   height: 150px;
   border-radius: 50%;
   object-fit: cover;
   cursor: pointer;
+  background: lightgrey;
+  display: block;
 }
 
-:host {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+:host .form-field-disabled ::ng-deep .mat-mdc-text-field-wrapper {
+  // hide form-field bottom line if not in edit mode
+  --mdc-filled-text-field-active-indicator-height: 0;
 }

--- a/src/app/features/file/edit-photo/edit-photo.component.scss
+++ b/src/app/features/file/edit-photo/edit-photo.component.scss
@@ -1,3 +1,9 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .image {
   width: 150px;
   height: 150px;
@@ -8,7 +14,8 @@
   display: block;
 }
 
-:host .form-field-disabled ::ng-deep .mat-mdc-text-field-wrapper {
-  // hide form-field bottom line if not in edit mode
-  --mdc-filled-text-field-active-indicator-height: 0;
+.img-controls {
+  display: flex;
+  align-items: end;
+  height: 48px;
 }

--- a/src/app/features/file/edit-photo/edit-photo.component.ts
+++ b/src/app/features/file/edit-photo/edit-photo.component.ts
@@ -13,13 +13,27 @@ import { MatButtonModule } from "@angular/material/button";
 import { resizeImage } from "../file-utils";
 import { MatDialog } from "@angular/material/dialog";
 import { ImagePopupComponent } from "./image-popup/image-popup.component";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { ReactiveFormsModule } from "@angular/forms";
+import { ErrorHintComponent } from "../../../core/common-components/error-hint/error-hint.component";
 
 @DynamicComponent("EditPhoto")
 @Component({
   selector: "app-edit-photo",
   templateUrl: "./edit-photo.component.html",
   styleUrls: ["./edit-photo.component.scss"],
-  imports: [MatButtonModule, MatTooltipModule, FontAwesomeModule, NgIf],
+  imports: [
+    MatButtonModule,
+    MatTooltipModule,
+    FontAwesomeModule,
+    NgIf,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule,
+    EditFileComponent,
+    ErrorHintComponent,
+  ],
   standalone: true,
 })
 export class EditPhotoComponent extends EditFileComponent implements OnInit {

--- a/src/app/features/file/edit-photo/edit-photo.component.ts
+++ b/src/app/features/file/edit-photo/edit-photo.component.ts
@@ -13,27 +13,13 @@ import { MatButtonModule } from "@angular/material/button";
 import { resizeImage } from "../file-utils";
 import { MatDialog } from "@angular/material/dialog";
 import { ImagePopupComponent } from "./image-popup/image-popup.component";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
-import { ReactiveFormsModule } from "@angular/forms";
-import { ErrorHintComponent } from "../../../core/common-components/error-hint/error-hint.component";
 
 @DynamicComponent("EditPhoto")
 @Component({
   selector: "app-edit-photo",
   templateUrl: "./edit-photo.component.html",
   styleUrls: ["./edit-photo.component.scss"],
-  imports: [
-    MatButtonModule,
-    MatTooltipModule,
-    FontAwesomeModule,
-    NgIf,
-    MatFormFieldModule,
-    MatInputModule,
-    ReactiveFormsModule,
-    EditFileComponent,
-    ErrorHintComponent,
-  ],
+  imports: [MatButtonModule, MatTooltipModule, FontAwesomeModule, NgIf],
   standalone: true,
 })
 export class EditPhotoComponent extends EditFileComponent implements OnInit {


### PR DESCRIPTION
The photo field until now did not display any form-field label. This is becoming an issue as the field is more widely used and there are forms with multiple photo fields.

- photo field has a label like any other field now
- I failed to keep the image centered within form-field, but the left bound layout also looks fairly clean and consistent now in my opinion.