### PR TITLE
Added call of blur() in basic-autocomplete

### DIFF
--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.ts
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.ts
@@ -235,6 +235,7 @@ export class BasicAutocompleteComponent<O, V = O>
       this.showAutocomplete();
     } else {
       this.value = option.asValue;
+      this.blur();
     }
   }
 


### PR DESCRIPTION
closes: #1939

### Visible/Frontend Changes
- When hitting enter after selecting an option from the dropdown menu, the input field looses its focus. This also is the case when selecting an option with the mouse.