### PR TITLE
fix(filters): "false" option of boolean filters includes undefined

### DIFF
--- a/src/app/core/filter/filter/filter.component.spec.ts
+++ b/src/app/core/filter/filter/filter.component.spec.ts
@@ -7,15 +7,11 @@ import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
 import { HarnessLoader } from "@angular/cdk/testing";
 import { MatSelectHarness } from "@angular/material/select/testing";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
-import { BooleanFilterConfig } from "../../entity-list/EntityListConfig";
-import { Entity } from "../../entity/model/entity";
-import { FilterService } from "../filter.service";
 
 describe("FilterComponent", () => {
   let component: FilterComponent;
   let fixture: ComponentFixture<FilterComponent>;
   let loader: HarnessLoader;
-  let filterService: FilterService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -26,8 +22,6 @@ describe("FilterComponent", () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
     fixture.detectChanges();
-
-    filterService = TestBed.inject(FilterService);
   });
 
   it("should create", () => {
@@ -60,59 +54,4 @@ describe("FilterComponent", () => {
     expect(selected).toEqual(t1.label);
     expect(component.filterObj).toEqual({ "category.id": t1.id } as any);
   });
-
-  it("should support a boolean filter", async () => {
-    class EntityWithBooleanFlag extends Entity {
-      value: boolean;
-
-      static create(value: boolean) {
-        const e = new EntityWithBooleanFlag();
-        e.value = value;
-        return e;
-      }
-    }
-
-    const recordFalse = EntityWithBooleanFlag.create(false);
-    const recordTrue = EntityWithBooleanFlag.create(true);
-    const recordUndefined = new EntityWithBooleanFlag();
-    component.entities = [recordFalse, recordTrue, recordUndefined];
-    component.entityType = EntityWithBooleanFlag;
-    component.filterConfig = [
-      {
-        id: "value",
-        type: "boolean",
-        default: "true",
-        true: "is true",
-        false: "is not true",
-        all: "All",
-      } as BooleanFilterConfig,
-    ];
-
-    await component.ngOnChanges({ filterConfig: true } as any);
-
-    const selection = await loader.getHarness(MatSelectHarness);
-    let selected = await selection.getValueText();
-    expect(selected).toBe("is true");
-    testFilter(component.filterObj, component.entities, [recordTrue]);
-
-    await selection.open();
-    const options = await selection.getOptions();
-    const falseOption = options[2];
-    const label = await falseOption.getText();
-    expect(label).toBe("is not true");
-
-    await falseOption.click();
-    selected = await selection.getValueText();
-    expect(selected).toBe("is not true");
-    testFilter(component.filterObj, component.entities, [
-      recordFalse,
-      recordUndefined,
-    ]);
-  });
-
-  function testFilter(filterObj, entities, expectedFilteredResult) {
-    const filterPred = filterService.getFilterPredicate(filterObj);
-    const filtered = entities.filter(filterPred);
-    expect(filtered).toEqual(expectedFilteredResult);
-  }
 });

--- a/src/app/core/filter/filters/filters.spec.ts
+++ b/src/app/core/filter/filters/filters.spec.ts
@@ -1,8 +1,20 @@
-import { SelectableFilter } from "./filters";
+import { BooleanFilter, Filter, SelectableFilter } from "./filters";
 import { FilterService } from "../filter.service";
 
 describe("Filters", () => {
   const filterService = new FilterService(undefined);
+
+  function testFilter(
+    filterObj: Filter<any>,
+    testData: any[],
+    expectedFilteredResult: any[],
+  ) {
+    const filterPred = filterService.getFilterPredicate(filterObj.getFilter());
+    const filtered = testData.filter(filterPred);
+    expect(filtered).toEqual(expectedFilteredResult);
+    return filtered;
+  }
+
   it("create an instance", () => {
     const fs = new SelectableFilter(
       "",
@@ -24,15 +36,49 @@ describe("Filters", () => {
 
     expect(fs.options).toHaveSize(keys.length + 1);
 
+    fs.selectedOption = "x";
+
     const testData = [
       { id: 1, category: "x" },
       { id: 2, category: "y" },
-    ] as any;
-    fs.selectedOption = "x";
-    const predicate = filterService.getFilterPredicate(fs.getFilter());
-    const filteredData = testData.filter(predicate);
-
-    expect(filteredData).toHaveSize(1);
+    ];
+    const filteredData = testFilter(fs, testData, [testData[0]]);
     expect(filteredData[0].category).toBe("x");
+  });
+
+  it("should support a boolean filter", async () => {
+    const filter = new BooleanFilter("Boolean Filter", "My Filter", {
+      id: "value",
+      type: "boolean",
+      default: "true",
+      true: "is true",
+      false: "is not true",
+      all: "All",
+    });
+
+    const recordTrue = { value: true };
+    const recordFalse = { value: false };
+    const recordUndefined = {};
+
+    filter.selectedOption = "true";
+    testFilter(
+      filter,
+      [recordFalse, recordTrue, recordUndefined],
+      [recordTrue],
+    );
+
+    filter.selectedOption = "false";
+    testFilter(
+      filter,
+      [recordFalse, recordTrue, recordUndefined],
+      [recordFalse, recordUndefined],
+    );
+
+    filter.selectedOption = "all";
+    testFilter(
+      filter,
+      [recordFalse, recordTrue, recordUndefined],
+      [recordFalse, recordTrue, recordUndefined],
+    );
   });
 });

--- a/src/app/core/filter/filters/filters.ts
+++ b/src/app/core/filter/filters/filters.ts
@@ -202,7 +202,7 @@ export class BooleanFilter<T extends Entity> extends SelectableFilter<T> {
           key: "false",
           label:
             config.false ?? $localize`:Filter label default boolean true:No`,
-          filter: { [config.id]: false },
+          filter: { $or: [{ [config.id]: false }, { [config.id]: undefined }] },
         },
       ],
       label,


### PR DESCRIPTION
so that entities for which the user has not touched a checkbox field (leaving it unchecked) are correctly included

:warning: mark commit for @codo-mentoring 