### PR TITLE
fix: range background color in date picker

### DIFF
--- a/src/styles/mdc_overwrites/mdc_overwrites.scss
+++ b/src/styles/mdc_overwrites/mdc_overwrites.scss
@@ -25,3 +25,8 @@
 .mdc-checkbox .mdc-checkbox__native-control:enabled~.mdc-checkbox__background .mdc-checkbox__checkmark {
   --mdc-checkbox-selected-checkmark-color: #{mat.get-contrast-color-from-palette(theme.$accent, A200)} !important
 }
+
+// Color for selected date range in date picker defaults to white
+.mat-calendar-body-in-range::before {
+  --mat-datepicker-calendar-date-in-range-state-background-color: #{color-mix(in srgb, mat.get-color-from-palette(theme.$primary, 500), transparent 80%)} !important;
+}


### PR DESCRIPTION
The date range picker does not highlight the selected range anymore.
