### PR TITLE
fix: app is reloaded if unrecoverable state is detected

### DIFF
--- a/src/app/core/ui/latest-changes/update-manager.service.ts
+++ b/src/app/core/ui/latest-changes/update-manager.service.ts
@@ -43,6 +43,10 @@ export class UpdateManagerService {
     private latestChangesDialogService: LatestChangesDialogService,
     @Inject(LOCATION_TOKEN) private location: Location,
   ) {
+    this.updates.unrecoverable.subscribe((err) => {
+      this.logger.error("App is in unrecoverable state: " + err.reason);
+      this.location.reload();
+    });
     const currentVersion = window.localStorage.getItem(
       LatestChangesDialogService.VERSION_KEY,
     );


### PR DESCRIPTION
See [this post](https://stackoverflow.com/q/69717382/10713841).
The `ChunkLoadError` might result from unrecoverable states of the service worker. With this solution the app is immediately reloaded if this is detected.
