### PR TITLE
test(e2e): disable regularly failing e2e test

### DIFF
--- a/e2e/integration/RecordingAttendanceOfChild.cy.ts
+++ b/e2e/integration/RecordingAttendanceOfChild.cy.ts
@@ -1,4 +1,4 @@
-describe("Scenario: Recording attendance of a child - E2E test", function () {
+xdescribe("Scenario: Recording attendance of a child - E2E test", function () {
   before("GIVEN A specific child is attending a specific class", function () {
     cy.visit("");
     cy.get(`[ng-reflect-angulartics-label="Attendance"]`).click();


### PR DESCRIPTION
the whole app bootstrap including generation of indices for attendance view may just be too slow and extensive to make this work reliably. For now, we need to get a reliable CI pipeline again, so I would disable this e2e test (we anyways don't have good e2e coverage)