### PR TITLE
fix(dashboard): attendance weeks only start from Monday correctly

### DIFF
--- a/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.spec.ts
+++ b/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.spec.ts
@@ -105,19 +105,19 @@ describe("AttendanceWeekDashboardComponent", () => {
     // default case: last week monday till saturday
 
     // on Monday, that's the first day of the current period
-    MockDate.set(new Date("2023-11-20"));
+    MockDate.set(moment("2023-11-20").toDate());
     const mondayLastWeek = moment("2023-11-13");
     const saturdayLastWeek = moment("2023-11-18");
     expectTimePeriodCalled(mondayLastWeek, saturdayLastWeek);
 
     // on Sunday, that's the still the last day of the currently ending period
-    MockDate.set(new Date("2023-11-26"));
+    MockDate.set(moment("2023-11-26").toDate());
     const mondayLastWeek2 = moment("2023-11-13");
     const saturdayLastWeek2 = moment("2023-11-18");
     expectTimePeriodCalled(mondayLastWeek2, saturdayLastWeek2);
 
     // with offset: this week monday till saturday
-    MockDate.set(new Date("2023-11-20"));
+    MockDate.set(moment("2023-11-20").toDate());
     const mondayThisWeek = moment("2023-11-20");
     const saturdayThisWeek = moment("2023-11-25");
     component.daysOffset = 7;

--- a/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.spec.ts
+++ b/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.spec.ts
@@ -10,6 +10,7 @@ import { ActivityAttendance } from "../../model/activity-attendance";
 import { AttendanceService } from "../../attendance.service";
 import { RecurringActivity } from "../../model/recurring-activity";
 import moment from "moment";
+import * as MockDate from "mockdate";
 
 describe("AttendanceWeekDashboardComponent", () => {
   let component: AttendanceWeekDashboardComponent;
@@ -90,28 +91,38 @@ describe("AttendanceWeekDashboardComponent", () => {
     ]);
   });
 
+  function expectTimePeriodCalled(from: moment.Moment, to: moment.Moment) {
+    mockAttendanceService.getAllActivityAttendancesForPeriod.calls.reset();
+
+    component.ngOnInit();
+
+    expect(
+      mockAttendanceService.getAllActivityAttendancesForPeriod,
+    ).toHaveBeenCalledWith(from.toDate(), to.toDate());
+  }
+
   it("should correctly use the offset", () => {
     // default case: last week monday till saturday
-    const mondayLastWeek = moment().startOf("isoWeek").subtract(7, "days");
-    const saturdayLastWeek = mondayLastWeek.clone().add("5", "days");
-    mockAttendanceService.getAllActivityAttendancesForPeriod.calls.reset();
 
-    component.ngOnInit();
+    // on Monday, that's the first day of the current period
+    MockDate.set(new Date("2023-11-20"));
+    const mondayLastWeek = moment("2023-11-13");
+    const saturdayLastWeek = moment("2023-11-18");
+    expectTimePeriodCalled(mondayLastWeek, saturdayLastWeek);
 
-    expect(
-      mockAttendanceService.getAllActivityAttendancesForPeriod,
-    ).toHaveBeenCalledWith(mondayLastWeek.toDate(), saturdayLastWeek.toDate());
+    // on Sunday, that's the still the last day of the currently ending period
+    MockDate.set(new Date("2023-11-26"));
+    const mondayLastWeek2 = moment("2023-11-13");
+    const saturdayLastWeek2 = moment("2023-11-18");
+    expectTimePeriodCalled(mondayLastWeek2, saturdayLastWeek2);
 
     // with offset: this week monday till saturday
-    const mondayThisWeek = moment().startOf("isoWeek");
-    const saturdayThisWeek = mondayThisWeek.clone().add(5, "days");
-    mockAttendanceService.getAllActivityAttendancesForPeriod.calls.reset();
-
+    MockDate.set(new Date("2023-11-20"));
+    const mondayThisWeek = moment("2023-11-20");
+    const saturdayThisWeek = moment("2023-11-25");
     component.daysOffset = 7;
-    component.ngOnInit();
+    expectTimePeriodCalled(mondayThisWeek, saturdayThisWeek);
 
-    expect(
-      mockAttendanceService.getAllActivityAttendancesForPeriod,
-    ).toHaveBeenCalledWith(mondayThisWeek.toDate(), saturdayThisWeek.toDate());
+    MockDate.reset();
   });
 });

--- a/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.ts
+++ b/src/app/child-dev-project/attendance/dashboard-widgets/attendance-week-dashboard/attendance-week-dashboard.component.ts
@@ -99,22 +99,16 @@ export class AttendanceWeekDashboardComponent implements OnInit, AfterViewInit {
   }
 
   private async loadAttendanceOfAbsentees() {
-    const today = new Date();
-    const previousMonday = new Date(
-      today.getFullYear(),
-      today.getMonth(),
-      today.getDate() - (6 - today.getDay() + 7) + this.daysOffset,
-    );
-    const previousSaturday = new Date(
-      previousMonday.getFullYear(),
-      previousMonday.getMonth(),
-      previousMonday.getDate() + 5,
-    );
+    const previousMonday = moment()
+      .startOf("isoWeek")
+      .subtract(1, "week")
+      .add(this.daysOffset, "days");
+    const previousSaturday = moment(previousMonday).add(5, "days");
 
     const activityAttendances =
       await this.attendanceService.getAllActivityAttendancesForPeriod(
-        previousMonday,
-        previousSaturday,
+        previousMonday.toDate(),
+        previousSaturday.toDate(),
       );
     const lowAttendanceCases = new Set<string>();
     const records: AttendanceWeekRow[] = [];

--- a/src/app/core/common-components/entity-form/entity-form.service.spec.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.spec.ts
@@ -173,7 +173,7 @@ describe("EntityFormService", () => {
 
     schema.defaultValue = PLACEHOLDERS.NOW;
     form = service.createFormGroup([{ id: "test" }], new Entity());
-    expect(form.get("test")).toHaveValue(new Date());
+    expect(form.get("test").value).toEqual(new Date());
 
     schema.defaultValue = PLACEHOLDERS.CURRENT_USER;
     form = service.createFormGroup([{ id: "test" }], new Entity());


### PR DESCRIPTION
Somehow I am too stupid to get this right. This is the second try after initially tests had failed when running on Sundays ...
Please double-check, @TheSlimvReal 