### PR TITLE
fix: clicking filename does not open file twice

### DIFF
--- a/src/app/features/file/edit-file/edit-file.component.html
+++ b/src/app/features/file/edit-file/edit-file.component.html
@@ -17,17 +17,16 @@
     [formControl]="formControl"
     i18n-placeholder="placeholder for file-input"
     placeholder="No file selected"
-    (click)="formClicked(true)"
     i18n-matTooltip="Tooltip show file"
     matTooltip="Show file"
-    [matTooltipDisabled]="!formControl.value"
+    [matTooltipDisabled]="!(initialValue && formControl.value === initialValue)"
   />
   <button
     *ngIf="formControl.value && formControl.enabled"
     type="button"
     mat-icon-button
     matIconSuffix
-    (click)="delete()"
+    (click)="delete(); $event.stopPropagation()"
     i18n-mattooltip="Tooltip remove file"
     matTooltip="Remove file"
   >
@@ -38,7 +37,7 @@
     type="button"
     mat-icon-button
     matIconSuffix
-    (click)="fileUpload.click()"
+    (click)="fileUpload.click(); $event.stopPropagation()"
     i18n-matTooltip="Tooltip upload file button"
     matTooltip="Upload file"
   >

--- a/src/app/features/file/edit-file/edit-file.component.ts
+++ b/src/app/features/file/edit-file/edit-file.component.ts
@@ -41,7 +41,7 @@ export class EditFileComponent extends EditComponent<string> implements OnInit {
   @ViewChild("fileUpload") fileUploadInput: ElementRef<HTMLInputElement>;
   private selectedFile: File;
   private removeClicked = false;
-  private initialValue: string;
+  initialValue: string;
 
   constructor(
     protected fileService: FileService,
@@ -104,10 +104,10 @@ export class EditFileComponent extends EditComponent<string> implements OnInit {
     return this.entityMapper.save(this.entity);
   }
 
-  formClicked(isInputElement?: boolean) {
+  formClicked() {
     if (this.initialValue && this.formControl.value === this.initialValue) {
       this.showFile();
-    } else if (isInputElement) {
+    } else {
       this.fileUploadInput.nativeElement.click();
     }
   }


### PR DESCRIPTION
When a file has been uploaded and the file name is clicked while in edit mode, then the file is opened twice. This is because the event is caught multiple times.
