### PR TITLE
refactor(core): change FormConfig structure to use .fieldGroups instead of .cols and .headers

### DIFF
--- a/src/app/child-dev-project/notes/note-details/note-details.component.html
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.html
@@ -30,33 +30,19 @@
       class="mat-elevation-z2 flex-column gap-small padding-small margin-bottom-regular"
     >
       <div class="middle-form-field">
-        <ng-container
-          [appDynamicComponent]="{
-            component: middleForm[0].edit,
-            config: {
-              formFieldConfig: middleForm[0],
-              propertySchema: entity.getSchema().get(middleForm[0].id),
-              formControl: form.get(middleForm[0].id),
-              entity: entity
-            }
-          }"
-        >
-        </ng-container>
+        <app-form-field
+          [field]="middleForm[0]"
+          [entity]="entity"
+          [form]="form"
+        ></app-form-field>
       </div>
 
       <div class="textarea middle-form-field">
-        <ng-container
-          [appDynamicComponent]="{
-            component: middleForm[1].edit,
-            config: {
-              formFieldConfig: middleForm[1],
-              propertySchema: entity.getSchema().get(middleForm[1].id),
-              formControl: form.get(middleForm[1].id),
-              entity: entity
-            }
-          }"
-        >
-        </ng-container>
+        <app-form-field
+          [field]="middleForm[1]"
+          [entity]="entity"
+          [form]="form"
+        ></app-form-field>
       </div>
     </div>
 

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -27,6 +27,7 @@ import { MAT_DIALOG_DATA, MatDialogModule } from "@angular/material/dialog";
 import { DialogButtonsComponent } from "../../../core/form-dialog/dialog-buttons/dialog-buttons.component";
 import { DialogCloseComponent } from "../../../core/common-components/dialog-close/dialog-close.component";
 import { EntityArchivedInfoComponent } from "../../../core/entity-details/entity-archived-info/entity-archived-info.component";
+import { FormFieldComponent } from "../../../core/common-components/entity-form/form-field/form-field.component";
 
 /**
  * Component responsible for displaying the Note creation/view window
@@ -48,6 +49,7 @@ import { EntityArchivedInfoComponent } from "../../../core/entity-details/entity
     MatMenuModule,
     DialogCloseComponent,
     EntityArchivedInfoComponent,
+    FormFieldComponent,
   ],
   standalone: true,
   encapsulation: ViewEncapsulation.None,

--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -18,6 +18,10 @@ import {
   PLACEHOLDERS,
 } from "../../entity/schema/entity-schema-field";
 import { isArrayDataType } from "../../basic-datatypes/datatype-utils";
+import {
+  ColumnConfig,
+  toFormFieldConfig,
+} from "../entity-subrecord/entity-subrecord/entity-subrecord-config";
 
 /**
  * These are utility types that allow to define the type of `FormGroup` the way it is returned by `EntityFormService.create`
@@ -60,27 +64,32 @@ export class EntityFormService {
    * @param forTable
    */
   public extendFormFieldConfig(
-    formFields: FormFieldConfig[],
+    formField: ColumnConfig,
     entityType: EntityConstructor,
     forTable = false,
-  ) {
-    formFields.forEach((formField) => {
-      try {
-        this.addFormFields(formField, entityType, forTable);
-      } catch (err) {
-        throw new Error(
-          `Could not create form config for ${formField.id}: ${err}`,
-        );
-      }
-    });
+  ): FormFieldConfig {
+    const fullField: FormFieldConfig = toFormFieldConfig(formField);
+
+    try {
+      this.addSchemaToFormField(
+        fullField,
+        entityType.schema.get(fullField.id),
+        forTable,
+      );
+    } catch (err) {
+      throw new Error(
+        `Could not create form config for ${fullField.id}: ${err}`,
+      );
+    }
+
+    return fullField;
   }
 
-  private addFormFields(
+  private addSchemaToFormField(
     formField: FormFieldConfig,
-    entityType: EntityConstructor,
+    propertySchema: EntitySchemaField,
     forTable: boolean,
   ) {
-    const propertySchema = entityType.schema.get(formField.id);
     formField.edit =
       formField.edit ||
       this.entitySchemaService.getComponent(propertySchema, "edit");
@@ -101,6 +110,8 @@ export class EntityFormService {
     if (propertySchema?.validators) {
       formField.validators = propertySchema?.validators;
     }
+
+    return formField;
   }
 
   /**
@@ -115,7 +126,9 @@ export class EntityFormService {
     entity: T,
     forTable = false,
   ): EntityForm<T> {
-    this.extendFormFieldConfig(formFields, entity.getConstructor(), forTable);
+    formFields = formFields.map((f) =>
+      this.extendFormFieldConfig(f, entity.getConstructor(), forTable),
+    );
     const formConfig = {};
     const entitySchema = entity.getSchema();
     const copy = entity.copy();

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
@@ -2,21 +2,11 @@
   <div *ngFor="let col of columns; let i = index" class="entity-form-cell">
     <h2 *ngIf="columnHeaders?.[i]">{{ columnHeaders[i] }}</h2>
     <div *ngFor="let row of col">
-      <div [class.field-with-tooltip-suffix]="row.tooltip">
-        <ng-container
-          [appDynamicComponent]="{
-            component: row.edit,
-            config: {
-              formFieldConfig: row,
-              propertySchema: entity.getSchema().get(row.id),
-              formControl: form.get(row.id),
-              entity: entity
-            }
-          }"
-        >
-        </ng-container>
-      </div>
-      <app-help-button [text]="row.tooltip"></app-help-button>
+      <app-form-field
+        [field]="row"
+        [entity]="entity"
+        [form]="form"
+      ></app-form-field>
     </div>
   </div>
 </form>

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
@@ -6,17 +6,16 @@ import {
   ViewEncapsulation,
 } from "@angular/core";
 import { Entity } from "../../../entity/model/entity";
-import { FormFieldConfig } from "./FormConfig";
 import { EntityForm } from "../entity-form.service";
 import { EntityMapperService } from "../../../entity/entity-mapper/entity-mapper.service";
 import { filter } from "rxjs/operators";
 import { ConfirmationDialogService } from "../../confirmation-dialog/confirmation-dialog.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NgClass, NgForOf, NgIf } from "@angular/common";
-import { DynamicComponentDirective } from "../../../config/dynamic-components/dynamic-component.directive";
 import { Subscription } from "rxjs";
 import moment from "moment";
-import { HelpButtonComponent } from "../../help-button/help-button.component";
+import { FormFieldComponent } from "../form-field/form-field.component";
+import { ColumnConfig } from "../../entity-subrecord/entity-subrecord/entity-subrecord-config";
 
 /**
  * A general purpose form component for displaying and editing entities.
@@ -35,24 +34,18 @@ import { HelpButtonComponent } from "../../help-button/help-button.component";
   // Use no encapsulation because we want to change the value of children (the mat-form-fields that are
   // dynamically created)
   encapsulation: ViewEncapsulation.None,
-  imports: [
-    NgForOf,
-    DynamicComponentDirective,
-    NgIf,
-    NgClass,
-    HelpButtonComponent,
-  ],
+  imports: [NgForOf, NgIf, NgClass, FormFieldComponent],
   standalone: true,
 })
 export class EntityFormComponent<T extends Entity = Entity>
-  implements OnChanges
+  implements OnChanges, EntityFormConfig
 {
   /**
    * The entity which should be displayed and edited
    */
   @Input() entity: T;
 
-  @Input() columns: FormFieldConfig[][];
+  @Input() columns: ColumnConfig[][];
 
   @Input() columnHeaders?: (string | null)[];
 
@@ -153,4 +146,9 @@ export class EntityFormComponent<T extends Entity = Entity>
       this.form.disable();
     }
   }
+}
+
+export interface EntityFormConfig {
+  columns: ColumnConfig[][];
+  columnHeaders?: (string | null)[];
 }

--- a/src/app/core/common-components/entity-form/form-field/form-field.component.html
+++ b/src/app/core/common-components/entity-form/form-field/form-field.component.html
@@ -1,0 +1,17 @@
+<div *ngIf="_field">
+  <div [class.field-with-tooltip-suffix]="_field.tooltip">
+    <ng-container
+      [appDynamicComponent]="{
+        component: _field.edit,
+        config: {
+          formFieldConfig: _field,
+          propertySchema: entity.getSchema().get(_field.id),
+          formControl: form.get(_field.id),
+          entity: entity
+        }
+      }"
+    >
+    </ng-container>
+  </div>
+  <app-help-button [text]="_field.tooltip"></app-help-button>
+</div>

--- a/src/app/core/common-components/entity-form/form-field/form-field.component.spec.ts
+++ b/src/app/core/common-components/entity-form/form-field/form-field.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormFieldComponent } from './form-field.component';
+
+describe('FormFieldComponent', () => {
+  let component: FormFieldComponent;
+  let fixture: ComponentFixture<FormFieldComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormFieldComponent]
+    });
+    fixture = TestBed.createComponent(FormFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/common-components/entity-form/form-field/form-field.component.ts
+++ b/src/app/core/common-components/entity-form/form-field/form-field.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
+import { DynamicComponentDirective } from "../../../config/dynamic-components/dynamic-component.directive";
+import { HelpButtonComponent } from "../../help-button/help-button.component";
+import { Entity } from "../../../entity/model/entity";
+import { EntityForm, EntityFormService } from "../entity-form.service";
+import { ColumnConfig } from "../../entity-subrecord/entity-subrecord/entity-subrecord-config";
+import { FormFieldConfig } from "../entity-form/FormConfig";
+import { NgIf } from "@angular/common";
+
+/**
+ * Generic component to display one form field (editComponent) of an entity.
+ *
+ * Dynamically extends field details from entity schema and loads the relevant, specific EditComponent implementation.
+ */
+@Component({
+  selector: "app-form-field",
+  templateUrl: "./form-field.component.html",
+  styleUrls: ["./form-field.component.scss"],
+  standalone: true,
+  imports: [DynamicComponentDirective, HelpButtonComponent, NgIf],
+})
+export class FormFieldComponent<T extends Entity> implements OnChanges {
+  /** field id or full config */
+  @Input() field: ColumnConfig;
+  /** full field config extended from schema (used internally and for template) */
+  _field: FormFieldConfig;
+
+  @Input() entity: T;
+  @Input() form: EntityForm<T>;
+
+  constructor(private entityFormService: EntityFormService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.field || changes.entity) {
+      this.updateField();
+    }
+  }
+
+  private updateField() {
+    if (!this.entity?.getConstructor()) {
+      this._field = undefined;
+      return;
+    }
+
+    this._field = this.entityFormService.extendFormFieldConfig(
+      this.field,
+      this.entity.getConstructor(),
+    );
+  }
+}

--- a/src/app/core/common-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
+++ b/src/app/core/common-components/entity-subrecord/entity-subrecord/entity-subrecord.component.ts
@@ -300,10 +300,12 @@ export class EntitySubrecordComponent<T extends Entity> implements OnChanges {
   private initFormGroups() {
     if (this.entityConstructorIsAvailable()) {
       try {
-        this.entityFormService.extendFormFieldConfig(
-          this.filteredColumns,
-          this.getEntityConstructor(),
-          true,
+        this.filteredColumns = this.filteredColumns.map((f) =>
+          this.entityFormService.extendFormFieldConfig(
+            f,
+            this.getEntityConstructor(),
+            true,
+          ),
         );
       } catch (err) {
         this.loggingService.warn(`Error creating form definitions: ${err}`);

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -4,6 +4,8 @@ import { Config } from "./config";
 import { LoggingService } from "../logging/logging.service";
 import { LatestEntityLoader } from "../entity/latest-entity-loader";
 import { shareReplay } from "rxjs/operators";
+import { EntitySchemaField } from "../entity/schema/entity-schema-field";
+import { FieldGroup } from "../entity-details/form/form.component";
 
 /**
  * Access dynamic app configuration retrieved from the database
@@ -35,7 +37,7 @@ export class ConfigService extends LatestEntityLoader<Config> {
   }
 
   public getConfig<T>(id: string): T {
-    return this.currentConfig.data[id];
+    return this.applyMigrations(id, this.currentConfig.data[id]);
   }
 
   public getAllConfigs<T>(prefix: string): T[] {
@@ -46,6 +48,67 @@ export class ConfigService extends LatestEntityLoader<Config> {
         matchingConfigs.push(this.currentConfig.data[id]);
       }
     }
-    return matchingConfigs;
+    return matchingConfigs.map((c) => this.applyMigrations(prefix, c));
   }
+
+  private applyMigrations(id: string, configData: any) {
+    configData = migrateFormHeadersIntoFieldGroups(id, configData);
+    return configData;
+  }
+}
+
+/**
+ * Transform legacy "view:...Form" config format to have form field group headers with the fields rather than as separate array.
+ */
+function migrateFormHeadersIntoFieldGroups(
+  idOrPrefix: string,
+  configData: any,
+) {
+  if (!idOrPrefix.startsWith("view") || !configData) {
+    return configData;
+  }
+
+  const configString = JSON.stringify(configData);
+  if (!configString.includes('"component":"Form"')) {
+    return configData;
+  }
+
+  function migrateFormConfig(formConfig) {
+    if (!formConfig) {
+      return formConfig;
+    }
+
+    // change .cols and .headers into .fieldGroups
+    const newFormConfig = { ...formConfig };
+    delete newFormConfig.cols;
+    delete newFormConfig.headers;
+
+    newFormConfig.fieldGroups = formConfig.cols?.map(
+      (colGroup) => ({ fields: colGroup }) as FieldGroup,
+    );
+    if (formConfig.headers) {
+      newFormConfig.fieldGroups.forEach((group, i) => {
+        if (formConfig.headers[i]) {
+          group.header = formConfig.headers[i];
+        }
+      });
+    }
+
+    return newFormConfig;
+  }
+
+  const newConfig = JSON.parse(
+    JSON.stringify(configData),
+    (_that, rawValue) => {
+      if (rawValue?.component !== "Form") {
+        // do not transform unless config for `{ component: "Form", config: { ... } }` parts
+        return rawValue;
+      }
+
+      rawValue.config = migrateFormConfig(rawValue.config);
+      return rawValue;
+    },
+  );
+
+  return newConfig;
 }

--- a/src/app/core/entity-details/form/form.component.html
+++ b/src/app/core/entity-details/form/form.component.html
@@ -37,7 +37,7 @@
 
 <app-entity-form
   [entity]="entity"
-  [columns]="_cols"
+  [columns]="columns"
   [columnHeaders]="headers"
   [form]="form"
 ></app-entity-form>


### PR DESCRIPTION
To ease the development of the setup wizard (PR #2049 ) this refactors config structure including an on-the-fly migration.

TODO:
- [ ] adapt tests
- [ ] adapt config-fix to new format
- [ ] refactor EntityFormComponent to also use new format

-----
:warning: mark as codo
