### PR TITLE
Query test fix

### DIFF
--- a/src/app/child-dev-project/notes/note-details/note-details.component.spec.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.spec.ts
@@ -4,10 +4,9 @@ import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { Child } from "../../children/model/child";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { defaultAttendanceStatusTypes } from "../../../core/config/default-config/default-attendance-status-types";
+import { NEVER } from "rxjs";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { LoginState } from "../../../core/session/session-states/login-state.enum";
-import { EntityConfigService } from "../../../core/entity/entity-config.service";
-import { NEVER } from "rxjs";
 
 function generateTestNote(forChildren: Child[]) {
   const testNote = Note.create(new Date(), "test note");
@@ -52,7 +51,6 @@ describe("NoteDetailsComponent", () => {
   }));
 
   beforeEach(() => {
-    TestBed.inject(EntityConfigService).setupEntitiesFromConfig();
     fixture = TestBed.createComponent(NoteDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/utils/database-testing.module.ts
+++ b/src/app/utils/database-testing.module.ts
@@ -11,6 +11,7 @@ import { ComponentRegistry } from "../dynamic-components";
 import { ConfigurableEnumService } from "../core/basic-datatypes/configurable-enum/configurable-enum.service";
 import { createTestingConfigurableEnumService } from "../core/basic-datatypes/configurable-enum/configurable-enum-testing";
 import { SwRegistrationOptions } from "@angular/service-worker";
+import { EntityConfigService } from "../core/entity/entity-config.service";
 
 /**
  * Utility module that creates a simple environment where a correctly configured database and session is set up.
@@ -35,7 +36,12 @@ import { SwRegistrationOptions } from "@angular/service-worker";
   ],
 })
 export class DatabaseTestingModule {
-  constructor(pouchDatabase: PouchDatabase, components: ComponentRegistry) {
+  constructor(
+    pouchDatabase: PouchDatabase,
+    components: ComponentRegistry,
+    entityConfigService: EntityConfigService,
+  ) {
+    entityConfigService.setupEntitiesFromConfig();
     environment.session_type = SessionType.mock;
     pouchDatabase.initInMemoryDB();
     components.allowDuplicates();


### PR DESCRIPTION
Some tests in the query service sometimes failed.

This is because the property `religion` is only defined in the config and the config attributes were not applied in the test environment. So in some cases the entity was not set up properly and the queries using this attribute failed.