### PR TITLE
Login not required

### DIFF
--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -37,7 +37,7 @@ export class PermissionEnforcerService {
 
   async enforcePermissionsOnLocalData(userRules: DatabaseRule[]) {
     const userRulesString = JSON.stringify(userRules);
-    if (!this.userRulesChanged(userRulesString)) {
+    if (!this.currentUser.value || !this.userRulesChanged(userRulesString)) {
       return;
     }
     const subjects = this.getSubjectsWithReadRestrictions(userRules);

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -65,7 +65,11 @@ export class LoginComponent implements OnInit {
     public sessionManager: SessionManagerService,
     public loginState: LoginStateSubject,
     public siteSettingsService: SiteSettingsService,
-  ) {}
+  ) {
+    sessionManager
+      .remoteLogin()
+      .then(() => sessionManager.clearRemoteSessionIfNecessary());
+  }
 
   ngOnInit() {
     this.loginState.pipe(untilDestroyed(this)).subscribe((state) => {

--- a/src/app/core/session/session.module.ts
+++ b/src/app/core/session/session.module.ts
@@ -38,13 +38,4 @@ import { KeycloakAngularModule } from "keycloak-angular";
     SyncStateSubject,
   ],
 })
-export class SessionModule {
-  constructor(sessionManager: SessionManagerService) {
-    this.initializeRemoteSession(sessionManager);
-  }
-
-  private async initializeRemoteSession(sessionManager: SessionManagerService) {
-    await sessionManager.remoteLogin();
-    await sessionManager.clearRemoteSessionIfNecessary();
-  }
-}
+export class SessionModule {}


### PR DESCRIPTION
Currently it's not possible to visit the public forms without logging in. This is because I triggered the login process in a module which will always be executed. I moved this now to the login component, so other (public) components can be visited without logging in.
