### PR TITLE
fix: prevent usage of superclass schema

### DIFF
--- a/src/app/core/entity/database-entity-decorator.spec.ts
+++ b/src/app/core/entity/database-entity-decorator.spec.ts
@@ -1,0 +1,11 @@
+import { DatabaseEntity } from "./database-entity.decorator";
+import { Entity } from "./model/entity";
+
+describe("DatabaseEntityDecorator", () => {
+  it("should use a new schema object", () => {
+    @DatabaseEntity("OnlyEntityDecorator")
+    class OnlyEntityDecorator extends Entity {}
+
+    expect(OnlyEntityDecorator.schema).not.toBe(Entity.schema);
+  });
+});

--- a/src/app/core/entity/database-entity.decorator.ts
+++ b/src/app/core/entity/database-entity.decorator.ts
@@ -1,5 +1,6 @@
 import { Entity, EntityConstructor } from "./model/entity";
 import { Registry } from "../config/registry/dynamic-registry";
+import { getEntitySchema } from "./database-field.decorator";
 
 export class EntityRegistry extends Registry<EntityConstructor> {}
 
@@ -27,8 +28,7 @@ export function DatabaseEntity(entityType: string) {
 
     // append parent schema definitions
     const parentConstructor = Object.getPrototypeOf(constructor);
-    parentConstructor.schema.forEach((value, key) =>
-      constructor.schema.set(key, value),
-    );
+    const schema = getEntitySchema(constructor);
+    parentConstructor.schema.forEach((value, key) => schema.set(key, value));
   };
 }

--- a/src/app/core/entity/database-field.decorator.ts
+++ b/src/app/core/entity/database-field.decorator.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { EntitySchemaField } from "./schema/entity-schema-field";
+import { EntitySchema } from "./schema/entity-schema";
 
 /**
  * Decorator (Annotation `@DatabaseField()`) to mark a property of an Entity that should be persisted in the database.
@@ -29,11 +30,18 @@ export function addPropertySchema(
   propertySchema: EntitySchemaField,
 ) {
   target[propertyName] = undefined; // This ensures that the field is not read only
-
-  if (Object.getOwnPropertyDescriptor(target.constructor, "schema") == null) {
-    target.constructor.schema = new Map<string, EntitySchemaField>();
-  }
-  target.constructor.schema.set(propertyName, propertySchema);
-
+  getEntitySchema(target.constructor).set(propertyName, propertySchema);
   return target;
+}
+
+/**
+ * Returns the schema map of this entity (not the superclass).
+ * Creates and assigns a new one if it doesn't exist yet.
+ * @param ctor
+ */
+export function getEntitySchema(ctor): EntitySchema {
+  if (Object.getOwnPropertyDescriptor(ctor, "schema") == null) {
+    ctor.schema = new Map<string, EntitySchemaField>();
+  }
+  return ctor.schema;
 }


### PR DESCRIPTION
If currently only the `@DatabaseEntity` property is used without any property being decorated with `@DatabaseField`, then the schema object from the superclass is used. This results in new properties also being added to the superclass's schema. 