### PR TITLE
Guards fix

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -53,6 +53,7 @@ export const allRoutes: Routes = [
   },
   {
     path: "admin",
+    canActivate: [AuthGuard],
     // add directly without lazy-loading so that Menu can detect permissions for child routes
     children: AdminModule.routes,
   },

--- a/src/app/core/admin/admin.routing.ts
+++ b/src/app/core/admin/admin.routing.ts
@@ -5,7 +5,6 @@ import { ConfigImportComponent } from "../../features/config-setup/config-import
 import { ConflictResolutionListComponent } from "../../features/conflict-resolution/conflict-resolution-list/conflict-resolution-list.component";
 import { UserRoleGuard } from "../permissions/permission-guard/user-role.guard";
 import { EntityPermissionGuard } from "../permissions/permission-guard/entity-permission.guard";
-import { AuthGuard } from "../session/auth.guard";
 
 export const adminRoutes: Routes = [
   {
@@ -24,7 +23,7 @@ export const adminRoutes: Routes = [
       entity: "Config",
       requiredPermissionOperation: "update",
     },
-    canActivate: [AuthGuard, EntityPermissionGuard],
+    canActivate: [EntityPermissionGuard],
   },
 
   {

--- a/src/app/core/permissions/permission-guard/entity-permission.guard.spec.ts
+++ b/src/app/core/permissions/permission-guard/entity-permission.guard.spec.ts
@@ -9,7 +9,7 @@ describe("EntityPermissionGuard", () => {
   let mockAbility: jasmine.SpyObj<EntityAbility>;
 
   beforeEach(() => {
-    mockAbility = jasmine.createSpyObj(["can"]);
+    mockAbility = jasmine.createSpyObj(["can"], { rules: [{}] });
 
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
@@ -25,10 +25,10 @@ describe("EntityPermissionGuard", () => {
     expect(guard).toBeTruthy();
   });
 
-  it("should use ability to check if current user is allowed", () => {
+  it("should use ability to check if current user is allowed", async () => {
     mockAbility.can.and.returnValue(true);
 
-    const result = guard.canActivate({
+    const result = await guard.canActivate({
       routeConfig: { path: "url" },
       data: {
         requiredPermissionOperation: "update",
@@ -40,7 +40,7 @@ describe("EntityPermissionGuard", () => {
     expect(mockAbility.can).toHaveBeenCalledWith("update", "TestEntity");
   });
 
-  it("should navigate to 404 for real navigation requests without permissions", () => {
+  it("should navigate to 404 for real navigation requests without permissions", async () => {
     const router = TestBed.inject(Router);
     spyOn(router, "navigate");
     const route = new ActivatedRouteSnapshot();
@@ -50,14 +50,14 @@ describe("EntityPermissionGuard", () => {
     });
     mockAbility.can.and.returnValue(false);
 
-    guard.canActivate(route);
+    await guard.canActivate(route);
 
     expect(router.navigate).toHaveBeenCalledWith(["/404"]);
   });
 
-  it("should check 'read' permissions if only entity and no operation is set", () => {
+  it("should check 'read' permissions if only entity and no operation is set", async () => {
     mockAbility.can.and.returnValue(true);
-    const result = guard.canActivate({
+    const result = await guard.canActivate({
       routeConfig: { path: "default-operation-config" },
       data: { entity: "Child" },
     } as Partial<ActivatedRouteSnapshot> as ActivatedRouteSnapshot);
@@ -66,8 +66,8 @@ describe("EntityPermissionGuard", () => {
     expect(mockAbility.can).toHaveBeenCalledWith("read", "Child");
   });
 
-  it("should return true as default if no entity or operation are configured", () => {
-    const result = guard.canActivate({
+  it("should return true as default if no entity or operation are configured", async () => {
+    const result = await guard.canActivate({
       routeConfig: { path: "no-permission-config" },
     } as any);
 
@@ -75,7 +75,7 @@ describe("EntityPermissionGuard", () => {
     expect(mockAbility.can).not.toHaveBeenCalled();
   });
 
-  it("should evaluate correct route permissions on 'pre-check' (checkRoutePermissions)", () => {
+  it("should evaluate correct route permissions on 'pre-check' (checkRoutePermissions)", async () => {
     mockAbility.can.and.returnValue(true);
 
     TestBed.inject(Router).config.push({
@@ -83,7 +83,7 @@ describe("EntityPermissionGuard", () => {
       data: { requiredPermissionOperation: "update", entityType: "Child" },
     });
 
-    const result = guard.checkRoutePermissions("check-route/1");
+    const result = await guard.checkRoutePermissions("check-route/1");
 
     expect(result).toBeTrue();
     expect(mockAbility.can).toHaveBeenCalledWith("update", "Child");

--- a/src/app/core/ui/navigation/navigation/navigation.component.spec.ts
+++ b/src/app/core/ui/navigation/navigation/navigation.component.spec.ts
@@ -118,7 +118,7 @@ describe("NavigationComponent", () => {
     ]);
   }));
 
-  it("should add menu items where entity permissions are missing", fakeAsync(() => {
+  it("should not add menu items if entity permissions are missing", fakeAsync(() => {
     const testConfig = {
       items: [
         { name: "Dashboard", icon: "home", link: "/dashboard" },

--- a/src/app/core/ui/navigation/navigation/navigation.component.ts
+++ b/src/app/core/ui/navigation/navigation/navigation.component.ts
@@ -114,12 +114,15 @@ export class NavigationComponent {
   /**
    * Load menu items from config file
    */
-  private initMenuItemsFromConfig() {
+  private async initMenuItemsFromConfig() {
     const config: NavigationMenuConfig =
       this.configService.getConfig<NavigationMenuConfig>(this.CONFIG_ID);
-    this.menuItems = config.items
-      .filter(({ link }) => this.isAccessibleRouteForUser(link))
-      .map(({ name, icon, link }) => new MenuItem(name, icon, link));
+    this.menuItems = [];
+    for (const item of config.items) {
+      if (await this.isAccessibleRouteForUser(item.link)) {
+        this.menuItems.push(new MenuItem(item.name, item.icon, item.link));
+      }
+    }
   }
 
   private isAccessibleRouteForUser(path: string) {

--- a/src/app/core/ui/navigation/navigation/navigation.component.ts
+++ b/src/app/core/ui/navigation/navigation/navigation.component.ts
@@ -117,12 +117,14 @@ export class NavigationComponent {
   private async initMenuItemsFromConfig() {
     const config: NavigationMenuConfig =
       this.configService.getConfig<NavigationMenuConfig>(this.CONFIG_ID);
-    this.menuItems = [];
+    const menuItems = [];
     for (const item of config.items) {
       if (await this.isAccessibleRouteForUser(item.link)) {
-        this.menuItems.push(new MenuItem(item.name, item.icon, item.link));
+        menuItems.push(new MenuItem(item.name, item.icon, item.link));
       }
     }
+    this.menuItems = menuItems;
+    this.activeLink = this.computeActiveLink(location.pathname);
   }
 
   private isAccessibleRouteForUser(path: string) {


### PR DESCRIPTION
closes: #2128 

- [x] `EntityPermissionGuard` waits for some rules to be initialised
- [x] `AuthGuards` needs to always be added before using another guard
