### PR TITLE
some CSP fixes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -88,7 +88,7 @@ ENV CSP_REPORT_URI="https://o167951.ingest.sentry.io/api/1242399/security/"
 # overwrite the Content-Security-Policy rules (report-uri is added automatically)
 ## default includes all required whitelists for production server
 ## to disable any CSP blocking, set to "default-src *  data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval'"
-ENV CSP="default-src 'self' 'unsafe-eval' data: https://*.tile.openstreetmap.org/ https://matomo.aam-digital.org  https://*.aam-digital.com https://api.github.com/repos/Aam-Digital/ https://sentry.io $CSP_REPORT_URI 'sha256-gtzIf+c+ujwirISvjI8lnwlaZwnMkh04eA9ZDBCd8TY='; style-src 'self' 'unsafe-inline'"
+ENV CSP="default-src 'self' 'unsafe-eval' data: blob: https://*.tile.openstreetmap.org/ https://matomo.aam-digital.org  https://*.aam-digital.com https://api.github.com/repos/Aam-Digital/ https://sentry.io $CSP_REPORT_URI 'sha256-0zZPgsifJ8h8aM+gmSxkrfNtAGUZb7ItVug6/j1UR5g='; style-src 'self' 'unsafe-inline'"
 ### 'sha256-gtzIf+c+ujwirISvjI8lnwlaZwnMkh04eA9ZDBCd8TY=' for index.html writing browser details
 ### 'unsafe-eval' required for pouchdb https://github.com/pouchdb/pouchdb/issues/7853#issuecomment-535020600
 

--- a/build/default.conf
+++ b/build/default.conf
@@ -10,7 +10,8 @@ server {
 
     root /usr/share/nginx/html;
 
-    add_header Content-Security-Policy-Report-Only "${CSP}; report-uri ${CSP_REPORT_URI}";
+    add_header Content-Security-Policy-Report-Only "${CSP}; report-uri ${CSP_REPORT_URI}?ngsw-bypass=true";
+    # ?ngsw-bypass prevents angular serviceworker to intercept and break CSP reporting (https://github.com/angular/angular/issues/31477)
 
     # TODO: consider adding `trusted-types angular angular#unsafe-bypass; require-trusted-types-for 'script';` CSP in future
     add_header X-Frame-Options: SAMEORIGIN; # only applies in older browsers, CSP frame-ancestors takes prevalence https://stackoverflow.com/a/40417609/1473411


### PR DESCRIPTION
see #1999 


---
allow blob images and fix angular blocking CSP reports going to sentry

CSP configuration is a huge pain ***  I still somehow couldn't get a new hash for the index.html script. And setting up nginx with nonces also doesn't look trivial ...
