### PR TITLE
fix: navigate to details upon click in "entity-select" form field

### DIFF
--- a/src/app/core/basic-datatypes/entity/display-entity/display-entity.component.html
+++ b/src/app/core/basic-datatypes/entity/display-entity/display-entity.component.html
@@ -15,6 +15,7 @@
     }"
   >
   </ng-container>
+
   <ng-container *ngIf="!entityBlockComponent">
     {{ entityToDisplay?.toString() }}
   </ng-container>

--- a/src/app/core/basic-datatypes/entity/display-entity/display-entity.component.scss
+++ b/src/app/core/basic-datatypes/entity/display-entity/display-entity.component.scss
@@ -1,9 +1,9 @@
 @use "variables/sizes";
 
 .clickable {
+  pointer-events: all;
   cursor: pointer;
 }
-
 .clickable:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
closes #1762

this only fixes the behavior of the "entity-array" fields but through #2175 this will also soon apply to single-select "entity" fields.