### PR TITLE
fix(core): generate valid regex in guard also for wildcard routes

### DIFF
--- a/src/app/core/permissions/permission-guard/abstract-permission.guard.spec.ts
+++ b/src/app/core/permissions/permission-guard/abstract-permission.guard.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from "@angular/core/testing";
+import { Router, Routes } from "@angular/router";
+import { AbstractPermissionGuard } from "./abstract-permission.guard";
+import { Injectable } from "@angular/core";
+import { DynamicComponentConfig } from "../../config/dynamic-components/dynamic-component-config.interface";
+
+@Injectable()
+class TestPermissionGuard extends AbstractPermissionGuard {
+  constructor(router: Router) {
+    super(router);
+  }
+
+  protected async canAccessRoute(
+    routeData: DynamicComponentConfig,
+  ): Promise<boolean> {
+    return routeData?.config;
+  }
+}
+
+describe("EntityPermissionGuard", () => {
+  let guard: TestPermissionGuard;
+
+  let testRoutes: Routes;
+
+  beforeEach(() => {
+    testRoutes = [{ path: "**", data: { config: true } }];
+
+    TestBed.configureTestingModule({
+      providers: [
+        TestPermissionGuard,
+        { provide: Router, useValue: { config: testRoutes } },
+      ],
+    });
+    guard = TestBed.inject(TestPermissionGuard);
+  });
+
+  it("should be created", () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it("should get route config also for '**' path", async () => {
+    const result = await guard.checkRoutePermissions("url");
+
+    expect(result).toBeTrue();
+  });
+});

--- a/src/app/core/permissions/permission-guard/abstract-permission.guard.ts
+++ b/src/app/core/permissions/permission-guard/abstract-permission.guard.ts
@@ -63,6 +63,7 @@ export abstract class AbstractPermissionGuard implements CanActivate {
 
     function isPathMatch(genericPath: string, path: string) {
       const routeRegex = genericPath
+        .replace(/\*/g, ".*") // allow for wildcard routes in regex
         .split("/")
         // replace params with wildcard regex
         .map((part) => (part.startsWith(":") ? "[^/]*" : part))


### PR DESCRIPTION
has caused errors that show up in sentry:
> Invalid regular expression: /^**[/.*]*$/: Nothing to repeat