### PR TITLE
refactor: remove deprecated User fields and functionalities

### DIFF
--- a/src/app/core/entity-list/entity-list/entity-list.stories.ts
+++ b/src/app/core/entity-list/entity-list/entity-list.stories.ts
@@ -7,7 +7,6 @@ import { StorybookBaseModule } from "../../../utils/storybook-base.module";
 import { importProvidersFrom } from "@angular/core";
 
 const user = new User();
-user.paginatorSettingsPageSize["ageprojectNumbernamegendercenterstatus"] = 13;
 
 export default {
   title: "Core/Entities/Entity List",

--- a/src/app/core/user/user.spec.ts
+++ b/src/app/core/user/user.spec.ts
@@ -23,22 +23,5 @@ describe("User", () => {
     _id: "User:tester",
 
     name: "tester",
-    paginatorSettingsPageSize: {},
-  });
-
-  it("should not allow to change the name after initialization and set it as the ID", () => {
-    const user = new User();
-    user.name = "test-name";
-
-    expect(user.name).toBe("test-name");
-    expect(user.getId()).toBe(`${User.ENTITY_TYPE}:test-name`);
-    expect(() => (user.name = "another-name")).toThrowError();
-  });
-
-  it("should not fail when name is actually the same", () => {
-    const user = new User();
-    user.name = "test-name";
-
-    expect(() => (user.name = "test-name")).not.toThrowError();
   });
 });

--- a/src/app/core/user/user.ts
+++ b/src/app/core/user/user.ts
@@ -25,6 +25,8 @@ import { IconName } from "@fortawesome/fontawesome-svg-core";
  *
  * Note that in addition to the User Entity there also is a "regular" CouchDB user with the same name and password
  * in the CouchDB _users database which is used for remote database authentication.
+ *
+ * @Deprecated: This entity type does not provide special functionality anymore and will be replaced by a config-only type in the future
  */
 @DatabaseEntity("User")
 export class User extends Entity {
@@ -39,28 +41,5 @@ export class User extends Entity {
     label: $localize`:Label of username:Username`,
     validators: { required: true, uniqueId: "User" },
   })
-  set name(value: string) {
-    if (this._name && value !== this._name) {
-      // Throwing error if trying to change existing username
-      const label = User.schema.get("name").label;
-      throw new Error(
-        $localize`:Error message when trying to change the username|e.g. username cannot be changed after initialization:${label} cannot be changed after initialization`,
-      );
-    }
-
-    // @ts-ignore allow overwriting of id in this special case, as the name is only given by user editing the form of the new entity
-    this.entityId = value;
-    this._name = value;
-  }
-
-  get name(): string {
-    return this._name;
-  }
-
-  private _name: string;
-
-  /**
-   * This map holds information for the page size settings for different tables in the app
-   */
-  @DatabaseField() paginatorSettingsPageSize: { [id: string]: number } = {};
+  name: string;
 }


### PR DESCRIPTION
remove code from User entity class that is not used anymore since we have separated user account logic from the business logic entities.