### PR TITLE
fix(export): more resilient export queries for uncleaned data

### DIFF
--- a/src/app/core/export/query.service.ts
+++ b/src/app/core/export/query.service.ts
@@ -272,7 +272,7 @@ export class QueryService {
 
     return ids
       .map((id) => {
-        const prefix = id.split(":")[0];
+        const prefix = id?.split(":")[0];
         return this.entities[prefix][id];
       })
       .filter((entity) => !!entity);


### PR DESCRIPTION
issue exporting ".schoolId:toEntities(School).name" in one client's setup