### PR TITLE
 #2324/ Admin UI should accept queryParam to route to details or list editor view

### DIFF
--- a/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
@@ -29,6 +29,8 @@ import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testi
 import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.service";
 import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
+import { ActivatedRoute } from "@angular/router";
+import { of } from 'rxjs';
 
 describe("AdminEntityComponent", () => {
   let component: AdminEntityComponent;
@@ -59,7 +61,9 @@ describe("AdminEntityComponent", () => {
       [viewConfigId]: { component: "EntityDetails", config: viewConfig },
       [entityConfigId]: {},
     };
-
+    const mockActivatedRoute = {
+      queryParams: of({ mode: 'list' })
+    };
     mockConfigService = jasmine.createSpyObj(["getConfig"]);
     mockConfigService.getConfig.and.returnValue(config[viewConfigId]);
 
@@ -87,6 +91,10 @@ describe("AdminEntityComponent", () => {
         {
           provide: EntityActionsService,
           useValue: jasmine.createSpyObj(["showSnackbarConfirmationWithUndo"]),
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: mockActivatedRoute,
         },
       ],
     });

--- a/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
@@ -30,7 +30,7 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
 import { ActivatedRoute } from "@angular/router";
-import { of } from 'rxjs';
+import { of } from "rxjs";
 
 describe("AdminEntityComponent", () => {
   let component: AdminEntityComponent;
@@ -62,7 +62,7 @@ describe("AdminEntityComponent", () => {
       [entityConfigId]: {},
     };
     const mockActivatedRoute = {
-      queryParams: of({ mode: 'list' })
+      queryParams: of({ mode: "list" })
     };
     mockConfigService = jasmine.createSpyObj(["getConfig"]);
     mockConfigService.getConfig.and.returnValue(config[viewConfigId]);

--- a/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
@@ -62,7 +62,7 @@ describe("AdminEntityComponent", () => {
       [entityConfigId]: {},
     };
     const mockActivatedRoute = {
-      queryParams: of({ mode: "list" })
+      queryParams: of({ mode: "list" }),
     };
     mockConfigService = jasmine.createSpyObj(["getConfig"]);
     mockConfigService.getConfig.and.returnValue(config[viewConfigId]);

--- a/src/app/core/admin/admin-entity/admin-entity.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.ts
@@ -28,7 +28,7 @@ import {
   MatSidenavContent,
 } from "@angular/material/sidenav";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
-import { RouterLink } from "@angular/router";
+import { RouterLink, ActivatedRoute } from "@angular/router";
 import { MatListItem, MatNavList } from "@angular/material/list";
 import { AdminEntityDetailsComponent } from "../admin-entity-details/admin-entity-details/admin-entity-details.component";
 
@@ -72,10 +72,18 @@ export class AdminEntityComponent implements OnInit {
     private location: Location,
     private entityMapper: EntityMapperService,
     private entityActionsService: EntityActionsService,
+    private routes: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
     this.init();
+    this.routes.queryParams.subscribe((params) => {
+      if (params.mode === "details") {
+        this.mode = "details";
+      } else if (params.mode === "list") {
+        this.mode = "list";
+      }
+    });
   }
 
   private init() {

--- a/src/app/core/admin/admin-entity/admin-entity.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.ts
@@ -83,6 +83,7 @@ export class AdminEntityComponent implements OnInit {
       } else if (params.mode === "list") {
         this.mode = "list";
       }
+      this.location.replaceState(window.location.pathname, "");
     });
   }
 

--- a/src/app/core/entity-details/entity-details/entity-details.component.html
+++ b/src/app/core/entity-details/entity-details/entity-details.component.html
@@ -32,6 +32,8 @@
     <button
       mat-menu-item
       [routerLink]="['/admin/entity', record?.getType()]"
+      [queryParams]="{ mode: 'details' }"
+      queryParamsHandling="merge"
       *ngIf="'update' | ablePure: 'Config' | async"
     >
       <fa-icon

--- a/src/app/core/entity-list/entity-list/entity-list.component.html
+++ b/src/app/core/entity-list/entity-list/entity-list.component.html
@@ -223,6 +223,8 @@
   <button
     mat-menu-item
     [routerLink]="['/admin/entity', entityConstructor.ENTITY_TYPE]"
+    [queryParams]="{ mode: 'list' }"
+    queryParamsHandling="merge"
     *ngIf="'update' | ablePure: 'Config' | async"
   >
     <fa-icon


### PR DESCRIPTION
closes:  #2324

### Description of changes

-  Added query parameters into the routes to entity details and list screen.
-  Create a function in the AdminEntityComponent to retrieve details from the query parameters.
-  Utilize the mode property to set the modes.
-  Empty the params when users coming from specific screen
