### PR TITLE
fix(forms): reset anonymized fields immediately

### DIFF
--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -237,10 +237,15 @@ export class EntityFormService {
     entity: T,
   ): Promise<T> {
     this.checkFormValidity(form);
-    const updatedEntity = entity.copy() as T;
-    Object.assign(updatedEntity, form.getRawValue());
-    updatedEntity.assertValid();
 
+    const updatedEntity = entity.copy() as T;
+    for (const [key, value] of Object.entries(form.getRawValue())) {
+      if (value !== null) {
+        updatedEntity[key] = value;
+      }
+    }
+
+    updatedEntity.assertValid();
     this.assertPermissionsToSave(entity, updatedEntity);
 
     return this.entityMapper

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
@@ -98,7 +98,7 @@ describe("EntityAnonymizeService", () => {
     }
   }
 
-  it("should anonymize and only keep properties marked to be retained", async () => {
+  it("should anonymize and only keep properties marked to be retained, setting others to 'null'", async () => {
     const entity = new AnonymizableEntity();
     entity.defaultField = "test";
     entity.retainedField = "test";
@@ -107,13 +107,12 @@ describe("EntityAnonymizeService", () => {
 
     AnonymizableEntity.expectAnonymized(
       entity.getId(),
-      AnonymizableEntity.create({ retainedField: "test" }),
+      AnonymizableEntity.create({ retainedField: "test", defaultField: null }),
     );
   });
 
   it("should anonymize and keep empty record without any fields", async () => {
     const entity = new AnonymizableEntity();
-    entity.defaultField = "test";
 
     await service.anonymizeEntity(entity);
 
@@ -140,6 +139,7 @@ describe("EntityAnonymizeService", () => {
       AnonymizableEntity.create({
         inactive: true,
         anonymized: true,
+        defaultField: null,
         ...entityProperties,
       }),
       true,
@@ -154,7 +154,11 @@ describe("EntityAnonymizeService", () => {
 
     AnonymizableEntity.expectAnonymized(
       entity.getId(),
-      AnonymizableEntity.create({ inactive: true, anonymized: true }),
+      AnonymizableEntity.create({
+        inactive: true,
+        anonymized: true,
+        defaultField: null,
+      }),
       true,
     );
   });
@@ -187,7 +191,7 @@ describe("EntityAnonymizeService", () => {
 
     AnonymizableEntity.expectAnonymized(
       entity.getId(),
-      AnonymizableEntity.create({}),
+      AnonymizableEntity.create({ file: null }),
     );
     expect(mockFileService.removeFile).toHaveBeenCalled();
   });
@@ -233,6 +237,12 @@ describe("EntityAnonymizeService", () => {
       expectedAnonymizedEntity.refComposite = anonEntity.refComposite;
       expectedAnonymizedEntity.inactive = true;
       expectedAnonymizedEntity.anonymized = true;
+
+      for (const [k, v] of Object.entries(actualEntity)) {
+        if (v === null) {
+          expectedAnonymizedEntity[k] = null;
+        }
+      }
 
       expect(comparableEntityData(actualEntity)).toEqual(
         comparableEntityData(expectedAnonymizedEntity),

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.ts
@@ -92,7 +92,9 @@ export class EntityAnonymizeService extends CascadingEntityAction {
       await firstValueFrom(this.fileService.removeFile(entity, key));
     }
 
-    delete entity[key];
+    if (entity[key] !== undefined) {
+      entity[key] = null;
+    }
   }
 
   private async keepEntityUnchanged(e: Entity): Promise<CascadingActionResult> {

--- a/src/app/core/entity/schema/entity-schema.service.spec.ts
+++ b/src/app/core/entity/schema/entity-schema.service.spec.ts
@@ -58,6 +58,25 @@ describe("EntitySchemaService", () => {
     expect(rawData.aString).toEqual("192");
   });
 
+  it("should keep 'null' as value if explicitly set", () => {
+    class TestEntity extends Entity {
+      @DatabaseField() aString: string;
+    }
+
+    const entity = new TestEntity();
+
+    const data = {
+      _id: entity.getId(),
+      aString: null,
+    };
+    service.loadDataIntoEntity(entity, data);
+
+    expect(entity.aString).toEqual(null);
+
+    const rawData = service.transformEntityToDatabaseFormat(entity);
+    expect(rawData.aString).toEqual(null);
+  });
+
   it("should return the directly defined component name for viewing and editing a property", () => {
     class Test extends Entity {
       @DatabaseField({

--- a/src/app/core/entity/schema/entity-schema.service.ts
+++ b/src/app/core/entity/schema/entity-schema.service.ts
@@ -104,7 +104,7 @@ export class EntitySchemaService {
     for (const key of schema.keys()) {
       const schemaField: EntitySchemaField = schema.get(key);
 
-      if (data[key] === undefined || data[key] === null) {
+      if (data[key] === undefined) {
         continue;
       }
 
@@ -153,7 +153,7 @@ export class EntitySchemaService {
       let value = entity[key];
       const schemaField: EntitySchemaField = schema.get(key);
 
-      if (value === undefined || value === null) {
+      if (value === undefined) {
         // skip and keep undefined
         continue;
       }
@@ -218,6 +218,11 @@ export class EntitySchemaService {
     schemaField: EntitySchemaField,
     entity?: Entity,
   ) {
+    if (value === null) {
+      // keep 'null' to be able to explicitly mark a value as being reset
+      return null;
+    }
+
     return this.getDatatypeOrDefault(
       schemaField.dataType,
     ).transformToDatabaseFormat(value, schemaField, entity);
@@ -234,6 +239,11 @@ export class EntitySchemaService {
     schemaField: EntitySchemaField,
     dataObject?: any,
   ) {
+    if (value === null) {
+      // keep 'null' to be able to explicitly mark a value as being reset
+      return null;
+    }
+
     return this.getDatatypeOrDefault(
       schemaField.dataType,
     ).transformToObjectFormat(value, schemaField, dataObject);


### PR DESCRIPTION
fixes #2285

### Visible/Frontend Changes
- [x] when clicking "anonymize" for an entity, the fields that are removed are immediately shown as empty in the form

### Architectural/Backend Changes
- [x] store "anonymized" removed properties as `null` to mark them explicitly as reset
- [x] retain `null` values during entity-schema transformations, to allow such explicitly reset values
- [x] prevent normal forms to save all empty fields as 'null'
