### PR TITLE
fix: ensure file upload works on newly created records

### DIFF
--- a/src/app/core/database/sync.service.ts
+++ b/src/app/core/database/sync.service.ts
@@ -103,7 +103,10 @@ export class SyncService {
     return PouchDB.fetch(url, opts);
   }
 
-  private sync(): Promise<SyncResult> {
+  /**
+   * Execute a (one-time) sync between the local and server database.
+   */
+  sync(): Promise<SyncResult> {
     this.syncStateSubject.next(SyncState.STARTED);
 
     return this.localDB

--- a/src/app/features/file/file.service.ts
+++ b/src/app/features/file/file.service.ts
@@ -16,10 +16,10 @@ import { SyncStateSubject } from "../../core/session/session-type";
  */
 export abstract class FileService {
   protected constructor(
-    private entityMapper: EntityMapperService,
-    private entities: EntityRegistry,
+    protected entityMapper: EntityMapperService,
+    protected entities: EntityRegistry,
     protected logger: LoggingService,
-    private syncState: SyncStateSubject,
+    protected syncState: SyncStateSubject,
   ) {
     // TODO maybe registration is too late (only when component is rendered)
     this.syncState


### PR DESCRIPTION
fixes #2398

The replication-backend needs to load the entity (from the "app" db) for permission checks during the file upload (put on the "app-attachments" db). For newly created documents we need to ensure the sync (nowadays at scheduled intervals) is completed before the upload.