### PR TITLE
fix: fix errors when creating note on group relation record

### DIFF
--- a/src/app/child-dev-project/notes/model/note.ts
+++ b/src/app/child-dev-project/notes/model/note.ts
@@ -231,8 +231,8 @@ export class Note extends Entity {
    * @param child The child or the id of the child to add to the notes
    */
   addChild(child: Child | string) {
-    const childId = typeof child === "string" ? child : child.getId();
-    if (this.children.includes(childId)) {
+    const childId = typeof child === "string" ? child : child?.getId();
+    if (!childId || this.children.includes(childId)) {
       return;
     }
 

--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
@@ -13,8 +13,14 @@ import { ChildSchoolRelation } from "../../children/model/childSchoolRelation";
 describe("NotesRelatedToEntityComponent", () => {
   let component: NotesRelatedToEntityComponent;
   let fixture: ComponentFixture<NotesRelatedToEntityComponent>;
+  const originalNoteSchema_relatedEntities =
+    Note.schema.get("relatedEntities").additional;
 
   beforeEach(waitForAsync(() => {
+    Note.schema.get("relatedEntities").additional = [
+      ChildSchoolRelation.ENTITY_TYPE,
+    ];
+
     TestBed.configureTestingModule({
       imports: [NotesRelatedToEntityComponent, MockedTestingModule.withState()],
     }).compileComponents();
@@ -23,9 +29,13 @@ describe("NotesRelatedToEntityComponent", () => {
   beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(NotesRelatedToEntityComponent);
     component = fixture.componentInstance;
-    component.entity = new Child("1");
-    fixture.detectChanges();
+    //fixture.detectChanges();
   }));
+
+  afterEach(() => {
+    Note.schema.get("relatedEntities").additional =
+      originalNoteSchema_relatedEntities;
+  });
 
   it("should create", () => {
     expect(component).toBeTruthy();
@@ -79,6 +89,21 @@ describe("NotesRelatedToEntityComponent", () => {
     expect(note.relatedEntities).toEqual([entity.getId()]);
     expect(note.children).toEqual([`${Child.ENTITY_TYPE}:someChild`]);
     expect(note.schools).toEqual([`${Child.ENTITY_TYPE}:someSchool`]);
+  });
+
+  it("should handle ChildSchoolRelation links also if they are arrays", async () => {
+    const relation = new ChildSchoolRelation();
+    relation.schoolId = ["School:1"] as any; // assume entity config was overwritten to hold array
+    relation.childId = ["Child:1", "Child:2"] as any; // assume entity config was overwritten to hold array
+
+    component.entity = relation;
+    await component.ngOnInit();
+
+    const newNote = component.createNewRecordFactory()();
+
+    expect(newNote.relatedEntities).toContain(relation.getId());
+    expect(newNote.children).toEqual(relation.childId);
+    expect(newNote.schools).toEqual(relation.schoolId);
   });
 
   it("should create a new note and fill it with indirectly related references (2-hop) of the types allowed for note.relatedEntities", () => {

--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
@@ -29,7 +29,6 @@ describe("NotesRelatedToEntityComponent", () => {
   beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(NotesRelatedToEntityComponent);
     component = fixture.componentInstance;
-    //fixture.detectChanges();
   }));
 
   afterEach(() => {

--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.ts
@@ -75,14 +75,31 @@ export class NotesRelatedToEntityComponent
       const newNote = super.createNewRecordFactory()();
       //TODO: generalize this code - possibly by only using relatedEntities to link other records here? see #1501
       if (this.entity.getType() === ChildSchoolRelation.ENTITY_TYPE) {
-        newNote.addChild((this.entity as ChildSchoolRelation).childId);
-        newNote.addSchool((this.entity as ChildSchoolRelation).schoolId);
+        for (const childId of asArray(
+          (this.entity as ChildSchoolRelation).childId,
+        )) {
+          if (childId) {
+            newNote.addChild(childId);
+          }
+        }
+
+        for (const schooldId of asArray(
+          (this.entity as ChildSchoolRelation).schoolId,
+        )) {
+          if (schooldId) {
+            newNote.addSchool(schooldId);
+          }
+        }
       }
 
-      newNote.relatedEntities.push(this.entity.getId());
-      this.getIndirectlyRelatedEntityIds(this.entity).forEach((e) =>
-        newNote.relatedEntities.push(e),
-      );
+      for (const e of [
+        this.entity.getId(),
+        ...this.getIndirectlyRelatedEntityIds(this.entity),
+      ]) {
+        if (!newNote.relatedEntities.includes(e)) {
+          newNote.relatedEntities.push(e);
+        }
+      }
 
       return newNote;
     };


### PR DESCRIPTION
For some use cases we overwrite the `ChildSchoolRelation` schema to enabe n-to-m relationships, i.e. allowing `childId` and `schoolId` to be arrays. This can cause errors in the NoteDetails component currently