### PR TITLE
feat: delete keycloak user when deleting user entity

### DIFF
--- a/src/app/core/entity-list/duplicate-records/duplicate-records.service.spec.ts
+++ b/src/app/core/entity-list/duplicate-records/duplicate-records.service.spec.ts
@@ -15,10 +15,13 @@ import { UpdateMetadata } from "../../entity/model/update-metadata";
 import { MatDialog } from "@angular/material/dialog";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { FileService } from "../../../features/file/file.service";
+import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 
 describe("DuplicateRecordsService", () => {
   let service: DuplicateRecordService;
   let entityMapperService: EntityMapperService;
+
+  let mockAuthService: jasmine.SpyObj<KeycloakAuthService>;
 
   @DatabaseEntity("DuplicateTestEntity")
   class DuplicateTestEntity extends Entity {
@@ -41,6 +44,7 @@ describe("DuplicateRecordsService", () => {
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: {} },
         { provide: FileService, useValue: {} },
+        { provide: KeycloakAuthService, useValue: mockAuthService },
         ComponentRegistry,
       ],
     });

--- a/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
@@ -8,14 +8,12 @@ import {
 } from "@angular/material/snack-bar";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { Entity } from "../model/entity";
-import { NEVER, of, Subject, throwError } from "rxjs";
+import { NEVER, of, Subject } from "rxjs";
 import { Router } from "@angular/router";
 import { CoreTestingModule } from "../../../utils/core-testing.module";
 import { EntityDeleteService } from "./entity-delete.service";
 import { EntityAnonymizeService } from "./entity-anonymize.service";
 import { CascadingActionResult } from "./cascading-entity-action";
-import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
-import { User } from "../../user/user";
 
 describe("EntityActionsService", () => {
   let service: EntityActionsService;
@@ -26,7 +24,6 @@ describe("EntityActionsService", () => {
   let mockRouter;
   let mockedEntityDeleteService: jasmine.SpyObj<EntityDeleteService>;
   let mockedEntityAnonymizeService: jasmine.SpyObj<EntityAnonymizeService>;
-  let mockAuthService: jasmine.SpyObj<KeycloakAuthService>;
 
   let singleTestEntity: Entity;
   let severalTestEntities: Entity[] = [];
@@ -36,13 +33,6 @@ describe("EntityActionsService", () => {
     severalTestEntities[0] = new Entity();
     severalTestEntities[1] = new Entity();
     severalTestEntities[2] = new Entity();
-
-    mockAuthService = jasmine.createSpyObj(["deleteUser"]);
-    mockAuthService.deleteUser.and.returnValue(
-      throwError(() => {
-        new Error();
-      }),
-    );
 
     mockedEntityDeleteService = jasmine.createSpyObj(["deleteEntity"]);
     mockedEntityDeleteService.deleteEntity.and.resolveTo(
@@ -72,7 +62,6 @@ describe("EntityActionsService", () => {
       imports: [CoreTestingModule],
       providers: [
         EntityActionsService,
-        { provide: KeycloakAuthService, useValue: mockAuthService },
         { provide: EntityDeleteService, useValue: mockedEntityDeleteService },
         {
           provide: EntityAnonymizeService,
@@ -114,6 +103,7 @@ describe("EntityActionsService", () => {
     expect(snackBarSpy.open).toHaveBeenCalled();
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       singleTestEntity,
+      true,
     );
     expect(mockRouter.navigate).toHaveBeenCalled();
   });
@@ -130,29 +120,16 @@ describe("EntityActionsService", () => {
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledTimes(3);
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[0],
+      true,
     );
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[1],
+      true,
     );
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[2],
+      true,
     );
-  });
-
-  it("should delete several entities and show dialog if keycloak deletion fails", async () => {
-    mockSnackBarRef.onAction.and.returnValues(NEVER);
-    mockSnackBarRef.afterDismissed.and.returnValue(of(undefined));
-
-    let userEntity = new User();
-    const result = await service.delete(userEntity);
-
-    expect(result).toBe(true);
-    expect(snackBarSpy.open).toHaveBeenCalled();
-    expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledTimes(1);
-    expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
-      userEntity,
-    );
-    expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledTimes(2);
   });
 
   it("should undo the deletion of several entities", fakeAsync(async () => {

--- a/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
@@ -14,6 +14,7 @@ import { CoreTestingModule } from "../../../utils/core-testing.module";
 import { EntityDeleteService } from "./entity-delete.service";
 import { EntityAnonymizeService } from "./entity-anonymize.service";
 import { CascadingActionResult } from "./cascading-entity-action";
+import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 
 describe("EntityActionsService", () => {
   let service: EntityActionsService;
@@ -24,6 +25,7 @@ describe("EntityActionsService", () => {
   let mockRouter;
   let mockedEntityDeleteService: jasmine.SpyObj<EntityDeleteService>;
   let mockedEntityAnonymizeService: jasmine.SpyObj<EntityAnonymizeService>;
+  let mockAuthService: jasmine.SpyObj<KeycloakAuthService>;
 
   let singleTestEntity: Entity;
   let severalTestEntities: Entity[] = [];
@@ -62,6 +64,7 @@ describe("EntityActionsService", () => {
       imports: [CoreTestingModule],
       providers: [
         EntityActionsService,
+        { provide: KeycloakAuthService, useValue: mockAuthService },
         { provide: EntityDeleteService, useValue: mockedEntityDeleteService },
         {
           provide: EntityAnonymizeService,

--- a/src/app/core/entity/entity-actions/entity-actions.service.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.ts
@@ -108,9 +108,7 @@ export class EntityActionsService {
     for (let entity of entities) {
       if ("User" === entity.getType()) {
         this.keycloakAuthService.deleteUser(entity.getId()).subscribe({
-          next: () => {
-            console.log("keycloak user deleted.");
-          },
+          next: () => {},
           error: async () =>
             await this.confirmationDialog.getConfirmation(
               $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,

--- a/src/app/core/entity/entity-actions/entity-actions.service.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.ts
@@ -9,7 +9,6 @@ import { EntityDeleteService } from "./entity-delete.service";
 import { EntityAnonymizeService } from "./entity-anonymize.service";
 import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { CascadingActionResult } from "./cascading-entity-action";
-import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 
 /**
  * A service that can triggers a user flow for entity actions (e.g. to safely remove or anonymize an entity),
@@ -26,7 +25,6 @@ export class EntityActionsService {
     private entityMapper: EntityMapperService,
     private entityDelete: EntityDeleteService,
     private entityAnonymize: EntityAnonymizeService,
-    private keycloakAuthService: KeycloakAuthService,
   ) {}
 
   showSnackbarConfirmationWithUndo(
@@ -106,18 +104,7 @@ export class EntityActionsService {
     let result = new CascadingActionResult();
 
     for (let entity of entities) {
-      if ("User" === entity.getType()) {
-        this.keycloakAuthService.deleteUser(entity.getId()).subscribe({
-          next: () => {},
-          error: async () =>
-            await this.confirmationDialog.getConfirmation(
-              $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
-              $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
-              OkButton,
-            ),
-        });
-      }
-      result.mergeResults(await this.entityDelete.deleteEntity(entity));
+      result.mergeResults(await this.entityDelete.deleteEntity(entity, true));
     }
 
     progressDialogRef.close();

--- a/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
@@ -19,23 +19,54 @@ import { Note } from "../../../child-dev-project/notes/model/note";
 import { Child } from "../../../child-dev-project/children/model/child";
 import { DefaultDatatype } from "../default-datatype/default.datatype";
 import { EventAttendanceMapDatatype } from "../../../child-dev-project/attendance/model/event-attendance.datatype";
+import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
+import { throwError } from "rxjs";
+import { User } from "../../user/user";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 
 describe("EntityDeleteService", () => {
   let service: EntityDeleteService;
   let entityMapper: MockEntityMapperService;
 
+  let snackBarSpy: jasmine.SpyObj<MatSnackBar>;
+  let mockConfirmationDialog: jasmine.SpyObj<ConfirmationDialogService>;
+  let mockAuthService: jasmine.SpyObj<KeycloakAuthService>;
+
   beforeEach(() => {
     entityMapper = mockEntityMapper(allEntities.map((e) => e.copy()));
+
+    mockAuthService = jasmine.createSpyObj(["deleteUser"]);
+    mockAuthService.deleteUser.and.returnValue(
+      throwError(() => {
+        new Error();
+      }),
+    );
+
+    mockConfirmationDialog = jasmine.createSpyObj([
+      "getConfirmation",
+      "showProgressDialog",
+    ]);
+    mockConfirmationDialog.getConfirmation.and.resolveTo(true);
+    mockConfirmationDialog.showProgressDialog.and.returnValue(
+      jasmine.createSpyObj(["close"]),
+    );
 
     TestBed.configureTestingModule({
       imports: [CoreTestingModule],
       providers: [
         EntityDeleteService,
         { provide: EntityMapperService, useValue: entityMapper },
+        { provide: KeycloakAuthService, useValue: mockAuthService },
+        { provide: MatSnackBar, useValue: snackBarSpy },
         {
           provide: DefaultDatatype,
           useClass: EventAttendanceMapDatatype,
           multi: true,
+        },
+        {
+          provide: ConfirmationDialogService,
+          useValue: mockConfirmationDialog,
         },
       ],
     });
@@ -79,6 +110,18 @@ describe("EntityDeleteService", () => {
       [ENTITIES.ReferencedAsComposite, ENTITIES.ReferencingSingleComposite],
       entityMapper,
     );
+  });
+
+  it("should delete several entities and show dialog if keycloak deletion fails", async () => {
+    // given
+    mockAuthService.deleteUser.and.returnValue(throwError(() => new Error()));
+    let userEntity = new User();
+
+    // when
+    await service.deleteEntity(userEntity, true);
+
+    // then
+    expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledTimes(1);
   });
 
   it("should not cascade delete the 'composite'-type entity that still references additional other entities but remove id", async () => {

--- a/src/app/core/entity/entity-actions/entity-delete.service.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.ts
@@ -6,6 +6,9 @@ import {
   CascadingActionResult,
   CascadingEntityAction,
 } from "./cascading-entity-action";
+import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
+import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 
 /**
  * Safely delete an entity including handling references with related entities.
@@ -18,6 +21,8 @@ export class EntityDeleteService extends CascadingEntityAction {
   constructor(
     protected entityMapper: EntityMapperService,
     protected schemaService: EntitySchemaService,
+    private keycloakAuthService: KeycloakAuthService,
+    private confirmationDialog: ConfirmationDialogService,
   ) {
     super(entityMapper, schemaService);
   }
@@ -29,9 +34,28 @@ export class EntityDeleteService extends CascadingEntityAction {
    * to support an undo action.
    *
    * @param entity
+   * @param showKeycloakWarning if keycloak deleteUser request fails, a popup warning is shown to the user
    * @private
    */
-  async deleteEntity(entity: Entity): Promise<CascadingActionResult> {
+  async deleteEntity(
+    entity: Entity,
+    showKeycloakWarning = false,
+  ): Promise<CascadingActionResult> {
+    if ("User" === entity.getType()) {
+      this.keycloakAuthService.deleteUser(entity.getId()).subscribe({
+        next: () => {},
+        error: () => {
+          if (showKeycloakWarning) {
+            this.confirmationDialog.getConfirmation(
+              $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
+              $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
+              OkButton,
+            );
+          }
+        },
+      });
+    }
+
     const cascadeResult = await this.cascadeActionToRelatedEntities(
       entity,
       (e) => this.deleteEntity(e),

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { KeycloakAuthService } from "./keycloak-auth.service";
 import { HttpClient } from "@angular/common/http";
 import { KeycloakEventType, KeycloakService } from "keycloak-angular";
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 
 /**
  * Check {@link https://jwt.io} to decode the token.
@@ -29,7 +29,7 @@ describe("KeycloakAuthService", () => {
   let mockKeycloak: jasmine.SpyObj<KeycloakService>;
 
   beforeEach(() => {
-    mockHttpClient = jasmine.createSpyObj(["post"]);
+    mockHttpClient = jasmine.createSpyObj(["get", "post", "delete"]);
     mockKeycloak = jasmine.createSpyObj(
       ["updateToken", "getToken", "login", "init"],
       { keycloakEvents$: new Subject() },
@@ -81,6 +81,28 @@ describe("KeycloakAuthService", () => {
       jasmine.objectContaining({ action: "UPDATE_PASSWORD" }),
     );
   });
+
+  it("should delete user by username", fakeAsync(() => {
+    // given
+    mockHttpClient.get.and.returnValue(
+      of({
+        id: "user-id",
+      }),
+    );
+
+    mockHttpClient.delete.and.returnValue(of(""));
+
+    // when
+    service.deleteUser("foo-user").subscribe(() => {
+      // then
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        "https://accounts.aam-digital.net/account/foo-user",
+      );
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        "https://accounts.aam-digital.net/account/user-id",
+      );
+    });
+  }));
 
   it("should add the Bearer token to a request", async () => {
     await service.login();

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
@@ -9,6 +9,7 @@ import { Entity } from "../../../entity/model/entity";
 import { User } from "../../../user/user";
 import { ParsedJWT, parseJwt } from "../../../../session/session-utils";
 import { RemoteLoginNotAvailableError } from "./remote-login-not-available.error";
+import { switchMap } from "rxjs/operators";
 
 /**
  * Handles the remote session with keycloak
@@ -166,6 +167,16 @@ export class KeycloakAuthService {
 
   createUser(user: Partial<KeycloakUserDto>): Observable<any> {
     return this.httpClient.post(`${environment.account_url}/account`, user);
+  }
+
+  deleteUser(username: string): Observable<any> {
+    return this.getUser(username).pipe(
+      switchMap((value) =>
+        this.httpClient.delete(
+          `${environment.account_url}/account/${value.id}`,
+        ),
+      ),
+    );
   }
 
   updateUser(userId: string, user: Partial<KeycloakUserDto>): Observable<any> {


### PR DESCRIPTION
closes: https://github.com/Aam-Digital/ndb-core/issues/1874

### Visible/Frontend Changes

- [ ] show warning popup, when keycloak user could not removed after user deletion 

### Architectural/Backend Changes

- [ ] see https://github.com/Aam-Digital/account-backend/pull/38
