### PR TITLE
fix: fix some glitches in the behavior of dropdown components

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.stories.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.stories.ts
@@ -24,7 +24,8 @@ export default {
         {
           provide: MAT_DIALOG_DATA,
           useValue: {
-            entitySchemaField: { id: null },
+            entitySchemaField: { id: "name" },
+            entityType: TestEntity,
           },
         },
         { provide: MatDialogRef, useValue: null },

--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.html
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.html
@@ -1,7 +1,7 @@
 <!--Display-->
 <input
   *ngIf="display === 'text' || display === 'none'; else chipsDisplay"
-  [hidden]="focused || display === 'none'"
+  [hidden]="isInSearchMode() || display === 'none'"
   [disabled]="_disabled"
   matInput
   style="text-overflow: ellipsis; width: calc(100% - 50px)"
@@ -13,7 +13,7 @@
 
 <!--Search-->
 <input
-  [hidden]="!focused"
+  [hidden]="!isInSearchMode()"
   #inputElement
   [formControl]="autocompleteForm"
   matInput
@@ -31,7 +31,7 @@
   #autoSuggestions="matAutocomplete"
   (optionSelected)="select($event.option.value)"
   autoActiveFirstOption
-  [hideSingleSelectionIndicator]="multi"
+  [hideSingleSelectionIndicator]="true"
 >
   <div
     cdkDropList
@@ -43,11 +43,15 @@
       [style.height]="(autocompleteOptions?.length ?? 0) * 48 + 'px'"
       [style.max-height]="3 * 48 + 'px'"
       itemSize="48"
+      minBufferPx="200"
     >
       <mat-option
         [value]="item"
         cdkDrag
-        *cdkVirtualFor="let item of autocompleteOptions"
+        *cdkVirtualFor="
+          let item of autocompleteOptions;
+          trackBy: trackByOptionValueFn
+        "
       >
         <div class="flex-row disable-autocomplete-active-color align-center">
           <div *ngIf="reorder">

--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.spec.ts
@@ -163,13 +163,13 @@ describe("BasicAutocompleteComponent", () => {
 
     component.showAutocomplete();
     expect(component.autocompleteForm).toHaveValue("");
-    expect(component.focused).toBeTrue();
+    expect(component.isInSearchMode()).toBeTrue();
 
     component.onFocusOut({} as any);
     tick(200);
 
     expect(component.displayText).toBe("some, values");
-    expect(component.focused).toBeFalse();
+    expect(component.isInSearchMode()).toBeFalse();
   }));
 
   it("should update the error state if the form is invalid", () => {


### PR DESCRIPTION
- avoid ExpressionChangedAfterItHasBeenCheckedError caused by use of `focused` in own template
- fix displaying of all options when reopening