### PR TITLE
fix: prevent duplicate keys in filter options

### DIFF
--- a/src/app/core/filter/filters/filters.ts
+++ b/src/app/core/filter/filters/filters.ts
@@ -79,15 +79,17 @@ export class SelectableFilter<T extends Entity> extends Filter<T> {
     attributeName: string,
   ): FilterSelectionOption<T>[] {
     let keys = new Set();
-    return valuesToMatchAsOptions
-      .filter((k) => !!k)
-      .map((k) => ({
-        key: k.toString().toLowerCase(),
-        label: k.toString(),
-        filter: { [attributeName]: k } as DataFilter<T>,
-      }))
-      // remove duplicates:
-      .filter((value) => !keys.has(value.key) && keys.add(value.key));
+    return (
+      valuesToMatchAsOptions
+        .filter((k) => !!k)
+        .map((k) => ({
+          key: k.toString().toLowerCase(),
+          label: k.toString(),
+          filter: { [attributeName]: k } as DataFilter<T>,
+        }))
+        // remove duplicates:
+        .filter((value) => !keys.has(value.key) && keys.add(value.key))
+    );
   }
 
   /**

--- a/src/app/core/filter/filters/filters.ts
+++ b/src/app/core/filter/filters/filters.ts
@@ -78,13 +78,15 @@ export class SelectableFilter<T extends Entity> extends Filter<T> {
     valuesToMatchAsOptions: (string | number)[],
     attributeName: string,
   ): FilterSelectionOption<T>[] {
+    let keys = new Set();
     return valuesToMatchAsOptions
       .filter((k) => !!k)
       .map((k) => ({
         key: k.toString().toLowerCase(),
         label: k.toString(),
         filter: { [attributeName]: k } as DataFilter<T>,
-      }));
+      }))
+      .filter((value) => !keys.has(value.key) && keys.add(value.key));
   }
 
   /**

--- a/src/app/core/filter/filters/filters.ts
+++ b/src/app/core/filter/filters/filters.ts
@@ -86,6 +86,7 @@ export class SelectableFilter<T extends Entity> extends Filter<T> {
         label: k.toString(),
         filter: { [attributeName]: k } as DataFilter<T>,
       }))
+      // remove duplicates:
       .filter((value) => !keys.has(value.key) && keys.add(value.key));
   }
 


### PR DESCRIPTION
prevent angular warnings for duplicate keys in options drop down.