### PR TITLE
refactor(core): add option to entities-table to open full details vie…

### DIFF
--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -80,6 +80,7 @@ export class EntitiesTableComponent<T extends Entity> {
     this.updateFilteredData();
     this.isLoading = false;
   }
+
   private lastSelectedIndex: number = null;
   private lastSelection: boolean = null;
   _records: T[] = [];
@@ -122,6 +123,7 @@ export class EntitiesTableComponent<T extends Entity> {
       .map((col) => col.id)
       .join("");
   }
+
   _customColumns: FormFieldConfig[];
   _columns: FormFieldConfig[] = [];
 
@@ -151,12 +153,14 @@ export class EntitiesTableComponent<T extends Entity> {
       this.sortIsInferred = true;
     }
   }
+
   _columnsToDisplay: string[];
 
   @Input() set entityType(value: EntityConstructor<T>) {
     this._entityType = value;
     this.customColumns = this._customColumns;
   }
+
   _entityType: EntityConstructor<T>;
 
   /** how to sort data by default during initialization */
@@ -185,6 +189,7 @@ export class EntitiesTableComponent<T extends Entity> {
     this._filter = value ?? {};
     this.updateFilteredData();
   }
+
   _filter: DataFilter<T> = {};
   /** output the currently displayed records, whenever filters for the user change */
   @Output() filteredRecordsChange = new EventEmitter<T[]>(true);
@@ -206,7 +211,15 @@ export class EntitiesTableComponent<T extends Entity> {
   @Input() getBackgroundColor?: (rec: T) => string = (rec: T) => rec.getColor();
   idForSavingPagination: string;
 
-  @Input() clickMode: "popup" | "navigate" | "none" = "popup";
+  /**
+   * The action the system triggers when a user clicks on an entry (row):
+   * - popup: open dialog with simplified form with the given fields only
+   * - navigate: route the app to the details view of the entity
+   * - popup-details: open dialog with the full EntityDetails view
+   * - none: do not trigger any automatic action
+   */
+  @Input() clickMode: "popup" | "navigate" | "popup-details" | "none" = "popup";
+
   /**
    * Emits the entity being clicked in the table - or the newly created entity from the "create" button.
    */
@@ -220,6 +233,7 @@ export class EntitiesTableComponent<T extends Entity> {
     this._selectable = v;
     this.columnsToDisplay = this._columnsToDisplay;
   }
+
   _selectable: boolean = false;
 
   readonly ACTIONCOLUMN_SELECT = "__select";
@@ -251,6 +265,7 @@ export class EntitiesTableComponent<T extends Entity> {
     this._editable = v;
     this.columnsToDisplay = this._columnsToDisplay;
   }
+
   _editable: boolean = true;
   readonly ACTIONCOLUMN_EDIT = "__edit";
   /**
@@ -354,6 +369,9 @@ export class EntitiesTableComponent<T extends Entity> {
       case "popup":
         this.formDialog.openFormPopup(entity, this._customColumns);
         break;
+      case "popup-details":
+        this.formDialog.openView(entity, "EntityDetails");
+        break;
       case "navigate":
         this.router.navigate([
           entity.getConstructor().route,
@@ -431,6 +449,7 @@ export class EntitiesTableComponent<T extends Entity> {
     this.updateFilteredData();
     this.showInactiveChange.emit(value);
   }
+
   _showInactive: boolean = false;
   @Output() showInactiveChange = new EventEmitter<boolean>();
 

--- a/src/app/core/entity-details/related-entities/related-entities.component.ts
+++ b/src/app/core/entity-details/related-entities/related-entities.component.ts
@@ -73,6 +73,7 @@ export class RelatedEntitiesComponent<E extends Entity> implements OnInit {
     this._columns = value.map((c) => toFormFieldConfig(c));
     this.updateColumnsToDisplayForScreenSize();
   }
+
   protected _columns: FormFieldConfig[];
 
   columnsToDisplay: string[];
@@ -87,7 +88,7 @@ export class RelatedEntitiesComponent<E extends Entity> implements OnInit {
    */
   @Input() showInactive: boolean;
 
-  @Input() clickMode: "popup" | "navigate" = "popup";
+  @Input() clickMode: "popup" | "navigate" | "popup-details" = "popup";
   @Input() editable: boolean = true;
 
   data: E[];

--- a/src/app/core/ui/dialog-view/dialog-view.component.spec.ts
+++ b/src/app/core/ui/dialog-view/dialog-view.component.spec.ts
@@ -3,9 +3,9 @@ import { DialogViewComponent } from "./dialog-view.component";
 import { MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { ComponentRegistry } from "../../../dynamic-components";
 import { Component } from "@angular/core";
-import { EntityConfigService } from "../../entity/entity-config.service";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
-import { Entity } from "../../entity/model/entity";
+import { Router } from "@angular/router";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
 
 @Component({
   template: ``,
@@ -17,11 +17,11 @@ describe("DialogViewComponent", () => {
   let fixture: ComponentFixture<DialogViewComponent>;
 
   let mockDialogData;
-  let mockEntityConfigService: jasmine.SpyObj<EntityConfigService>;
+  let mockRouter: Partial<Router>;
 
   beforeEach(() => {
     mockDialogData = {};
-    mockEntityConfigService = jasmine.createSpyObj(["getDetailsViewConfig"]);
+    mockRouter = { config: [] };
 
     TestBed.configureTestingModule({
       imports: [DialogViewComponent, FontAwesomeTestingModule],
@@ -34,7 +34,7 @@ describe("DialogViewComponent", () => {
           provide: ComponentRegistry,
           useValue: { get: () => async () => MockComponent },
         },
-        { provide: EntityConfigService, useValue: mockEntityConfigService },
+        { provide: Router, useValue: mockRouter },
       ],
     });
   });
@@ -63,14 +63,14 @@ describe("DialogViewComponent", () => {
   }));
 
   it("should add view config for given entity type as config", fakeAsync(() => {
-    const testEntity = new Entity();
+    const testEntity = new TestEntity();
     mockDialogData.config = { dialogDetail: "1" };
     mockDialogData.entity = testEntity;
-    mockEntityConfigService.getDetailsViewConfig.and.returnValue({
-      config: {
-        viewConfig: "2",
-      },
-    } as any);
+
+    const testRouteConfig = { config: { viewConfig: "2" } };
+    mockRouter.config.push({ path: "test-entity/:id", data: testRouteConfig });
+    mockRouter.config.push({ path: "other", data: {} });
+
     createComponent();
 
     expect(component.config).toEqual({
@@ -78,8 +78,5 @@ describe("DialogViewComponent", () => {
       viewConfig: "2",
       entity: testEntity,
     });
-    expect(mockEntityConfigService.getDetailsViewConfig).toHaveBeenCalledWith(
-      Entity,
-    );
   }));
 });

--- a/src/app/core/ui/dialog-view/dialog-view.component.ts
+++ b/src/app/core/ui/dialog-view/dialog-view.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject, Injector } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { DynamicComponentDirective } from "../../config/dynamic-components/dynamic-component.directive";
 import {
   MAT_DIALOG_DATA,
   MatDialogActions,
@@ -10,11 +9,11 @@ import {
 } from "@angular/material/dialog";
 import { EntityConfigService } from "../../entity/entity-config.service";
 import { Entity } from "../../entity/model/entity";
-import { ViewTitleComponent } from "../../common-components/view-title/view-title.component";
 import { DialogCloseComponent } from "../../common-components/dialog-close/dialog-close.component";
-import { CdkPortalOutlet } from "@angular/cdk/portal";
 import { DynamicComponentPipe } from "../../config/dynamic-components/dynamic-component.pipe";
 import { AbstractViewComponent } from "../abstract-view/abstract-view.component";
+import { Router } from "@angular/router";
+import { PREFIX_VIEW_CONFIG } from "../../config/dynamic-routing/view-config.interface";
 
 /**
  * Wrapper component for a modal/dialog view
@@ -28,11 +27,8 @@ import { AbstractViewComponent } from "../abstract-view/abstract-view.component"
   standalone: true,
   imports: [
     CommonModule,
-    DynamicComponentDirective,
-    ViewTitleComponent,
     DialogCloseComponent,
     MatDialogClose,
-    CdkPortalOutlet,
     DynamicComponentPipe,
     MatDialogTitle,
     MatDialogContent,
@@ -48,8 +44,8 @@ export class DialogViewComponent<T = any> extends AbstractViewComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     dialogData: DialogViewData<T>,
-    private entityConfigService: EntityConfigService,
     injector: Injector,
+    router: Router,
   ) {
     super(injector, true);
 
@@ -57,10 +53,12 @@ export class DialogViewComponent<T = any> extends AbstractViewComponent {
 
     let viewConfig = {};
     if (dialogData.entity) {
+      const detailsRoute = EntityConfigService.getDetailsViewId(
+        dialogData.entity.getConstructor(),
+      ).substring(PREFIX_VIEW_CONFIG.length);
       viewConfig =
-        this.entityConfigService.getDetailsViewConfig(
-          dialogData.entity.getConstructor(),
-        )?.config ?? {};
+        router.config.find((route) => route.path === detailsRoute)?.data
+          ?.config ?? {};
     }
 
     if (dialogData.entity) {


### PR DESCRIPTION
Add option in core components to open an entity list item in a full Details View popup as an alternative to the simplified RowDetails form popup or navigation to the details route.

required for #2740