### PR TITLE
Fix: Update `isPushNotificationEnabled` Value Based on User Notification Preferences

### DIFF
--- a/src/app/features/notification/notification-settings/notification-settings.component.ts
+++ b/src/app/features/notification/notification-settings/notification-settings.component.ts
@@ -97,8 +97,10 @@ export class NotificationSettingsComponent implements OnInit {
   async togglePushNotifications(event: MatSlideToggleChange) {
     if (event.checked) {
       this.notificationService.registerDevice();
+      this.isPushNotificationEnabled = true;
     } else {
       this.notificationService.unregisterDevice();
+      this.isPushNotificationEnabled = false;
     }
 
     let notificationConfig = await this.loadNotificationConfig();


### PR DESCRIPTION
### Visible/Frontend Changes
- [x] Update the `isPushNotificationEnabled` value if the user enables/diable the notification.
