### PR TITLE
refactor: row click handling in EntitiesTableComponent

### DIFF
--- a/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.scss
+++ b/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.scss
@@ -1,14 +1,6 @@
 @use "variables/sizes";
 @use "variables/colors";
 
-.clickable {
-  pointer-events: all;
-  cursor: pointer;
-}
-.clickable:hover {
-  text-decoration: underline;
-}
-
 .block-height {
   line-height: sizes.$icon-block;
 }

--- a/src/app/core/common-components/entities-table/entities-table.component.spec.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.spec.ts
@@ -184,12 +184,13 @@ describe("EntitiesTableComponent", () => {
 
   it("should notify when an entity is clicked", (done) => {
     const child = new TestEntity();
+    const mockEvent = new MouseEvent("click");
     component.entityClick.subscribe((entity) => {
       expect(entity).toEqual(child);
       done();
     });
 
-    component.onRowClick({ record: child });
+    component.onRowClick({ record: child }, mockEvent);
   });
 
   it("should filter data based on filter definition", () => {

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -282,8 +282,7 @@ export class EntitiesTableComponent<T extends Entity> {
     const targetElement = event.target as HTMLElement;
 
     // Check if the clicked element has the 'clickable' class
-    if (targetElement.closest(".clickable")) {
-      event.stopPropagation();
+    if (targetElement && targetElement.closest(".clickable")) {
       return;
     }
     if (row.formGroup && !row.formGroup.disabled) {

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -278,7 +278,14 @@ export class EntitiesTableComponent<T extends Entity> {
    * Show one record's details in a modal dialog (if configured).
    * @param row The entity whose details should be displayed.
    */
-  onRowClick(row: TableRow<T>) {
+  onRowClick(row: TableRow<T>, event: MouseEvent) {
+    const targetElement = event.target as HTMLElement;
+
+    // Check if the clicked element has the 'clickable' class
+    if (targetElement.closest(".clickable")) {
+      event.stopPropagation();
+      return;
+    }
     if (row.formGroup && !row.formGroup.disabled) {
       return;
     }
@@ -286,14 +293,13 @@ export class EntitiesTableComponent<T extends Entity> {
       this.selectRow(row, !this.selectedRecords?.includes(row.record));
       return;
     }
-
     this.showEntity(row.record);
     this.entityClick.emit(row.record);
   }
 
   onRowMouseDown(event: MouseEvent, row: TableRow<T>) {
     if (!this._selectable) {
-      this.onRowClick(row);
+      this.onRowClick(row, event);
       return;
     }
 
@@ -337,7 +343,7 @@ export class EntitiesTableComponent<T extends Entity> {
     }
 
     if (isCheckboxClick) {
-      this.onRowClick(row);
+      this.onRowClick(row, event);
     }
   }
 

--- a/src/styles/globals/_utility-classes.scss
+++ b/src/styles/globals/_utility-classes.scss
@@ -33,6 +33,17 @@
   }
 }
 
+/**
+ * Display the cursor as a pointer and underline the element which has entitylinked when hovered
+ */
+.clickable {
+  pointer-events: all;
+  cursor: pointer;
+}
+.clickable:hover {
+  text-decoration: underline;
+}
+
 /*
  * Hide the element that this is applied on when on a desktop device
  */


### PR DESCRIPTION
closes: #2837 

### Visible/Frontend Changes

- [x] clicking on entity-link should navigate to its details view