### PR TITLE
fix: Add required validation for applicableForEntityTypes field

### DIFF
--- a/src/app/core/entity/edit-entity-type/edit-entity-type.component.html
+++ b/src/app/core/entity/edit-entity-type/edit-entity-type.component.html
@@ -4,4 +4,9 @@
     [formControl]="formControl"
     [multi]="multi"
   ></app-entity-type-select>
+  @if (formControl.invalid && formControl.touched) {
+    <mat-error>
+      <app-error-hint [form]="formControl"></app-error-hint>
+    </mat-error>
+  }
 </mat-form-field>

--- a/src/app/core/entity/edit-entity-type/edit-entity-type.component.ts
+++ b/src/app/core/entity/edit-entity-type/edit-entity-type.component.ts
@@ -2,8 +2,9 @@ import { Component, OnInit } from "@angular/core";
 import { EditComponent } from "../default-datatype/edit-component";
 import { DynamicComponent } from "../../config/dynamic-components/dynamic-component.decorator";
 import { EntityTypeSelectComponent } from "../entity-type-select/entity-type-select.component";
-import { MatFormField, MatLabel } from "@angular/material/form-field";
+import { MatError, MatFormField, MatLabel } from "@angular/material/form-field";
 import { ReactiveFormsModule } from "@angular/forms";
+import { ErrorHintComponent } from "app/core/common-components/error-hint/error-hint.component";
 
 /**
  * Edit component for selecting an entity type from a dropdown.
@@ -17,6 +18,8 @@ import { ReactiveFormsModule } from "@angular/forms";
     MatFormField,
     MatLabel,
     ReactiveFormsModule,
+    ErrorHintComponent,
+    MatError,
   ],
   standalone: true,
 })

--- a/src/app/features/template-export/template-export.entity.ts
+++ b/src/app/features/template-export/template-export.entity.ts
@@ -49,6 +49,7 @@ export class TemplateExport extends Entity {
     labelShort: $localize`:TemplateExport:Entity Types`,
     editComponent: "EditEntityType",
     isArray: true,
+    validators: { required: true },
   })
   applicableForEntityTypes: string[];
 


### PR DESCRIPTION
closes: #2703 

### Visible/Frontend Changes

- [x] Applicable Entity type" marked as a mandatory field in the Add new export template screen