### PR TITLE
Notification userid

### DIFF
--- a/src/app/features/notification/model/notification-config.ts
+++ b/src/app/features/notification/model/notification-config.ts
@@ -30,9 +30,15 @@ export class NotificationConfig extends Entity {
 
   /**
    * Helper method to access the user ID for whom this config is.
+   *
+   * Persisted to the database as to make permission checks easier.
    */
-  getUserId(): string {
-    return this.getId();
+  @DatabaseField() get userId(): string {
+    return this.getId(true);
+  }
+
+  set userId(value: string) {
+    // do not set manually, this is inferred from _id only
   }
 }
 


### PR DESCRIPTION
see https://github.com/Aam-Digital/ndb-core/issues/2847

Make userId available on NotificationConfig entity because replication-backend cannot have a placeholder in combination with normal text (yet)

i.e.
possible:
```
{
  "subject": "NotificationConfig",
  "action": "manage",
  "conditions": {
    "userId": "${user.id}"
  }
},
```

not supported in backend:
```
{
  "subject": "NotificationConfig",
  "action": "manage",
  "conditions": {
    "_id": "NotificationConfig:${user.id}"
  }
},
```

related to https://github.com/Aam-Digital/replication-backend/pull/171