### PR TITLE
The Entity Actions column (with buttons) should always be the least possible width

### DIFF
--- a/src/app/core/common-components/entities-table/entities-table.component.scss
+++ b/src/app/core/common-components/entities-table/entities-table.component.scss
@@ -39,3 +39,10 @@
 .inactive-row {
   color: colors.$inactive;
 }
+
+/* adjust action coloumn width to use least possible width */
+.mat-column-__edit {
+  flex: 0 0 auto !important;
+  width: 78px;
+  padding-right: 0;
+}


### PR DESCRIPTION
closes: #2838

### Visible/Frontend Changes

- [x] The entity action icon now uses the least possible width.

