### PR TITLE
fix(core): emit valueChange in all CustomFormControls like dropdowns

### DIFF
--- a/src/app/core/common-components/basic-autocomplete/custom-form-control.directive.ts
+++ b/src/app/core/common-components/basic-autocomplete/custom-form-control.directive.ts
@@ -86,8 +86,11 @@ export abstract class CustomFormControlDirective<T>
   }
 
   set value(value: T) {
+    if (value === this._value) return;
+
     this._value = value;
     this.onChange(value);
+    this.valueChange.emit(value);
     this.stateChanges.next();
   }
 


### PR DESCRIPTION
to ensure components like entity-field-select can be used with two-way data binding instead of a formControl also