### PR TITLE
feat: Lint and type-check e2e test code

### DIFF
--- a/.github/workflows/on-master-push.yml
+++ b/.github/workflows/on-master-push.yml
@@ -26,6 +26,19 @@ jobs:
           destination_dir: documentation
           force_orphan: true
 
+  code-qualty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm install --ci
+      - run: npx eslint
+      - run: npx tsc -p e2e
+
   test:
     strategy:
       fail-fast: false
@@ -76,7 +89,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: lts/*
           cache: npm
 
       - run: npm install --ci

--- a/.github/workflows/on-master-push.yml
+++ b/.github/workflows/on-master-push.yml
@@ -26,7 +26,7 @@ jobs:
           destination_dir: documentation
           force_orphan: true
 
-  code-qualty:
+  code-quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request-update-or-push-tag.yml
+++ b/.github/workflows/pull-request-update-or-push-tag.yml
@@ -10,7 +10,7 @@ env:
   REGISTRY_IMAGE: aamdigital/ndb-server
 
 jobs:
-  code-qualty:
+  code-quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request-update-or-push-tag.yml
+++ b/.github/workflows/pull-request-update-or-push-tag.yml
@@ -10,6 +10,19 @@ env:
   REGISTRY_IMAGE: aamdigital/ndb-server
 
 jobs:
+  code-qualty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm install --ci
+      - run: npx eslint
+      - run: npx tsc -p e2e
+
   prepare-code-coverage:
     runs-on: ubuntu-latest
     env:
@@ -143,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: lts/*
           cache: npm
 
       - run: npm install --ci

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -74,7 +74,6 @@ RUN if [ -n "${TZ}" ] ; then \
     cp /usr/share/zoneinfo/Europe/Brussels /etc/localtime && \
     echo "$TZ" > /etc/timezone ; fi
 
-RUN npm run lint
 ARG CHROME_BIN=/usr/lib/chromium/chromium
 RUN npm run test-ci
 

--- a/e2e/tests/attendance-tests.spec.ts
+++ b/e2e/tests/attendance-tests.spec.ts
@@ -177,7 +177,7 @@ test("Attendance Dashboard View", async ({ page }) => {
     }
   } else {
     // If there are no absent students, assert that the "no current entries" message is visible
-    const noEntriesMessage = await page.locator('text="no current entries"');
+    const noEntriesMessage = page.locator('text="no current entries"');
     await expect(noEntriesMessage).toBeVisible();
   }
   //Verify for the absences last week
@@ -222,7 +222,7 @@ test("Attendance Dashboard View", async ({ page }) => {
     }
   } else {
     // If there are no absent students, assert that the "no current entries" message is visible
-    const noEntriesMessage = await page.locator('text="no current entries"');
+    const noEntriesMessage = page.locator('text="no current entries"');
     await expect(noEntriesMessage).toBeVisible();
   }
 });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": []
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,10 @@
+import * as path from "node:path";
 import { defineConfig } from "eslint/config";
 import angular from "angular-eslint";
 import prettier from "eslint-plugin-prettier/recommended";
 import storybook from "eslint-plugin-storybook";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
 
 export default defineConfig([
   { ignores: [".angular", "dist", "doc/compodoc"] },
@@ -33,6 +36,19 @@ export default defineConfig([
       ],
 
       "@angular-eslint/no-output-native": "off",
+    },
+  },
+  {
+    files: ["e2e/**/*.ts"],
+    extends: [
+      eslint.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+    ],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: path.join(import.meta.dirname, "e2e"),
+      },
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,15 +64,12 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.2.8",
-        "@angular-eslint/builder": "^19.3.0",
-        "@angular-eslint/eslint-plugin": "^19.3.0",
-        "@angular-eslint/eslint-plugin-template": "^19.3.0",
         "@angular-eslint/schematics": "^19.3.0",
-        "@angular-eslint/template-parser": "^19.3.0",
         "@angular/cli": "^19.2.7",
         "@angular/compiler-cli": "^19.2.6",
         "@babel/core": "^7.26.10",
         "@compodoc/compodoc": "^1.1.26",
+        "@eslint/js": "^9.26.0",
         "@percy/cli": "^1.30.9",
         "@playwright/test": "^1.51.1",
         "@schematics/angular": "^19.2.7",
@@ -93,7 +90,6 @@
         "angular-eslint": "^19.4.0",
         "babel-loader": "^10.0.0",
         "eslint": "^9.24.0",
-        "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-prettier": "^5.2.6",
         "eslint-plugin-storybook": "^0.12.0",
         "jasmine-core": "^5.6.0",
@@ -110,6 +106,7 @@
         "storybook": "^8.6.12",
         "ts-node": "^10.9.2",
         "typescript": "~5.8.3",
+        "typescript-eslint": "^8.32.1",
         "xliff": "^6.2.2"
       }
     },
@@ -3805,9 +3802,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13718,6 +13715,8 @@
       "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13802,6 +13801,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -24133,7 +24142,6 @@
       "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "ng build --configuration production",
     "test": "ng test",
     "test-ci": "ng test --code-coverage --karma-config=build/karma-ci.conf.js ",
-    "lint": "ng lint ndb-core",
+    "lint": "eslint",
     "e2e": "playwright test",
     "e2e:debug": "playwright test --headed --timeout=0",
     "percy-storybook": "npm run build-storybook && percy storybook ./storybook-static",
@@ -87,6 +87,7 @@
     "@angular/compiler-cli": "^19.2.6",
     "@babel/core": "^7.26.10",
     "@compodoc/compodoc": "^1.1.26",
+    "@eslint/js": "^9.26.0",
     "@percy/cli": "^1.30.9",
     "@playwright/test": "^1.51.1",
     "@schematics/angular": "^19.2.7",
@@ -123,6 +124,7 @@
     "storybook": "^8.6.12",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
+    "typescript-eslint": "^8.32.1",
     "xliff": "^6.2.2"
   },
   "overrides": {


### PR DESCRIPTION
Lint and type-check e2e test code. I’ve created a separate tsconfig file for the e2e code so that we cna start with best practices like setting strict mode.

I also created a new `code-quality` step in the workflows and moved the lint step there from the test step. This means we can run the steps in parallel and get quicker feedback.

I opted to run `eslint` instead of `ng lint ndb-core` because the former is more flexible and faster.