### PR TITLE
refactor: Prepare for new Angular build system

### DIFF
--- a/src/app/utils/parse-xliff-to-js.ts
+++ b/src/app/utils/parse-xliff-to-js.ts
@@ -1,4 +1,4 @@
-const xliff = require("xliff");
+import xliff from "xliff";
 
 /**
  * Parses a XLIFF text to a JSON object with the structure needed for `loadTranslations()` by Angular
@@ -8,7 +8,7 @@ const xliff = require("xliff");
  * @param translations a XLIFF text
  * @returns {Promise<{}>} with the JSON object
  */
-module.exports = async (translations) => {
+export default async function (translations): Promise<unknown> {
   const parserResult = await xliff.xliff12ToJs(translations, {
     captureSpacesBetweenElements: true,
   });
@@ -30,4 +30,4 @@ module.exports = async (translations) => {
     }
     return result;
   }, {});
-};
+}

--- a/src/bootstrap-i18n.ts
+++ b/src/bootstrap-i18n.ts
@@ -4,7 +4,7 @@ import {
 } from "./app/core/language/language-statics";
 import { loadTranslations } from "@angular/localize";
 import { registerLocaleData } from "@angular/common";
-import * as parseXliffToJson from "./app/utils/parse-xliff-to-js";
+import parseXliffToJson from "./app/utils/parse-xliff-to-js";
 
 /**
  * Load translation files and apply them to angular localize system.
@@ -32,9 +32,16 @@ export async function initLanguage(locale?: string): Promise<void> {
   $localize.locale = locale;
   // This is needed for locale-aware components & pipes to work.
   // Add the required locales to `webpackInclude` to keep the bundle size small
-  const localeModule = await import(
-    /* webpackInclude: /(fr|de|it)\.mjs/ */
-    `../node_modules/@angular/common/locales/${locale}`
-  );
-  registerLocaleData(localeModule.default);
+  let localeModule;
+  if (locale == "de") {
+    localeModule = await import("@angular/common/locales/de");
+  } else if (locale == "fr") {
+    localeModule = await import("@angular/common/locales/fr");
+  } else if (locale == "it") {
+    localeModule = await import("@angular/common/locales/it");
+  }
+
+  if (localeModule) {
+    registerLocaleData(localeModule.default);
+  }
 }


### PR DESCRIPTION
This is the first set of fixes for issues that popped up when I tried to change the Angular build architect
1. Convert CommonJS modules in the codebase to ES modules
2. Hardcode dynamic import identifiers
