### PR TITLE
Make e2e test code and app code compatible

### DIFF
--- a/build/karma-ci.conf.js
+++ b/build/karma-ci.conf.js
@@ -14,21 +14,22 @@
  *     You should have received a copy of the GNU General Public License
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
+import * as path from "node:path";
 
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 // This file karma configuration is used by the pipeline. It uses the chrome headless browser in no-sandbox mode
 
-module.exports = function (config) {
+export default function (config) {
   config.set({
     basePath: "..",
     frameworks: ["jasmine", "@angular-devkit/build-angular"],
     plugins: [
-      require("karma-jasmine"),
-      require("karma-chrome-launcher"),
-      require("karma-jasmine-html-reporter"),
-      require("karma-coverage"),
-      require("@angular-devkit/build-angular/plugins/karma"),
+      "karma-jasmine",
+      "karma-chrome-launcher",
+      "karma-jasmine-html-reporter",
+      "karma-coverage",
+      "@angular-devkit/build-angular/plugins/karma",
     ],
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
@@ -40,7 +41,7 @@ module.exports = function (config) {
       "text/x-typescript": ["ts", "tsx"],
     },
     coverageReporter: {
-      dir: require("path").join(__dirname, "../coverage"),
+      dir: path.join(import.meta.dirname, "..", "coverage"),
       reporters: [{ type: "lcovonly", subdir: "." }],
     },
     angularCli: {
@@ -62,4 +63,4 @@ module.exports = function (config) {
     browsers: ["ChromeCustom"],
     singleRun: true,
   });
-};
+}

--- a/e2e/tests/attendance-tests.spec.ts
+++ b/e2e/tests/attendance-tests.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "#e2e/fixtures.ts";
+import { expect, test } from "#e2e/fixtures.js";
 
 test("Record attendance for one activity", async ({ page }) => {
   await page.getByRole("navigation").getByText("Attendance").click();

--- a/e2e/tests/dashboard-tests.spec.ts
+++ b/e2e/tests/dashboard-tests.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, argosScreenshot } from "#e2e/fixtures.ts";
+import { expect, test, argosScreenshot } from "#e2e/fixtures.js";
 
 test("Dashboard widgets and actions", async ({ page }) => {
   await expect(page.getByText("Quick Actions")).toBeVisible();

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,14 +1,12 @@
 {
+  "extends": ["../tsconfig.json"],
+  "exclude": [],
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "target": "ESNext",
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "strict": true,
     "allowImportingTsExtensions": true,
+    "strict": true,
     "isolatedModules": true,
-    "skipLibCheck": true,
     "types": [
       "node"
     ]

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "allowImportingTsExtensions": true,
     "strict": true,
     "isolatedModules": true,
     "types": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,16 +1,18 @@
+import * as path from "node:path";
+
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 
-module.exports = function (config) {
+export default function (config) {
   config.set({
     basePath: "",
     frameworks: ["jasmine", "@angular-devkit/build-angular"],
     plugins: [
-      require("karma-jasmine"),
-      require("karma-chrome-launcher"),
-      require("karma-jasmine-html-reporter"),
-      require("karma-coverage"),
-      require("@angular-devkit/build-angular/plugins/karma"),
+      "karma-jasmine",
+      "karma-chrome-launcher",
+      "karma-jasmine-html-reporter",
+      "karma-coverage",
+      "@angular-devkit/build-angular/plugins/karma",
     ],
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
@@ -23,7 +25,7 @@ module.exports = function (config) {
       "text/x-typescript": ["ts", "tsx"],
     },
     coverageReporter: {
-      dir: require("path").join(__dirname, "coverage"),
+      dir: path.join(import.meta.dirname, "..", "coverage"),
       reporters: [{ type: "html" }, { type: "lcovonly" }],
     },
     angularCli: {
@@ -41,4 +43,4 @@ module.exports = function (config) {
     singleRun: false,
     retryLimit: 10,
   });
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "prettier": "^3.5.3",
         "storybook": "^8.6.12",
         "ts-node": "^10.9.2",
+        "tsx": "^4.19.4",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.32.1",
         "xliff": "^6.2.2"
@@ -16315,6 +16316,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-uri": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
@@ -22975,6 +22989,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -25518,6 +25542,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tuf-js": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stream": "./node_modules/stream-browserify"
   },
   "imports": {
+    "#src/*": "./src/*",
     "#e2e/*": "./e2e/*"
   },
   "dependencies": {
@@ -127,6 +128,7 @@
     "prettier": "^3.5.3",
     "storybook": "^8.6.12",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.32.1",
     "xliff": "^6.2.2"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ndb-core",
   "version": "0.0.0",
   "license": "GPL-3.0",
+  "type": "module",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from "@playwright/test";
+import "tsx/esm";
+
+// Prevent the `scource-map-support` package used by playwright from taking care
+// of remapping stack traces. Instead we want Node’s native source map support
+// used by `tsx` to work.
+delete Error.prepareStackTrace;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: "./e2e/tests",
+  // Let `tsx` take care of transforming code
+  build: { external: ["*"] },
 
   reporter: [
     ["list"],

--- a/src/app/child-dev-project/children/demo-data-generators/fixtures/religions.ts
+++ b/src/app/child-dev-project/children/demo-data-generators/fixtures/religions.ts
@@ -1,3 +1,5 @@
+import { $localize } from "@angular/localize/init";
+
 export const religions = [
   // multiple entries for the same value increase its probability
   $localize`:religion:Hindu`,

--- a/src/app/child-dev-project/warning-level.ts
+++ b/src/app/child-dev-project/warning-level.ts
@@ -1,3 +1,4 @@
+import { $localize } from "@angular/localize/init";
 import { Ordering } from "../core/basic-datatypes/configurable-enum/configurable-enum-ordering";
 
 export enum WarningLevel {

--- a/src/app/core/common-components/entities-table/value-accessor/value-accessor.ts
+++ b/src/app/core/common-components/entities-table/value-accessor/value-accessor.ts
@@ -1,4 +1,4 @@
-import moment from "moment/moment";
+import moment from "moment";
 import { GeoLocation } from "app/features/location/geo-location";
 import { ConfigurableEnumValue } from "app/core/basic-datatypes/configurable-enum/configurable-enum.types";
 

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -15,6 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { $localize } from "@angular/localize/init";
 import { EntitySchemaField } from "../schema/entity-schema-field";
 import { Entity } from "../model/entity";
 import { ColumnMapping } from "../../import/column-mapping";


### PR DESCRIPTION
With #2995 we plan to import app code in the test runner. This PR prepares for that change.

* Remove CommonJS/Angular quirks from app code
* Align tsconfig between code bases
* Use [tsx](https://github.com/privatenumber/tsx) to support app’s tsconfig in test runner. We want the e2e test code run by Playwright to be transformed with TypeScripts [`experimentalDecorators`][1] option. Playwrights builtin
transformer [does not support][2] this option. Instead we disable the builtin transformer and use `tsx`.

[1]: https://www.typescriptlang.org/tsconfig/#experimentalDecorators
[2]: https://playwright.dev/docs/test-typescript#tsconfigjson
