### PR TITLE
refactor: Type-check app code on CI

### DIFF
--- a/.github/workflows/_qa.yaml
+++ b/.github/workflows/_qa.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - run: npm install --ci
       - run: npx eslint --max-warnings=0
+      - run: npx tsc -p .
       - run: npx tsc -p e2e
       - name: actionlint
         run: |

--- a/src/app/core/user/user-security/user-security.stories.ts
+++ b/src/app/core/user/user-security/user-security.stories.ts
@@ -31,7 +31,7 @@ export default {
         {
           provide: SessionSubject,
           useValue: new BehaviorSubject<SessionInfo>({
-            roles: [KeycloakAuthService.ACCOUNT_MANAGER_ROLE],
+            roles: [],
             name: "tester",
             id: "tester",
           }),


### PR DESCRIPTION

I think it’s a good idea to type-check all app code separately. This surfaced on
type issue in one of the Storybook stories.
