### PR TITLE
fix: avoid errors while re-routing for not-found notes

### DIFF
--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -107,6 +107,12 @@ export class NoteDetailsComponent
   override async ngOnChanges(changes: SimpleChanges) {
     await super.ngOnChanges(changes);
 
+    await this.initForm();
+  }
+
+  private async initForm() {
+    if (!this.entity) return;
+
     this.topFieldGroups = this.topForm.map((f) => ({ fields: [f] }));
     this.bottomFieldGroups = [{ fields: this.bottomForm }];
 

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -171,7 +171,7 @@ export class EntitiesTableComponent<T extends Entity>
     }
   }
 
-  _columnsToDisplay: string[];
+  _columnsToDisplay: string[] = [];
 
   @Input() set entityType(value: EntityConstructor<T>) {
     this._entityType = value;
@@ -427,9 +427,7 @@ export class EntitiesTableComponent<T extends Entity>
 
   private inferDefaultSort(): Sort {
     // initial sorting by first column, ensure that not the 'action' column is used
-    const sortBy = (this._columnsToDisplay ?? []).filter(
-      (c) => !c.startsWith("__"),
-    )[0];
+    const sortBy = this._columnsToDisplay.filter((c) => !c.startsWith("__"))[0];
     const sortByColumn = this._columns.find((c) => c.id === sortBy);
 
     let sortDirection: SortDirection = "asc";


### PR DESCRIPTION
when navigating to a note ID that is not found, Sentry still picked up errors before the app correctly navigates to the 404 page. Preventing init if no entity is defined now.