### PR TITLE
Properly limit width of autocomplete dropdown browsers other than Webkit

### DIFF
--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.scss
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.scss
@@ -20,7 +20,7 @@ em {
 
 ::ng-deep {
   .cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
-    width: -webkit-fill-available !important;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Before it looked like this on Firefox

![Screenshot 2025-06-13 at 10-46-08 Aam Digital - Demo](https://github.com/user-attachments/assets/c81f28f6-fc47-42dc-b2f5-4cefb8c0a252)

Now it’s fixed and looks the same across all browsers

![Screenshot 2025-06-13 at 10-47-13 Aam Digital - Demo](https://github.com/user-attachments/assets/0b344e4e-5585-4c02-b037-891ff44ae620)
