### PR TITLE
fix: remove unnecessary default values in ReportConfig entity

### DIFF
--- a/src/app/features/reporting/report-config.ts
+++ b/src/app/features/reporting/report-config.ts
@@ -36,10 +36,10 @@ class ReportConfig extends Entity {
   @DatabaseField() neededArgs?: string[] = [];
 
   /** (reporting/exporting only, in browser reports) the definitions to calculate the report's aggregations */
-  @DatabaseField() aggregationDefinitions: any[] = [];
+  @DatabaseField() aggregationDefinitions: any[];
 
   /** (sql v1 only) the definition to calculate the report */
-  @DatabaseField() aggregationDefinition: string | undefined = undefined;
+  @DatabaseField() aggregationDefinition: string | undefined;
 
   /**
    *  (sql v2 only) transformations that are applied to input variables (e.g. startDate, endDate)

--- a/src/app/features/reporting/reporting/reporting.component.spec.ts
+++ b/src/app/features/reporting/reporting/reporting.component.spec.ts
@@ -252,6 +252,7 @@ describe("ReportingComponent", () => {
     mockDataTransformationService.queryAndTransformData.and.resolveTo(data);
     const report = new ReportEntity();
     report.mode = "exporting";
+    report.aggregationDefinitions = [];
 
     await component.calculateResults(report, new Date(), new Date());
 


### PR DESCRIPTION
to keep config simple for admins

- closes #3157
