### PR TITLE
chore: Clarify current state of browser support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,12 +1,14 @@
-# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
-# For additional information regarding the format and rule options, please see:
-# https://github.com/browserslist/browserslist#queries
+# Define supported browsers
+#
+# Angular will ensure that CSS and JS syntax features are transpiled to work for
+# these browsers. Polyfills for JS or Web standard libraries will NOT be
+# included.
+#
+# The list is based on usage data.
+# See https://github.com/browserslist/browserslist#queries for reference.
 
-# You can see what browsers were selected by your queries by running:
-#   npx browserslist
-
-> 0.5%
-last 2 versions
-Firefox ESR
-not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+ChromeAndroid >= 131
+Chrome >= 131
+Firefox >= 133
+Edge >= 131
+Safari >= 16.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,12 +22,15 @@
     "importHelpers": true,
     "allowSyntheticDefaultImports": true,
     "useDefineForClassFields": false,
-    // TODO fix decorator issues caused by the changed initialization order
-    "target": "ES2022",
-    "module": "ES2022",
+    // we ensure browser compatibility through babel and .browserslistrc
+    "target": "ESNext",
+    "module": "ESNext",
     "resolveJsonModule": true,
     "lib": [
-      "ES2022",
+      // NOTE: If you change this you must use caniuse.com to ensure that the
+      // targeted browsers (as defined in `.browserlistsrc`) support all
+      // language features. No polyfills are used.
+      "ES2023",
       "dom"
     ],
     "types": [


### PR DESCRIPTION

Based on the [discussion in #3175](https://github.com/Aam-Digital/ndb-core/pull/3175#discussion_r2242332558) I clarified the current state of browser support and browser targeting. We can change this in the future but I found it useful to have the current state documented.

* Update `.browserlistsrc` to the currently used browsers
* Update the `lib` setting in `tsconfig.json` to ES2023. All supported browsers [support ES2023](https://caniuse.com/?search=ES2023) (except for [WeakMap with non-registered keys](https://caniuse.com/mdn-javascript_builtins_weakmap_symbol_as_keys))
* Make it clear that no polyfills are used
* Define a sensible policy for updating `lib` to a newer version that considers that no polyfills are used at the moment.
