### PR TITLE
Fix race condition in `app-entity-select`

### DIFF
--- a/e2e/tests/attendance-tests.spec.ts
+++ b/e2e/tests/attendance-tests.spec.ts
@@ -269,11 +269,6 @@ test("Assign a recurring activity to a user", async ({ page }) => {
   // When I assign myself
   await page.getByRole("button", { name: "Edit" }).click();
   await page.getByLabel("Assigned user(s)").click();
-
-  // wait to ensure the dropdown option is rendered and interactable, to avoid playwriting timeout issue
-  await page
-    .getByRole("option", { name: currentUser.name, exact: true })
-    .waitFor({ timeout: 10000 });
   await page
     .getByRole("option", { name: currentUser.name, exact: true })
     .click();

--- a/src/app/core/common-components/entity-select/entity-select.component.html
+++ b/src/app/core/common-components/entity-select/entity-select.component.html
@@ -6,14 +6,14 @@
   <div class="autocomplete-container">
     <app-basic-autocomplete
       #autocomplete
-      [formControl]="form"
+      [formControl]="form()"
       [valueMapper]="entityToId"
       [optionToString]="accessor"
       (autocompleteFilterChange)="recalculateMatchingInactive($event)"
       [multi]="multi"
       [display]="showEntities ? 'chips' : 'none'"
-      [options]="availableOptions | async"
-      [placeholder]="(loading | async) ? loadingPlaceholder : placeholder"
+      [options]="availableOptions()"
+      [placeholder]="loading() ? loadingPlaceholder : placeholder"
       [createOption]="disableCreateNew ? null : createNewEntity"
     >
       <ng-template let-item>
@@ -21,18 +21,18 @@
           <app-entity-block
             style="margin: auto"
             [entity]="item"
-            [linkDisabled]="form.enabled"
+            [linkDisabled]="form().enabled"
           ></app-entity-block>
         }
       </ng-template>
 
-      @if (currentlyMatchingInactive > 0) {
+      @if (currentlyMatchingInactive() > 0) {
         <ng-container autocompleteFooter>
           <mat-slide-toggle
-            [checked]="includeInactive"
+            [checked]="includeInactive()"
             (toggleChange)="toggleIncludeInactive()"
             i18n="Label for checkbox|e.g. include inactive children"
-            >Also show {{ currentlyMatchingInactive }} inactive
+            >Also show {{ currentlyMatchingInactive() }} inactive
           </mat-slide-toggle>
         </ng-container>
       }
@@ -42,7 +42,7 @@
       role="combobox"
       [attr.aria-labelledby]="formField.getLabelId()"
     >
-      @if (form.enabled) {
+      @if (form().enabled) {
         <fa-icon
           icon="caret-down"
           class="form-field-icon-suffix"
@@ -66,9 +66,9 @@
     </mat-hint>
   }
 
-  @if (form.errors) {
+  @if (form().errors) {
     <mat-error>
-      <app-error-hint [form]="form"></app-error-hint>
+      <app-error-hint [form]="form()"></app-error-hint>
     </mat-error>
   }
 </mat-form-field>

--- a/src/app/utils/resourceWithRetention.spec.ts
+++ b/src/app/utils/resourceWithRetention.spec.ts
@@ -1,0 +1,43 @@
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { signal } from "@angular/core";
+import { resourceWithRetention } from "./resourceWithRetention";
+
+describe("resourceWithRetention", () => {
+  it("retains previous value during loading", fakeAsync(() => {
+    let resolvePromise: (value: string) => void;
+
+    const params = signal("initial");
+    const resource = TestBed.runInInjectionContext(() =>
+      resourceWithRetention({
+        params,
+        loader: () => {
+          return new Promise<string>((resolve) => {
+            resolvePromise = resolve;
+          });
+        },
+      }),
+    );
+    tick();
+    expect(resource.value()).toBe(undefined);
+    expect(resource.isLoading()).toBe(true);
+    expect(resource.status()).toBe("loading");
+
+    resolvePromise("first-value");
+    tick();
+    expect(resource.value()).toBe("first-value");
+    expect(resource.isLoading()).toBe(false);
+    expect(resource.status()).toBe("resolved");
+
+    params.set("updated");
+    tick();
+    expect(resource.value()).toBe("first-value");
+    expect(resource.isLoading()).toBe(true);
+    expect(resource.status()).toBe("loading");
+
+    resolvePromise("second-value");
+    tick();
+    expect(resource.value()).toBe("second-value");
+    expect(resource.isLoading()).toBe(false);
+    expect(resource.status()).toBe("resolved");
+  }));
+});

--- a/src/app/utils/resourceWithRetention.ts
+++ b/src/app/utils/resourceWithRetention.ts
@@ -1,0 +1,34 @@
+import {
+  linkedSignal,
+  resource,
+  ResourceOptions,
+  ResourceRef,
+} from "@angular/core";
+
+/**
+ * Creates a resource that retains its previous value when reloading.
+ *
+ * This function is similar to {@link resource} except while reloading. When
+ * `isLoading()` is true, `value()` holds the previously loaded value instead of
+ * `undefined` or `defaultValue`.
+ */
+export function resourceWithRetention<T, R>(
+  options: ResourceOptions<T, R>,
+): ResourceRef<T | undefined> {
+  const r = resource(options);
+  const retainedValue = linkedSignal<{ value: T; isLoading: boolean }, T>({
+    source: () => ({ value: r.value(), isLoading: r.isLoading() }),
+    computation: (newValue, previous) =>
+      newValue.isLoading && previous ? previous.value : newValue.value,
+  });
+
+  return new Proxy(r, {
+    get(target, prop, receiver) {
+      if (prop === "value") {
+        return retainedValue.asReadonly();
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}


### PR DESCRIPTION

Before this change it could happen that `this.availableOptions.next(newAvailableEntities)` was called out of order which resulted in only the entity from `this.form.value` being displayed and not those loaded by `loadAvailbleEntities`. We rewrite the component with signals and Observables to prevent this issue.

See https://github.com/Aam-Digital/ndb-core/pull/3240#discussion_r2300337858
