### PR TITLE
Fix/matching info

### DIFF
--- a/src/app/core/basic-datatypes/configurable-enum/display-configurable-enum/display-configurable-enum.component.scss
+++ b/src/app/core/basic-datatypes/configurable-enum/display-configurable-enum/display-configurable-enum.component.scss
@@ -11,10 +11,13 @@
   vertical-align: middle;
   font-size: inherit;
   font-family: inherit;
-  max-width: 120px; // Cap width
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
+
+  // max width to get more consistent, clean look
+  // disable for now as it cuts too many important details
+  //max-width: 120px;
 }
 
 .bubble-list {

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.html
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.html
@@ -117,6 +117,13 @@
           >
             Select {{ (side.entityType | entityType)?.label }}
           </h3>
+
+          @if (side.multiSelect) {
+            <div class="selection-table-hint margin-bottom-regular" i18n>
+              Click on multiple rows below to match a group.
+            </div>
+          }
+
           <app-filter
             class="flex-row gap-regular flex-wrap"
             [filterConfig]="side.availableFilters"
@@ -124,6 +131,7 @@
             [entities]="side.availableEntities"
             (filterObjChange)="applySelectedFilters(side, $event)"
           ></app-filter>
+
           <app-entities-table
             [entityType]="side.entityType | entityType"
             [records]="side.availableEntities"

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.scss
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.scss
@@ -37,3 +37,11 @@
   position: absolute;
   right: 0;
 }
+
+.selection-table-hint {
+  font-size: 0.9em;
+  font-style: italic;
+
+  // replace the margin of the heading above
+  margin-top: -16px;
+}


### PR DESCRIPTION
- closes #2341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a multi-select hint in the matching screen: “Click on multiple rows below to match a group.”
  - Matching tables now support custom columns, read-only display, disabled row clicks, and filtering for clearer selection.
- Bug Fixes
  - Enum bubbles no longer get clipped; long values now display without an artificial width limit.
- Style
  - Introduced subtle italic styling for the selection hint and adjusted spacing under section headers for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->