### PR TITLE
chore(CI): pin Action to hash for security

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Stop container and remove folder
-        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         continue-on-error: true
         with:
           host: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/pull-request-opened.yml
+++ b/.github/workflows/pull-request-opened.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare server deployment
-        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}

--- a/.github/workflows/pull-request-updated.yml
+++ b/.github/workflows/pull-request-updated.yml
@@ -37,7 +37,7 @@ jobs:
       - build
     steps:
       - name: Deploy updated image
-        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}


### PR DESCRIPTION
security measure based on SonarCloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin a third-party deployment action to a fixed revision for more stable, predictable deployments while preserving existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->