### PR TITLE
fix: update default COUCHDB_URL and QUERY_URL to match docker-compose network aliases

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,10 +4,10 @@ COPY ./dist/ /usr/share/nginx/html
 
 # The port on which the app will run in the Docker container
 ENV PORT=8080
-# The url to the CouchDB database
-ENV COUCHDB_URL="http://localhost"
+# The url to the CouchDB database (default matches the network alias in docker-compose)
+ENV COUCHDB_URL="http://db-entrypoint:5984"
 # The url to the query backend, see https://github.com/Aam-Digital/query-backend
-ENV QUERY_URL="http://localhost:3000"
+ENV QUERY_URL="http://aam-backend-service:8080"
 # The url to a nominatim instance, see https://nominatim.org/
 ENV NOMINATIM_URL="https://nominatim.openstreetmap.org"
 


### PR DESCRIPTION
## Summary

Update the default values for `COUCHDB_URL` and `QUERY_URL` in the Dockerfile to match the Docker network aliases defined in the standard `docker-compose.yml` deployment (Aam-Digital/ndb-setup#86).

### Changes

| Env var | Old default | New default |
|---|---|---|
| `COUCHDB_URL` | `http://localhost` | `http://db-entrypoint:5984` |
| `QUERY_URL` | `http://localhost:3000` | `http://aam-backend-service:8080` |

### Why

With the SWAG proxy cleanup (Aam-Digital/ndb-setup#85), path-based routing (`/db`, `/api`, `/query`, `/nominatim`) is now fully handled by the app container's nginx. The old defaults (`localhost`) were never correct for any real deployment — they only "worked" because the SWAG proxy intercepted those paths before they reached the app container.

The new defaults use Docker network aliases (`db-entrypoint`, `aam-backend-service`) that are being added to `docker-compose.yml` in Aam-Digital/ndb-setup#86. This means existing deployments work correctly **without** needing to add explicit `COUCHDB_URL`/`QUERY_URL` environment variables to their docker-compose files.

Instances that need custom URLs can still override via environment variables as before.

### Related

- Aam-Digital/ndb-setup#85 (tracking issue)
- Aam-Digital/ndb-setup#86 (docker-compose network aliases + SWAG cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration values for internal service endpoints to align with updated network infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->