### PR TITLE
fix(#3597): check permissions and confirm before deleting linked user account

### DIFF
--- a/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
@@ -179,7 +179,6 @@ describe("EntityActionsService", () => {
     expect(snackBarSpy.open).toHaveBeenCalled();
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       singleTestEntity,
-      true,
     );
     expect(mockRouter.navigate).toHaveBeenCalled();
   });
@@ -196,15 +195,12 @@ describe("EntityActionsService", () => {
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledTimes(3);
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[0],
-      true,
     );
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[1],
-      true,
     );
     expect(mockedEntityDeleteService.deleteEntity).toHaveBeenCalledWith(
       severalTestEntities[2],
-      true,
     );
   });
 

--- a/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.spec.ts
@@ -11,7 +11,10 @@ import { Entity } from "../model/entity";
 import { NEVER, Observable, of, Subject } from "rxjs";
 import { Router } from "@angular/router";
 import { CoreTestingModule } from "../../../utils/core-testing.module";
-import { EntityDeleteService } from "./entity-delete.service";
+import {
+  EntityDeleteService,
+  EntityDeletionAbortedError,
+} from "./entity-delete.service";
 import { EntityAnonymizeService } from "./entity-anonymize.service";
 import { CascadingActionResult } from "./cascading-entity-action";
 import { PublicFormsService } from "app/features/public-form/public-forms.service";
@@ -166,6 +169,17 @@ describe("EntityActionsService", () => {
     expect(result).toBe(false);
     expect(snackBarSpy.open).not.toHaveBeenCalled();
     expect(mockedEntityDeleteService.deleteEntity).not.toHaveBeenCalled();
+  });
+
+  it("should return false when deletion is aborted in account confirmation", async () => {
+    mockedEntityDeleteService.deleteEntity.mockRejectedValue(
+      new EntityDeletionAbortedError(),
+    );
+
+    const result = await service.delete(new Entity());
+
+    expect(result).toBe(false);
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
   });
 
   it("should delete a single entity, show snackbar confirmation and navigate back", async () => {

--- a/src/app/core/entity/entity-actions/entity-actions.service.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.ts
@@ -5,7 +5,10 @@ import { ConfirmationDialogService } from "../../common-components/confirmation-
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Router } from "@angular/router";
 import { getUrlWithoutParams } from "../../../utils/utils";
-import { EntityDeleteService } from "./entity-delete.service";
+import {
+  EntityDeleteService,
+  EntityDeletionAbortedError,
+} from "./entity-delete.service";
 import { EntityAnonymizeService } from "./entity-anonymize.service";
 import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { CascadingActionResult } from "./cascading-entity-action";
@@ -159,7 +162,7 @@ export class EntityActionsService {
         $localize`:Delete confirmation dialog:
         This will remove the data permanently as if it never existed. This cannot be undone. Statistical reports (also for past time periods) will change and not include this record anymore.\n
         If you have not just created a record accidentally, deleting this is probably not what you want to do. If a record represents something that actually happened in your work, consider to use "anonymize" or just "archive" instead, so that you will not lose your documentation for reports.\n
-        Are you sure you want to delete ${textForDeleteEntity}?`,
+        Do you want to continue?`,
       ))
     ) {
       return false;
@@ -170,8 +173,16 @@ export class EntityActionsService {
     );
     let result = new CascadingActionResult();
 
-    for (let entity of entities) {
-      result.mergeResults(await this.entityDelete.deleteEntity(entity));
+    try {
+      for (let entity of entities) {
+        result.mergeResults(await this.entityDelete.deleteEntity(entity));
+      }
+    } catch (error: unknown) {
+      progressDialogRef.close();
+      if (error instanceof EntityDeletionAbortedError) {
+        return false;
+      }
+      throw error;
     }
 
     progressDialogRef.close();

--- a/src/app/core/entity/entity-actions/entity-actions.service.ts
+++ b/src/app/core/entity/entity-actions/entity-actions.service.ts
@@ -171,7 +171,7 @@ export class EntityActionsService {
     let result = new CascadingActionResult();
 
     for (let entity of entities) {
-      result.mergeResults(await this.entityDelete.deleteEntity(entity, true));
+      result.mergeResults(await this.entityDelete.deleteEntity(entity));
     }
 
     progressDialogRef.close();

--- a/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
@@ -16,10 +16,12 @@ import {
 import { expectEntitiesToMatch } from "../../../utils/expect-entity-data.spec";
 import { Note } from "../../../child-dev-project/notes/model/note";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
-import { throwError } from "rxjs";
+import { BehaviorSubject, of, throwError } from "rxjs";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { UserAdminService } from "../../user/user-admin-service/user-admin.service";
+import { SessionInfo, SessionSubject } from "../../session/auth/session-info";
 import { EntityMapperService } from "../entity-mapper/entity-mapper.service";
 import { DefaultDatatype } from "../default-datatype/default.datatype";
 import { AttendanceDatatype } from "#src/app/features/attendance/model/attendance.datatype";
@@ -36,20 +38,29 @@ describe("EntityDeleteService", () => {
     getConfirmation: Mock;
     showProgressDialog: Mock;
   };
-  let mockUserAdminService: { deleteUser: Mock };
+  let mockUserAdminService: { deleteUser: Mock; getUser: Mock };
+  let mockSessionSubject: BehaviorSubject<SessionInfo>;
 
   beforeEach(() => {
     snackBarSpy = {
       open: vi.fn(),
     };
+    mockSessionSubject = new BehaviorSubject<SessionInfo>({
+      id: "session-user-id",
+      name: "test-user",
+      roles: [],
+    });
+
     mockUserAdminService = {
       deleteUser: vi.fn(),
+      getUser: vi.fn(),
     };
     mockUserAdminService.deleteUser.mockReturnValue(
       throwError(() => {
         new Error();
       }),
     );
+    mockUserAdminService.getUser.mockReturnValue(of(null));
 
     mockConfirmationDialog = {
       getConfirmation: vi.fn(),
@@ -66,6 +77,7 @@ describe("EntityDeleteService", () => {
         EntityDeleteService,
         ...mockEntityMapperProvider(allEntities.map((e) => e.copy())),
         { provide: UserAdminService, useValue: mockUserAdminService },
+        { provide: SessionSubject, useValue: mockSessionSubject },
         { provide: MatSnackBar, useValue: snackBarSpy },
         { provide: DefaultDatatype, useClass: AttendanceDatatype, multi: true },
         {
@@ -125,20 +137,137 @@ describe("EntityDeleteService", () => {
     );
   });
 
-  it("should delete several entities and show dialog if keycloak deletion fails", async () => {
-    // given
+  it("should show error dialog if user account deletion fails after confirmation", async () => {
+    // given: account_manager with linked account confirms deletion, but Keycloak returns error
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
     mockUserAdminService.deleteUser.mockReturnValue(
       throwError(() => new Error()),
     );
+    mockConfirmationDialog.getConfirmation.mockResolvedValue(true);
     const userEntity = new TestEntity();
     TestEntity.enableUserAccounts = true;
 
     // when
-    await service.deleteEntity(userEntity, true);
+    await service.deleteEntity(userEntity);
 
-    // then
+    // then: confirmation dialog + error dialog = 2 calls
+    expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledTimes(2);
+
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should skip account deletion silently if current user lacks account_manager role", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({ id: "session-id", name: "test", roles: [] });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+
+    await service.deleteEntity(userEntity);
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(mockConfirmationDialog.getConfirmation).not.toHaveBeenCalled();
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should ask confirmation and delete account when user has account_manager role and confirms", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+    mockUserAdminService.deleteUser.mockReturnValue(of({ userDeleted: true }));
+    mockConfirmationDialog.getConfirmation.mockResolvedValue(true);
+
+    await service.deleteEntity(userEntity);
+
     expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledTimes(1);
+    expect(mockUserAdminService.deleteUser).toHaveBeenCalled();
+    TestEntity.enableUserAccounts = false;
+  });
 
+  it("should not delete account if user declines account deletion confirmation", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+    mockConfirmationDialog.getConfirmation.mockResolvedValue(false);
+
+    await service.deleteEntity(userEntity);
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should skip account deletion silently if no linked account exists", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+    mockUserAdminService.getUser.mockReturnValue(of(null));
+
+    await service.deleteEntity(userEntity);
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(mockConfirmationDialog.getConfirmation).not.toHaveBeenCalled();
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should not delete own account and show self-deletion warning (full entity ID)", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+      entityId: userEntity.getId(),
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+
+    await service.deleteEntity(userEntity);
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("own account"),
+      OkButton,
+    );
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should not delete own account and show self-deletion warning (short entity ID without type prefix)", async () => {
+    const userEntity = new TestEntity();
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+      entityId: userEntity.getId(true),
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+
+    await service.deleteEntity(userEntity);
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("own account"),
+      OkButton,
+    );
     TestEntity.enableUserAccounts = false;
   });
 

--- a/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
@@ -20,7 +20,10 @@ import { BehaviorSubject, of, throwError } from "rxjs";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
-import { UserAdminService } from "../../user/user-admin-service/user-admin.service";
+import {
+  UserAdminApiError,
+  UserAdminService,
+} from "../../user/user-admin-service/user-admin.service";
 import { SessionInfo, SessionSubject } from "../../session/auth/session-info";
 import { EntityMapperService } from "../entity-mapper/entity-mapper.service";
 import { DefaultDatatype } from "../default-datatype/default.datatype";
@@ -56,9 +59,7 @@ describe("EntityDeleteService", () => {
       getUser: vi.fn(),
     };
     mockUserAdminService.deleteUser.mockReturnValue(
-      throwError(() => {
-        new Error();
-      }),
+      throwError(() => new UserAdminApiError(500)),
     );
     mockUserAdminService.getUser.mockReturnValue(of(null));
 
@@ -146,7 +147,7 @@ describe("EntityDeleteService", () => {
     });
     mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
     mockUserAdminService.deleteUser.mockReturnValue(
-      throwError(() => new Error()),
+      throwError(() => new UserAdminApiError(500)),
     );
     mockConfirmationDialog.getConfirmation.mockResolvedValue(true);
     const userEntity = new TestEntity();
@@ -169,6 +170,7 @@ describe("EntityDeleteService", () => {
 
     await service.deleteEntity(userEntity);
 
+    expect(mockUserAdminService.getUser).not.toHaveBeenCalled();
     expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
     expect(mockConfirmationDialog.getConfirmation).not.toHaveBeenCalled();
     TestEntity.enableUserAccounts = false;
@@ -229,6 +231,7 @@ describe("EntityDeleteService", () => {
 
   it("should not delete own account and show self-deletion warning (full entity ID)", async () => {
     const userEntity = new TestEntity();
+    const removeSpy = vi.spyOn(entityMapper, "remove");
     TestEntity.enableUserAccounts = true;
     mockSessionSubject.next({
       id: "session-id",
@@ -238,9 +241,12 @@ describe("EntityDeleteService", () => {
     });
     mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
 
-    await service.deleteEntity(userEntity);
+    await expect(service.deleteEntity(userEntity)).rejects.toThrow(
+      "Entity deletion aborted by user",
+    );
 
     expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
     expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledWith(
       expect.any(String),
       expect.stringContaining("own account"),
@@ -251,6 +257,7 @@ describe("EntityDeleteService", () => {
 
   it("should not delete own account and show self-deletion warning (short entity ID without type prefix)", async () => {
     const userEntity = new TestEntity();
+    const removeSpy = vi.spyOn(entityMapper, "remove");
     TestEntity.enableUserAccounts = true;
     mockSessionSubject.next({
       id: "session-id",
@@ -260,14 +267,38 @@ describe("EntityDeleteService", () => {
     });
     mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
 
-    await service.deleteEntity(userEntity);
+    await expect(service.deleteEntity(userEntity)).rejects.toThrow(
+      "Entity deletion aborted by user",
+    );
 
     expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
     expect(mockConfirmationDialog.getConfirmation).toHaveBeenCalledWith(
       expect.any(String),
       expect.stringContaining("own account"),
       OkButton,
     );
+    TestEntity.enableUserAccounts = false;
+  });
+
+  it("should abort entity deletion when account confirmation is cancelled", async () => {
+    const userEntity = new TestEntity();
+    const removeSpy = vi.spyOn(entityMapper, "remove");
+    TestEntity.enableUserAccounts = true;
+    mockSessionSubject.next({
+      id: "session-id",
+      name: "test",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+    mockConfirmationDialog.getConfirmation.mockResolvedValue(undefined);
+
+    await expect(service.deleteEntity(userEntity)).rejects.toThrow(
+      "Entity deletion aborted by user",
+    );
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
     TestEntity.enableUserAccounts = false;
   });
 

--- a/src/app/core/entity/entity-actions/entity-delete.service.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.ts
@@ -4,13 +4,27 @@ import {
   CascadingActionResult,
   CascadingEntityAction,
 } from "./cascading-entity-action";
-import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
+import {
+  OkButton,
+  YesNoCancelButtons,
+} from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
-import { UserAdminService } from "../../user/user-admin-service/user-admin.service";
+import {
+  UserAdminApiError,
+  UserAdminService,
+} from "../../user/user-admin-service/user-admin.service";
 import { UserAccount } from "../../user/user-admin-service/user-account";
 import { SessionSubject } from "../../session/auth/session-info";
 import { itemReferencesId } from "../entity-mapper/entity-relations.service";
 import { firstValueFrom } from "rxjs";
+import { UserAccountActionGuardService } from "../../user/user-admin-service/user-account-action-guard.service";
+
+export class EntityDeletionAbortedError extends Error {
+  constructor() {
+    super("Entity deletion aborted by user");
+    this.name = "EntityDeletionAbortedError";
+  }
+}
 
 /**
  * Safely delete an entity including handling references with related entities.
@@ -22,6 +36,7 @@ import { firstValueFrom } from "rxjs";
 export class EntityDeleteService extends CascadingEntityAction {
   private userAdminService = inject(UserAdminService);
   private confirmationDialog = inject(ConfirmationDialogService);
+  private readonly accountActionGuard = inject(UserAccountActionGuardService);
   private readonly sessionInfo = inject(SessionSubject, { optional: true });
 
   /**
@@ -34,7 +49,10 @@ export class EntityDeleteService extends CascadingEntityAction {
    */
   async deleteEntity(entity: Entity): Promise<CascadingActionResult> {
     if (entity.getConstructor()?.enableUserAccounts) {
-      await this.handleUserAccountDeletion(entity);
+      const continueDeletion = await this.handleUserAccountDeletion(entity);
+      if (!continueDeletion) {
+        throw new EntityDeletionAbortedError();
+      }
     }
 
     const cascadeResult = await this.cascadeActionToRelatedEntities(
@@ -52,63 +70,71 @@ export class EntityDeleteService extends CascadingEntityAction {
     );
   }
 
-  private async handleUserAccountDeletion(entity: Entity): Promise<void> {
+  private async handleUserAccountDeletion(entity: Entity): Promise<boolean> {
+    const session = this.sessionInfo?.value;
+    if (!session?.roles.includes(UserAdminService.ACCOUNT_MANAGER_ROLE)) {
+      // Cannot manage accounts without admin role — skip silently
+      return true;
+    }
+
     let linkedAccount: UserAccount | null;
     try {
       linkedAccount = await firstValueFrom(
         this.userAdminService.getUser(entity.getId()),
       );
-    } catch {
-      // API inaccessible (e.g. 403 — no permission to query accounts) — skip silently
-      return;
+    } catch (error: unknown) {
+      if (
+        error instanceof UserAdminApiError &&
+        (error.status === 403 || error.status === 404)
+      ) {
+        // API inaccessible for this user or account does not exist — skip silently
+        return true;
+      }
+      throw error;
     }
 
     if (!linkedAccount) {
-      return;
+      return true;
     }
 
     if (
-      !this.sessionInfo.value?.roles.includes(
-        UserAdminService.ACCOUNT_MANAGER_ROLE,
-      )
+      this.accountActionGuard.isOwnAccount({ userEntityId: entity.getId() })
     ) {
-      // Cannot manage accounts without admin role — skip silently
-      return;
-    }
-
-    const sessionEntityId = this.sessionInfo.value?.entityId;
-    const isOwnAccount =
-      sessionEntityId !== undefined &&
-      (sessionEntityId === entity.getId() ||
-        sessionEntityId === entity.getId(true));
-
-    if (isOwnAccount) {
-      await this.confirmationDialog.getConfirmation(
-        $localize`:self-deletion warning title:Cannot delete own account`,
-        $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
-        OkButton,
+      await this.accountActionGuard.showSelfAccountActionBlockedWarning(
+        "delete",
       );
-      return;
+      return false;
     }
 
     const confirmed = await this.confirmationDialog.getConfirmation(
       $localize`:delete account confirmation title:Also delete linked user account?`,
       $localize`:delete account confirmation dialog:This entity has a linked user account. Do you also want to permanently delete the user account? This cannot be undone.`,
+      YesNoCancelButtons,
     );
 
+    if (confirmed === undefined) {
+      return false;
+    }
+
     if (!confirmed) {
-      return;
+      return true;
     }
 
     try {
       await firstValueFrom(this.userAdminService.deleteUser(entity.getId()));
-    } catch {
-      await this.confirmationDialog.getConfirmation(
-        $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
-        $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
-        OkButton,
-      );
+    } catch (error: unknown) {
+      if (error instanceof UserAdminApiError) {
+        await this.confirmationDialog.getConfirmation(
+          $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
+          $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
+          OkButton,
+        );
+        return true;
+      }
+      throw error;
     }
+
+    return true;
   }
 
   /**

--- a/src/app/core/entity/entity-actions/entity-delete.service.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.ts
@@ -22,7 +22,7 @@ import { firstValueFrom } from "rxjs";
 export class EntityDeleteService extends CascadingEntityAction {
   private userAdminService = inject(UserAdminService);
   private confirmationDialog = inject(ConfirmationDialogService);
-  private sessionInfo = inject(SessionSubject);
+  private readonly sessionInfo = inject(SessionSubject, { optional: true });
 
   /**
    * The actual delete action without user interactions.

--- a/src/app/core/entity/entity-actions/entity-delete.service.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.ts
@@ -7,7 +7,10 @@ import {
 import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { UserAdminService } from "../../user/user-admin-service/user-admin.service";
+import { UserAccount } from "../../user/user-admin-service/user-account";
+import { SessionSubject } from "../../session/auth/session-info";
 import { itemReferencesId } from "../entity-mapper/entity-relations.service";
+import { firstValueFrom } from "rxjs";
 
 /**
  * Safely delete an entity including handling references with related entities.
@@ -19,6 +22,7 @@ import { itemReferencesId } from "../entity-mapper/entity-relations.service";
 export class EntityDeleteService extends CascadingEntityAction {
   private userAdminService = inject(UserAdminService);
   private confirmationDialog = inject(ConfirmationDialogService);
+  private sessionInfo = inject(SessionSubject);
 
   /**
    * The actual delete action without user interactions.
@@ -27,26 +31,10 @@ export class EntityDeleteService extends CascadingEntityAction {
    * to support an undo action.
    *
    * @param entity
-   * @param showKeycloakWarning if keycloak deleteUser request fails, a popup warning is shown to the user
-   * @private
    */
-  async deleteEntity(
-    entity: Entity,
-    showKeycloakWarning = false,
-  ): Promise<CascadingActionResult> {
+  async deleteEntity(entity: Entity): Promise<CascadingActionResult> {
     if (entity.getConstructor()?.enableUserAccounts) {
-      this.userAdminService.deleteUser(entity.getId()).subscribe({
-        next: () => {},
-        error: () => {
-          if (showKeycloakWarning) {
-            this.confirmationDialog.getConfirmation(
-              $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
-              $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
-              OkButton,
-            );
-          }
-        },
-      });
+      await this.handleUserAccountDeletion(entity);
     }
 
     const cascadeResult = await this.cascadeActionToRelatedEntities(
@@ -62,6 +50,65 @@ export class EntityDeleteService extends CascadingEntityAction {
     return new CascadingActionResult([originalEntity]).mergeResults(
       cascadeResult,
     );
+  }
+
+  private async handleUserAccountDeletion(entity: Entity): Promise<void> {
+    let linkedAccount: UserAccount | null;
+    try {
+      linkedAccount = await firstValueFrom(
+        this.userAdminService.getUser(entity.getId()),
+      );
+    } catch {
+      // API inaccessible (e.g. 403 — no permission to query accounts) — skip silently
+      return;
+    }
+
+    if (!linkedAccount) {
+      return;
+    }
+
+    if (
+      !this.sessionInfo.value?.roles.includes(
+        UserAdminService.ACCOUNT_MANAGER_ROLE,
+      )
+    ) {
+      // Cannot manage accounts without admin role — skip silently
+      return;
+    }
+
+    const sessionEntityId = this.sessionInfo.value?.entityId;
+    const isOwnAccount =
+      sessionEntityId !== undefined &&
+      (sessionEntityId === entity.getId() ||
+        sessionEntityId === entity.getId(true));
+
+    if (isOwnAccount) {
+      await this.confirmationDialog.getConfirmation(
+        $localize`:self-deletion warning title:Cannot delete own account`,
+        $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
+        OkButton,
+      );
+      return;
+    }
+
+    const confirmed = await this.confirmationDialog.getConfirmation(
+      $localize`:delete account confirmation title:Also delete linked user account?`,
+      $localize`:delete account confirmation dialog:This entity has a linked user account. Do you also want to permanently delete the user account? This cannot be undone.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.userAdminService.deleteUser(entity.getId()));
+    } catch {
+      await this.confirmationDialog.getConfirmation(
+        $localize`:delete account in keycloak related error title:Keycloak User could not be deleted`,
+        $localize`:delete account in keycloak related error dialog:User Account could not be deleted in Keycloak. Please delete user manually in Keycloak.`,
+        OkButton,
+      );
+    }
   }
 
   /**

--- a/src/app/core/user/entity-user/entity-user.component.spec.ts
+++ b/src/app/core/user/entity-user/entity-user.component.spec.ts
@@ -10,6 +10,8 @@ import { SyncStateSubject } from "../../session/session-type";
 import { CurrentUserSubject } from "../../session/current-user-subject";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
 import { EntityAbility } from "../../permissions/ability/entity-ability";
+import { FaIconLibrary } from "@fortawesome/angular-fontawesome";
+import { fas } from "@fortawesome/free-solid-svg-icons";
 import type { SessionInfo } from "../../session/auth/session-info";
 import type { Mock } from "vitest";
 
@@ -86,6 +88,8 @@ describe("EntityUserComponent", () => {
         EntityAbility,
       ],
     }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIconPacks(fas);
 
     fixture = TestBed.createComponent(EntityUserComponent);
     component = fixture.componentInstance;

--- a/src/app/core/user/user-admin-service/user-account-action-guard.service.ts
+++ b/src/app/core/user/user-admin-service/user-account-action-guard.service.ts
@@ -1,0 +1,74 @@
+import { inject, Injectable } from "@angular/core";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
+import { SessionSubject } from "../../session/auth/session-info";
+
+export type SelfAccountAction = "delete" | "deactivate";
+
+@Injectable({
+  providedIn: "root",
+})
+export class UserAccountActionGuardService {
+  private readonly sessionInfo = inject(SessionSubject, { optional: true });
+  private readonly confirmationDialog = inject(ConfirmationDialogService);
+
+  isOwnAccount(account: {
+    userAccountId?: string | null;
+    userEntityId?: string | null;
+  }): boolean {
+    const session = this.sessionInfo?.value;
+    if (!session) {
+      return false;
+    }
+
+    if (account.userAccountId && session.id === account.userAccountId) {
+      return true;
+    }
+
+    if (!account.userEntityId || !session.entityId) {
+      return false;
+    }
+
+    return this.entityIdsMatch(session.entityId, account.userEntityId);
+  }
+
+  async showSelfAccountActionBlockedWarning(
+    action: SelfAccountAction,
+  ): Promise<void> {
+    if (action === "deactivate") {
+      await this.confirmationDialog.getConfirmation(
+        $localize`:self-deactivation warning title:Cannot disable own account`,
+        $localize`:self-deactivation warning dialog:You cannot disable your own account. Please ask another admin to deactivate your account if needed.`,
+        OkButton,
+      );
+      return;
+    }
+
+    await this.confirmationDialog.getConfirmation(
+      $localize`:self-deletion warning title:Cannot delete own account`,
+      $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
+      OkButton,
+    );
+  }
+
+  private entityIdsMatch(sessionEntityId: string, accountEntityId: string) {
+    if (sessionEntityId === accountEntityId) {
+      return true;
+    }
+
+    const sessionHasTypePrefix = sessionEntityId.includes(":");
+    const accountHasTypePrefix = accountEntityId.includes(":");
+    if (sessionHasTypePrefix && accountHasTypePrefix) {
+      return false;
+    }
+
+    return (
+      this.getEntityIdWithoutTypePrefix(sessionEntityId) ===
+      this.getEntityIdWithoutTypePrefix(accountEntityId)
+    );
+  }
+
+  private getEntityIdWithoutTypePrefix(entityId: string) {
+    return entityId.split(":").at(-1) ?? entityId;
+  }
+}

--- a/src/app/core/user/user-details/user-details.component.html
+++ b/src/app/core/user/user-details/user-details.component.html
@@ -43,27 +43,42 @@
             Edit
           </button>
         } @else {
-          @if (userAccount()?.enabled) {
+          <!-- Three-dots overflow menu for secondary/destructive actions -->
+          <button
+            mat-icon-button
+            color="warn"
+            [matMenuTriggerFor]="userAccountActionsMenu"
+            matTooltip="More actions"
+            i18n-matTooltip
+          >
+            <fa-icon icon="ellipsis-v" class="standard-icon"></fa-icon>
+          </button>
+          <mat-menu #userAccountActionsMenu>
+            @if (userAccount()?.enabled) {
+              <button
+                mat-menu-item
+                (click)="enableAccount(false)"
+                i18n="button to disable a user"
+              >
+                Deactivate user
+              </button>
+            } @else {
+              <button
+                mat-menu-item
+                (click)="enableAccount(true)"
+                i18n="button to enable a user"
+              >
+                Activate user
+              </button>
+            }
             <button
-              mat-stroked-button
-              color="warn"
-              (click)="enableAccount(false)"
-              matTooltip="User will not be able to login again, no information will be lost"
-              i18n="button to update disable a user"
+              mat-menu-item
+              (click)="deleteAccount()"
+              i18n="button to delete user account"
             >
-              Deactivate user
+              Delete user account
             </button>
-          } @else {
-            <button
-              mat-raised-button
-              color="accent"
-              (click)="enableAccount(true)"
-              matTooltip="User can login again with the previously used credentials"
-              i18n="button to enable a user"
-            >
-              Activate user
-            </button>
-          }
+          </mat-menu>
 
           <button
             mat-raised-button

--- a/src/app/core/user/user-details/user-details.component.html
+++ b/src/app/core/user/user-details/user-details.component.html
@@ -30,9 +30,7 @@
       </div>
     } @else {
       <!-- Actions editing existing account -->
-      <div
-        class="padding-bottom-small flex-row gap-small align-self-end flex-wrap padding-top-small"
-      >
+      <div class="user-account-actions padding-bottom-small padding-top-small">
         @if (formDisabled()) {
           <button
             mat-raised-button
@@ -43,42 +41,25 @@
             Edit
           </button>
         } @else {
-          <!-- Three-dots overflow menu for secondary/destructive actions -->
-          <button
-            mat-icon-button
-            color="warn"
-            [matMenuTriggerFor]="userAccountActionsMenu"
-            matTooltip="More actions"
-            i18n-matTooltip
-          >
-            <fa-icon icon="ellipsis-v" class="standard-icon"></fa-icon>
-          </button>
-          <mat-menu #userAccountActionsMenu>
-            @if (userAccount()?.enabled) {
-              <button
-                mat-menu-item
-                (click)="enableAccount(false)"
-                i18n="button to disable a user"
-              >
-                Deactivate user
-              </button>
-            } @else {
-              <button
-                mat-menu-item
-                (click)="enableAccount(true)"
-                i18n="button to enable a user"
-              >
-                Activate user
-              </button>
-            }
+          @if (userAccount()?.enabled) {
             <button
-              mat-menu-item
-              (click)="deleteAccount()"
-              i18n="button to delete user account"
+              mat-stroked-button
+              class="action-button"
+              (click)="enableAccount(false)"
+              i18n="button to disable a user account"
             >
-              Delete user account
+              Deactivate account
             </button>
-          </mat-menu>
+          } @else {
+            <button
+              mat-stroked-button
+              class="action-button"
+              (click)="enableAccount(true)"
+              i18n="button to enable a user account"
+            >
+              Activate account
+            </button>
+          }
 
           <button
             mat-raised-button
@@ -98,6 +79,26 @@
           >
             Cancel
           </button>
+          <!-- Three-dots overflow menu for secondary/destructive actions -->
+          <button
+            mat-icon-button
+            color="warn"
+            class="more-actions-button"
+            [matMenuTriggerFor]="userAccountActionsMenu"
+            matTooltip="More actions"
+            i18n-matTooltip
+          >
+            <fa-icon icon="ellipsis-v" class="standard-icon"></fa-icon>
+          </button>
+          <mat-menu #userAccountActionsMenu>
+            <button
+              mat-menu-item
+              (click)="deleteAccount()"
+              i18n="button to delete user account"
+            >
+              Delete account
+            </button>
+          </mat-menu>
         }
       </div>
     }

--- a/src/app/core/user/user-details/user-details.component.scss
+++ b/src/app/core/user/user-details/user-details.component.scss
@@ -6,6 +6,18 @@
   gap: 1rem;
 }
 
+.user-account-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.more-actions-button {
+  align-self: center;
+}
+
 .field-row {
   display: flex;
   flex-direction: column;

--- a/src/app/core/user/user-details/user-details.component.spec.ts
+++ b/src/app/core/user/user-details/user-details.component.spec.ts
@@ -8,6 +8,9 @@ import { HttpClient } from "@angular/common/http";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 import { SessionSubject } from "../../session/auth/session-info";
 import { CurrentUserSubject } from "../../session/current-user-subject";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { FaIconLibrary } from "@fortawesome/angular-fontawesome";
+import { fas } from "@fortawesome/free-solid-svg-icons";
 import { BehaviorSubject, of } from "rxjs";
 import { CoreTestingModule } from "#src/app/utils/core-testing.module";
 import type { SessionInfo } from "../../session/auth/session-info";
@@ -17,6 +20,7 @@ type UserAdminServiceMock = {
   getAllRoles: Mock;
   createUser: Mock;
   updateUser: Mock;
+  deleteUser: Mock;
 };
 
 type AlertServiceMock = {
@@ -37,6 +41,10 @@ type DialogRefMock = {
   close: Mock;
 };
 
+type ConfirmationDialogMock = {
+  getConfirmation: Mock;
+};
+
 describe("UserDetailsComponent", () => {
   let component: UserDetailsComponent;
   let fixture: ComponentFixture<UserDetailsComponent>;
@@ -47,6 +55,7 @@ describe("UserDetailsComponent", () => {
   let mockSessionSubject: BehaviorSubject<SessionInfo | null>;
   let mockCurrentUserSubject: BehaviorSubject<UserAccount | null>;
   let mockDialogRef: DialogRefMock;
+  let mockConfirmationDialog: ConfirmationDialogMock;
 
   const mockRole: Role = {
     id: "test-role",
@@ -67,6 +76,7 @@ describe("UserDetailsComponent", () => {
       getAllRoles: vi.fn().mockName("UserAdminService.getAllRoles"),
       createUser: vi.fn().mockName("UserAdminService.createUser"),
       updateUser: vi.fn().mockName("UserAdminService.updateUser"),
+      deleteUser: vi.fn().mockReturnValue(of({ userDeleted: true })),
     };
     mockUserAdminService.getAllRoles.mockReturnValue(of([mockRole]));
     mockUserAdminService.updateUser.mockReturnValue(of({ userUpdated: true }));
@@ -97,6 +107,10 @@ describe("UserDetailsComponent", () => {
       close: vi.fn().mockName("MatDialogRef.close"),
     };
 
+    mockConfirmationDialog = {
+      getConfirmation: vi.fn().mockResolvedValue(true),
+    };
+
     await TestBed.configureTestingModule({
       imports: [UserDetailsComponent, CoreTestingModule],
       providers: [
@@ -108,8 +122,11 @@ describe("UserDetailsComponent", () => {
         { provide: KeycloakAuthService, useValue: mockKeycloakService },
         { provide: SessionSubject, useValue: mockSessionSubject },
         { provide: CurrentUserSubject, useValue: mockCurrentUserSubject },
+        { provide: ConfirmationDialogService, useValue: mockConfirmationDialog },
       ],
     }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIconPacks(fas);
 
     fixture = TestBed.createComponent(UserDetailsComponent);
     component = fixture.componentInstance;
@@ -267,6 +284,50 @@ describe("UserDetailsComponent", () => {
       expect.stringContaining("/admin/clear_local/"),
       undefined,
     );
+  });
+
+  it("should call deleteUser and clear userAccount when confirmed", async () => {
+    fixture.componentRef.setInput("userAccount", {
+      ...mockUserAccount,
+      userEntityId: "User:some-entity-id",
+    });
+    fixture.detectChanges();
+    component.editMode();
+    fixture.detectChanges();
+
+    await component.deleteAccount();
+
+    expect(mockUserAdminService.deleteUser).toHaveBeenCalledWith(
+      "User:some-entity-id",
+    );
+    expect(component.userAccount()).toBeNull();
+  });
+
+  it("should not delete own account and show self-deletion warning", async () => {
+    fixture.componentRef.setInput("userAccount", {
+      ...mockUserAccount,
+      userEntityId: "User:some-entity-id",
+    });
+    mockSessionSubject.next({ id: mockUserAccount.id, name: "test", roles: [] });
+    fixture.detectChanges();
+    component.editMode();
+    fixture.detectChanges();
+
+    await component.deleteAccount();
+
+    expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("should not deactivate own account and show self-deletion warning", async () => {
+    fixture.componentRef.setInput("userAccount", mockUserAccount);
+    mockSessionSubject.next({ id: mockUserAccount.id, name: "test", roles: [] });
+    fixture.detectChanges();
+    component.editMode();
+    fixture.detectChanges();
+
+    await component.enableAccount(false);
+
+    expect(mockUserAdminService.updateUser).not.toHaveBeenCalled();
   });
 
   it("should not trigger sync reset when only email is updated", () => {

--- a/src/app/core/user/user-details/user-details.component.spec.ts
+++ b/src/app/core/user/user-details/user-details.component.spec.ts
@@ -122,7 +122,10 @@ describe("UserDetailsComponent", () => {
         { provide: KeycloakAuthService, useValue: mockKeycloakService },
         { provide: SessionSubject, useValue: mockSessionSubject },
         { provide: CurrentUserSubject, useValue: mockCurrentUserSubject },
-        { provide: ConfirmationDialogService, useValue: mockConfirmationDialog },
+        {
+          provide: ConfirmationDialogService,
+          useValue: mockConfirmationDialog,
+        },
       ],
     }).compileComponents();
 
@@ -308,7 +311,11 @@ describe("UserDetailsComponent", () => {
       ...mockUserAccount,
       userEntityId: "User:some-entity-id",
     });
-    mockSessionSubject.next({ id: mockUserAccount.id, name: "test", roles: [] });
+    mockSessionSubject.next({
+      id: mockUserAccount.id,
+      name: "test",
+      roles: [],
+    });
     fixture.detectChanges();
     component.editMode();
     fixture.detectChanges();
@@ -320,7 +327,11 @@ describe("UserDetailsComponent", () => {
 
   it("should not deactivate own account and show self-deletion warning", async () => {
     fixture.componentRef.setInput("userAccount", mockUserAccount);
-    mockSessionSubject.next({ id: mockUserAccount.id, name: "test", roles: [] });
+    mockSessionSubject.next({
+      id: mockUserAccount.id,
+      name: "test",
+      roles: [],
+    });
     fixture.detectChanges();
     component.editMode();
     fixture.detectChanges();

--- a/src/app/core/user/user-details/user-details.component.ts
+++ b/src/app/core/user/user-details/user-details.component.ts
@@ -22,6 +22,8 @@ import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatButtonModule } from "@angular/material/button";
+import { MatMenuModule } from "@angular/material/menu";
+import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import {
   MAT_DIALOG_DATA,
   MatDialogModule,
@@ -34,11 +36,14 @@ import { DialogCloseComponent } from "../../common-components/dialog-close/dialo
 import { AlertService } from "../../alerts/alert.service";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 import { CurrentUserSubject } from "../../session/current-user-subject";
+import { SessionSubject } from "../../session/auth/session-info";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { Angulartics2Module } from "angulartics2";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
 import { EditEntityComponent } from "../../basic-datatypes/entity/edit-entity/edit-entity.component";
-import { lastValueFrom, of } from "rxjs";
+import { lastValueFrom, of, firstValueFrom } from "rxjs";
 import { Entity } from "../../entity/model/entity";
 import { Logging } from "#src/app/core/logging/logging.service";
 import { catchError, map } from "rxjs/operators";
@@ -74,6 +79,8 @@ export interface UserDetailsAction {
     MatSelectModule,
     MatTooltipModule,
     MatButtonModule,
+    MatMenuModule,
+    FontAwesomeModule,
     MatDialogModule,
     DialogCloseComponent,
     Angulartics2Module,
@@ -97,6 +104,8 @@ export class UserDetailsComponent {
     optional: true,
   });
   protected currentUser = inject(CurrentUserSubject, { optional: true });
+  private readonly sessionInfo = inject(SessionSubject, { optional: true });
+  private readonly confirmationDialog = inject(ConfirmationDialogService);
 
   userAccount = model<UserAccount | null>(this._dialogData?.userAccount);
   isInDialog = input<boolean>(!!this._dialogData || false);
@@ -365,7 +374,49 @@ export class UserDetailsComponent {
     );
   }
 
+  async deleteAccount() {
+    if (this.sessionInfo?.value?.id === this.userAccount()?.id) {
+      await this.confirmationDialog.getConfirmation(
+        $localize`:self-deletion warning title:Cannot delete own account`,
+        $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
+        OkButton,
+      );
+      return;
+    }
+
+    const confirmed = await this.confirmationDialog.getConfirmation(
+      $localize`:delete account confirmation title:Delete user account?`,
+      $localize`:delete account confirmation dialog:Are you sure you want to permanently delete this user account? This cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    try {
+      await firstValueFrom(
+        this.userAdminService.deleteUser(this.userAccount().userEntityId),
+      );
+      this.alertService.addInfo(
+        $localize`:delete account success message:User account has been deleted.`,
+      );
+      this.userAccount.set(null);
+    } catch (err) {
+      this.alertService.addDanger(
+        err?.["error"]?.message ||
+          err?.["message"] ||
+          $localize`:Error message:Failed to delete user account`,
+      );
+    }
+  }
+
   async enableAccount(enabled: boolean) {
+    if (!enabled && this.sessionInfo?.value?.id === this.userAccount()?.id) {
+      await this.confirmationDialog.getConfirmation(
+        $localize`:self-deactivation warning title:Cannot disable own account`,
+        $localize`:self-deactivation warning dialog:You cannot disable your own account. Please ask another admin to deactivate your account if needed.`,
+        OkButton,
+      );
+      return;
+    }
+
     const message = enabled
       ? $localize`:Snackbar message:Account has been activated, user can login again.`
       : $localize`:Snackbar message:Account has been disabled, user will not be able to login anymore.`;

--- a/src/app/core/user/user-details/user-details.component.ts
+++ b/src/app/core/user/user-details/user-details.component.ts
@@ -36,9 +36,7 @@ import { DialogCloseComponent } from "../../common-components/dialog-close/dialo
 import { AlertService } from "../../alerts/alert.service";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 import { CurrentUserSubject } from "../../session/current-user-subject";
-import { SessionSubject } from "../../session/auth/session-info";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
-import { OkButton } from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { Angulartics2Module } from "angulartics2";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
@@ -47,6 +45,7 @@ import { lastValueFrom, of, firstValueFrom } from "rxjs";
 import { Entity } from "../../entity/model/entity";
 import { Logging } from "#src/app/core/logging/logging.service";
 import { catchError, map } from "rxjs/operators";
+import { UserAccountActionGuardService } from "../user-admin-service/user-account-action-guard.service";
 
 /**
  * Options as input to the UserDetailsComponent when it is opened in a dialog.
@@ -104,7 +103,7 @@ export class UserDetailsComponent {
     optional: true,
   });
   protected currentUser = inject(CurrentUserSubject, { optional: true });
-  private readonly sessionInfo = inject(SessionSubject, { optional: true });
+  private readonly accountActionGuard = inject(UserAccountActionGuardService);
   private readonly confirmationDialog = inject(ConfirmationDialogService);
 
   userAccount = model<UserAccount | null>(this._dialogData?.userAccount);
@@ -375,11 +374,19 @@ export class UserDetailsComponent {
   }
 
   async deleteAccount() {
-    if (this.sessionInfo?.value?.id === this.userAccount()?.id) {
-      await this.confirmationDialog.getConfirmation(
-        $localize`:self-deletion warning title:Cannot delete own account`,
-        $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
-        OkButton,
+    const currentAccount = this.userAccount();
+    if (!currentAccount?.userEntityId) {
+      return;
+    }
+
+    if (
+      this.accountActionGuard.isOwnAccount({
+        userAccountId: currentAccount.id,
+        userEntityId: currentAccount.userEntityId,
+      })
+    ) {
+      await this.accountActionGuard.showSelfAccountActionBlockedWarning(
+        "delete",
       );
       return;
     }
@@ -392,7 +399,7 @@ export class UserDetailsComponent {
 
     try {
       await firstValueFrom(
-        this.userAdminService.deleteUser(this.userAccount().userEntityId),
+        this.userAdminService.deleteUser(currentAccount.userEntityId),
       );
       this.alertService.addInfo(
         $localize`:delete account success message:User account has been deleted.`,
@@ -408,11 +415,15 @@ export class UserDetailsComponent {
   }
 
   async enableAccount(enabled: boolean) {
-    if (!enabled && this.sessionInfo?.value?.id === this.userAccount()?.id) {
-      await this.confirmationDialog.getConfirmation(
-        $localize`:self-deactivation warning title:Cannot disable own account`,
-        $localize`:self-deactivation warning dialog:You cannot disable your own account. Please ask another admin to deactivate your account if needed.`,
-        OkButton,
+    if (
+      !enabled &&
+      this.accountActionGuard.isOwnAccount({
+        userAccountId: this.userAccount()?.id,
+        userEntityId: this.userAccount()?.userEntityId,
+      })
+    ) {
+      await this.accountActionGuard.showSelfAccountActionBlockedWarning(
+        "deactivate",
       );
       return;
     }


### PR DESCRIPTION
## Summary

- **AC1**: During entity deletion, checks if a linked Keycloak account exists and asks the admin for confirmation before also deleting it. If the user lacks `account_manager` role, the check is skipped silently (see known limitation comment below).
- **AC2**: Adds a "Delete user account" button in a three-dots overflow menu (next to Deactivate user) inside `UserDetailsComponent`, allowing account deletion without deleting the entity.
- **AC3**: Prevents admins from deactivating or deleting their own account — shows a warning dialog if they attempt to do so.

## Test plan

- [ ] As `account_manager`, delete an entity with a linked account → confirmation dialog appears → confirm → account deleted
- [ ] As `account_manager`, same → decline → entity deleted, account kept
- [ ] As `account_manager`, delete an entity with no linked account → no dialog, entity deleted silently
- [ ] As non-`account_manager`, delete an entity with a linked account → entity deleted silently, no error
- [ ] Open a user profile in edit mode → click three-dots (⋮) → menu shows Deactivate and Delete user account
- [ ] Click Delete user account → confirm → account deleted, form clears
- [ ] As admin, try to deactivate/delete your own account → warning shown, action blocked

Closes #3597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete user accounts from the user details view with a confirmation flow and success/error feedback.
  * Prevent deleting or deactivating the currently logged-in account; shows an explanatory warning.

* **UI/UX Improvements**
  * Actions moved into a “More actions” menu and unified button styling for a cleaner layout.
  * Confirmation dialogs clarified and streamlined for account operations.

* **Bug Fixes**
  * Improved handling of account-deletion failures and aborted deletions.

* **Tests**
  * Expanded unit tests covering account-deletion, confirmations, and self-action guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->