### PR TITLE
fix: ignore network errors for keycloak init to keep logging clean

### DIFF
--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -34,7 +34,7 @@ export class SyncedPouchDatabase extends PouchDatabase {
     return SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX + this.pouchDB.name;
   }
 
-  POUCHDB_SYNC_BATCH_SIZE = 200;
+  POUCHDB_SYNC_BATCH_SIZE = 500;
   SYNC_INTERVAL = 30000;
 
   private remoteDatabase: RemotePouchDatabase;

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -34,7 +34,7 @@ export class SyncedPouchDatabase extends PouchDatabase {
     return SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX + this.pouchDB.name;
   }
 
-  POUCHDB_SYNC_BATCH_SIZE = 500;
+  POUCHDB_SYNC_BATCH_SIZE = 200;
   SYNC_INTERVAL = 30000;
 
   private remoteDatabase: RemotePouchDatabase;

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
@@ -183,6 +183,57 @@ describe("KeycloakAuthService", () => {
     }
   });
 
+  it("should throw RemoteLoginNotAvailableError on network errors (e.g. Failed to fetch)", async () => {
+    const fetchError = new TypeError("Failed to fetch");
+    mockKeycloak.init.mockRejectedValue(fetchError);
+
+    await expect(service.login()).rejects.toBeInstanceOf(
+      RemoteLoginNotAvailableError,
+    );
+  });
+
+  it("should throw RemoteLoginNotAvailableError on any error when offline", async () => {
+    const originalOnLine = Object.getOwnPropertyDescriptor(
+      Navigator.prototype,
+      "onLine",
+    );
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      get: () => false,
+      configurable: true,
+    });
+
+    try {
+      const serverError = new Error("Unexpected server error");
+      mockKeycloak.init.mockRejectedValue(serverError);
+
+      await expect(service.login()).rejects.toBeInstanceOf(
+        RemoteLoginNotAvailableError,
+      );
+    } finally {
+      Object.defineProperty(Navigator.prototype, "onLine", originalOnLine!);
+    }
+  });
+
+  it("should throw original error for non-network errors when online", async () => {
+    const originalOnLine = Object.getOwnPropertyDescriptor(
+      Navigator.prototype,
+      "onLine",
+    );
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      get: () => true,
+      configurable: true,
+    });
+
+    try {
+      const configError = new Error("Invalid realm configuration");
+      mockKeycloak.init.mockRejectedValue(configError);
+
+      await expect(service.login()).rejects.toEqual(configError);
+    } finally {
+      Object.defineProperty(Navigator.prototype, "onLine", originalOnLine!);
+    }
+  });
+
   it.skip("should gracefully handle failed re-authorization", async () => {
     vi.useFakeTimers();
     try {

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
@@ -56,12 +56,8 @@ export class KeycloakAuthService {
         shouldAddToken: ({ url }) => !url.includes("api.github.com"),
       });
     } catch (err) {
-      if (
-        err?.message?.includes(
-          "Timeout when waiting for 3rd party check iframe message.",
-        )
-      ) {
-        // this is actually an expected scenario, user's internet is slow or not available
+      if (this.isOfflineOrUnavailableError(err)) {
+        Logging.debug("Keycloak init failed (offline/unavailable)", err);
         err = new RemoteLoginNotAvailableError();
       } else {
         Logging.error("Keycloak init failed", err);
@@ -80,6 +76,26 @@ export class KeycloakAuthService {
       }
     });
   });
+
+  private static readonly NETWORK_ERROR_PATTERNS = [
+    "Failed to fetch",
+    "NetworkError",
+    "Load failed",
+    "Network request failed",
+    "Timeout when waiting for 3rd party check iframe message.",
+  ];
+
+  private isOfflineOrUnavailableError(err: any): boolean {
+    const message = err?.message ?? "";
+    if (
+      KeycloakAuthService.NETWORK_ERROR_PATTERNS.some((pattern) =>
+        message.includes(pattern),
+      )
+    ) {
+      return true;
+    }
+    return !navigator.onLine;
+  }
 
   private processToken(token: string): SessionInfo {
     if (!token) {


### PR DESCRIPTION
as these are expected when accessing the app offline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering authentication login failures across network, offline, and configuration error scenarios; includes per-test navigator.onLine isolation.

* **Bug Fixes**
  * Improved detection/classification of network/unavailable errors during authentication init to surface a clear remote-login-unavailable outcome.

* **Performance**
  * Reduced default sync replication batch size from 500 to 200 to improve synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->