### PR TITLE
fix: prevent crash when navigating away during roll-call participant loading

### DIFF
--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -281,8 +281,9 @@ export class RollCallComponent {
   }
 
   private async loadParticipants() {
-    if (!this.event()) return;
-    const attendanceItems: AttendanceItem[] = this.event().attendanceItems;
+    const event = this.event();
+    if (!event) return;
+    const attendanceItems: AttendanceItem[] = event.attendanceItems;
 
     const active: Entity[] = [];
     const inactive: Entity[] = [];
@@ -302,7 +303,7 @@ export class RollCallComponent {
           "Could not find participant " +
             participantId +
             " for event " +
-            this.event().entity.getId(),
+            event.entity.getId(),
         );
         continue;
       }
@@ -317,7 +318,7 @@ export class RollCallComponent {
       }
     }
 
-    this.event().attendanceItems = validAttendanceItems;
+    event.attendanceItems = validAttendanceItems;
     this.participants.set(active);
     this.inactiveParticipants.set(inactive);
     this.attendanceByParticipant.set(attendanceMap);


### PR DESCRIPTION
Fixes #3872

## Problem

`loadParticipants()` was reading `this.event()` (a computed signal backed by an async `resource()`) multiple times across `await` boundaries. When the user navigated away before all participant DB loads completed, the component was destroyed and the resource returned `undefined` — causing:

```
TypeError: Cannot set properties of undefined (setting 'attendanceItems')
```

**Sentry**: [AAM-DIGITAL-6SN](https://aam-digital.sentry.io/issues/7365551122/) — 20 occurrences on production, ongoing since 2026-03-26.

**Root cause from breadcrumbs**: User navigated to `/attendance/add-day/new` then back after ~3s (before the async participant loop finished), then navigated to the same activity with a different date. The old component instance's dangling async function resumed and called `this.event()` on the destroyed resource.

## Fix

Capture `this.event()` into a local variable **once at the start** of `loadParticipants()` and use it throughout, including after all `await` calls:

```ts
private async loadParticipants() {
  const event = this.event();  // captured once — holds reference even after component destroy
  if (!event) return;
  // ... use `event` instead of `this.event()` everywhere
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure in the roll-call component for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->