### PR TITLE
chore: optimize CI for "Final Review" label

### DIFF
--- a/.github/workflows/label-triggered-review.yml
+++ b/.github/workflows/label-triggered-review.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   qa:
@@ -17,3 +18,19 @@ jobs:
       ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
     with:
       is-fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+
+  remove-label:
+    name: Remove 'Final Review' label
+    needs: qa
+    if: always() && github.event.label.name == 'Final Review'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'Final Review',
+            })

--- a/.github/workflows/label-triggered-review.yml
+++ b/.github/workflows/label-triggered-review.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   qa:
@@ -24,6 +23,8 @@ jobs:
     needs: qa
     if: always() && github.event.label.name == 'Final Review'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/label-triggered-review.yml
+++ b/.github/workflows/label-triggered-review.yml
@@ -29,9 +29,19 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              name: 'Final Review',
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'Final Review',
+              });
+            } catch (error) {
+              const status = error.status ?? error.response?.status;
+              // 404: label already gone, 403: token can't mutate labels in this context
+              if (status === 404 || status === 403) {
+                core.info(`Skipping label removal (${status}): ${error.message}`);
+                return;
+              }
+              throw error;
+            }

--- a/.github/workflows/pull-request-updated.yml
+++ b/.github/workflows/pull-request-updated.yml
@@ -7,7 +7,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
 
 permissions:
   contents: read


### PR DESCRIPTION
closes #3903

Co-authored-by: Copilot <copilot@github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull-request workflow triggers to run on opened, reopened, and synchronize events (removed ready_for_review).
  * Added an automated step to remove the "Final Review" label after QA completes; it safely handles cases where the label is already gone or cannot be changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->