### PR TITLE
fix(login): convert state to signals so OnPush updates the UI

### DIFF
--- a/src/app/core/session/login/login.component.html
+++ b/src/app/core/session/login/login.component.html
@@ -39,6 +39,12 @@
             ></mat-progress-bar>
           </div>
         } @else if (ssoCheckDone()) {
+          @if (loginError(); as error) {
+            <div class="login-error" role="alert">
+              <fa-icon icon="triangle-exclamation"></fa-icon>
+              <span>{{ error }}</span>
+            </div>
+          }
           <div>
             <button
               mat-flat-button

--- a/src/app/core/session/login/login.component.html
+++ b/src/app/core/session/login/login.component.html
@@ -14,7 +14,7 @@
       <!-- ONLINE-ONLY OPTION -->
       @if (showOnlineOnlyOption) {
         <mat-checkbox
-          [ngModel]="onlineOnly"
+          [ngModel]="onlineOnly()"
           (ngModelChange)="onOnlineOnlyChanged($event)"
           matTooltip="When enabled, data is not synced and stored on this device. This is faster but you cannot use the app offline later."
           i18n-matTooltip="online-only mode tooltip"
@@ -30,7 +30,7 @@
         matTooltip="It is necessary to log in to the server so that your data can be synchronized with other team members. We are checking whether you are still logged in or otherwise forward you to provide your credentials. You can still use the application offline, if you currently have no internet connection."
         i18n-matTooltip="online login tooltip"
       >
-        @if (loginInProgress) {
+        @if (loginInProgress()) {
           <div>
             <em i18n="login progess bar title">Checking online login ...</em>
             <mat-progress-bar
@@ -38,7 +38,7 @@
               class="login-check-progressbar"
             ></mat-progress-bar>
           </div>
-        } @else if (ssoCheckDone) {
+        } @else if (ssoCheckDone()) {
           <div>
             <button
               mat-flat-button
@@ -55,7 +55,7 @@
       </div>
 
       <!-- OFFLINE -->
-      @if (showOfflineSection && offlineUsers.length > 0) {
+      @if (showOfflineSection() && offlineUsers.length > 0) {
         <mat-card class="margin-top-large" appearance="outlined">
           <mat-card-header
             matTooltip="You can use the application completely offline. However, your changes cannot be synchronized with other team members in this mode. When available, you should always use the online login."
@@ -78,7 +78,7 @@
                 <button
                   mat-list-item
                   (click)="sessionManager.offlineLogin(user)"
-                  [disabled]="!enableOfflineLogin"
+                  [disabled]="!enableOfflineLogin()"
                 >
                   <fa-icon matListItemIcon icon="user"></fa-icon>
                   {{ user.email ?? user.name }}

--- a/src/app/core/session/login/login.component.html
+++ b/src/app/core/session/login/login.component.html
@@ -40,7 +40,11 @@
           </div>
         } @else if (ssoCheckDone()) {
           @if (loginError(); as error) {
-            <div class="login-error" role="alert">
+            <div
+              class="login-error"
+              role="alert"
+              [matTooltip]="loginTechnicalError()"
+            >
               <fa-icon icon="triangle-exclamation"></fa-icon>
               <span>{{ error }}</span>
             </div>

--- a/src/app/core/session/login/login.component.scss
+++ b/src/app/core/session/login/login.component.scss
@@ -5,6 +5,10 @@
   color: colors.$error;
   font-size: 90%;
   text-align: justify;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 :host {

--- a/src/app/core/session/login/login.component.spec.ts
+++ b/src/app/core/session/login/login.component.spec.ts
@@ -77,8 +77,7 @@ describe("LoginComponent", () => {
     expect(sessionManager.checkRemoteSession).toHaveBeenCalled();
   });
 
-  it("should route to redirect uri once state changes to 'logged-in'", async () => {
-    vi.useFakeTimers();
+  it("should route to redirect uri once state changes to 'logged-in'", () => {
     vi.stubGlobal("location", { origin: "http://localhost" });
     try {
       const navigateSpy = vi.spyOn(TestBed.inject(Router), "navigateByUrl");
@@ -88,11 +87,9 @@ describe("LoginComponent", () => {
 
       fixture.detectChanges();
       loginState.next(LoginState.LOGGED_IN);
-      await vi.advanceTimersByTimeAsync(100);
 
       expect(navigateSpy).toHaveBeenCalledWith("/someUrl");
     } finally {
-      vi.useRealTimers();
       vi.unstubAllGlobals();
     }
   });
@@ -106,12 +103,13 @@ describe("LoginComponent", () => {
       fixture.detectChanges();
 
       loginState.next(LoginState.IN_PROGRESS);
-      expect(component.enableOfflineLogin).toBe(false);
+      expect(component.enableOfflineLogin()).toBe(false);
       expect(loginState.value).toBe(LoginState.IN_PROGRESS);
 
       loginState.next(LoginState.LOGIN_FAILED);
       await vi.advanceTimersByTimeAsync(0);
-      expect(component.enableOfflineLogin).toBe(true);
+      expect(component.enableOfflineLogin()).toBe(true);
+      expect(component.showOfflineSection()).toBe(true);
       expect(component.offlineUsers).toEqual(mockUsers);
     } finally {
       vi.useRealTimers();
@@ -127,14 +125,70 @@ describe("LoginComponent", () => {
       loginState.next(LoginState.LOGGED_OUT);
       fixture.detectChanges();
       loginState.next(LoginState.IN_PROGRESS);
-      expect(component.enableOfflineLogin).toBe(false);
+      expect(component.enableOfflineLogin()).toBe(false);
+      expect(component.showOfflineSection()).toBe(false);
 
       await vi.advanceTimersByTimeAsync(10000);
       await fixture.whenStable();
-      expect(component.enableOfflineLogin).toBe(true);
+      expect(component.enableOfflineLogin()).toBe(true);
+      expect(component.showOfflineSection()).toBe(true);
       expect(component.offlineUsers).toEqual(mockUsers);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("should reveal the 'Log in' button after the silent SSO check resolves (OnPush)", async () => {
+    // Override the mock with a deferred promise so we can observe the
+    // pre-resolution state before allowing the silent SSO check to complete.
+    let resolveSsoCheck: () => void;
+    const ssoCheckPromise = new Promise<void>((res) => {
+      resolveSsoCheck = res;
+    });
+    vi.spyOn(sessionManager, "checkRemoteSession").mockReturnValue(
+      ssoCheckPromise,
+    );
+
+    // Re-create the component after re-mocking so the new promise is used.
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    // While the silent check is pending: spinner shown, no button.
+    expect(component.ssoCheckDone()).toBe(false);
+    expect(
+      fixture.nativeElement.querySelector("button[mat-flat-button]"),
+    ).toBeFalsy();
+
+    // Resolve the silent check and let the .finally callback run.
+    resolveSsoCheck!();
+    await ssoCheckPromise;
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(component.ssoCheckDone()).toBe(true);
+    const loginButton = fixture.nativeElement.querySelector(
+      "button[mat-flat-button]",
+    );
+    expect(loginButton).toBeTruthy();
+    expect(loginButton.textContent).toContain("Log in");
+  });
+
+  it("should keep the spinner state in sync with login state changes (OnPush)", () => {
+    fixture.detectChanges();
+
+    loginState.next(LoginState.IN_PROGRESS);
+    fixture.detectChanges();
+    expect(component.loginInProgress()).toBe(true);
+    expect(
+      fixture.nativeElement.querySelector(".login-check-progressbar"),
+    ).toBeTruthy();
+
+    loginState.next(LoginState.LOGIN_FAILED);
+    fixture.detectChanges();
+    expect(component.loginInProgress()).toBe(false);
+    expect(
+      fixture.nativeElement.querySelector(".login-check-progressbar"),
+    ).toBeFalsy();
   });
 });

--- a/src/app/core/session/login/login.component.spec.ts
+++ b/src/app/core/session/login/login.component.spec.ts
@@ -191,4 +191,46 @@ describe("LoginComponent", () => {
       fixture.nativeElement.querySelector(".login-check-progressbar"),
     ).toBeFalsy();
   });
+
+  it("should NOT show an error after the silent SSO check fails on initial load", () => {
+    fixture.detectChanges();
+
+    // Simulate the initial silent SSO check transitioning to LOGIN_FAILED
+    // (the normal "you are not yet logged in" path).
+    loginState.next(LoginState.IN_PROGRESS);
+    loginState.next(LoginState.LOGIN_FAILED);
+    fixture.detectChanges();
+
+    expect(component.loginError()).toBeNull();
+    expect(fixture.nativeElement.querySelector(".login-error")).toBeFalsy();
+  });
+
+  it("should show an error message when a user-initiated remote login fails", () => {
+    fixture.detectChanges();
+
+    component.tryLogin();
+    loginState.next(LoginState.IN_PROGRESS);
+    loginState.next(LoginState.LOGIN_FAILED);
+    fixture.detectChanges();
+
+    expect(component.loginError()).toBeTruthy();
+    const errorEl = fixture.nativeElement.querySelector(".login-error");
+    expect(errorEl).toBeTruthy();
+    expect(errorEl.textContent).toContain("login service");
+  });
+
+  it("should clear the error when the user retries", () => {
+    fixture.detectChanges();
+    component.tryLogin();
+    loginState.next(LoginState.IN_PROGRESS);
+    loginState.next(LoginState.LOGIN_FAILED);
+    fixture.detectChanges();
+    expect(component.loginError()).toBeTruthy();
+
+    component.tryLogin();
+    fixture.detectChanges();
+
+    expect(component.loginError()).toBeNull();
+    expect(fixture.nativeElement.querySelector(".login-error")).toBeFalsy();
+  });
 });

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -20,6 +20,7 @@ import {
   OnInit,
   inject,
   ChangeDetectionStrategy,
+  signal,
 } from "@angular/core";
 import { MatCardModule } from "@angular/material/card";
 import { MatButtonModule } from "@angular/material/button";
@@ -40,6 +41,7 @@ import { race, timer } from "rxjs";
 import { environment } from "../../../../environments/environment";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { FormsModule } from "@angular/forms";
+import { Logging } from "../../logging/logging.service";
 
 /**
  * Allows the user to login online or offline depending on the connection status
@@ -70,14 +72,19 @@ export class LoginComponent implements OnInit {
   siteSettingsService = inject(SiteSettingsService);
 
   offlineUsers: SessionInfo[] = [];
-  enableOfflineLogin: boolean;
-  loginInProgress = false;
+  /**
+   * Whether offline-login buttons are clickable.
+   * Becomes true once the remote login has failed or after a hard timeout,
+   * so the user always has a fallback path to enter the app.
+   */
+  enableOfflineLogin = signal(false);
+  loginInProgress = signal(false);
 
   /** Whether the offline login section should be shown at all. */
-  showOfflineSection = false;
+  showOfflineSection = signal(false);
 
   /** Whether the initial silent SSO check has completed (showing the login form). */
-  ssoCheckDone = false;
+  ssoCheckDone = signal(false);
 
   /**
    * localStorage key under which the online-only preference is persisted.
@@ -98,31 +105,32 @@ export class LoginComponent implements OnInit {
       environment.session_type === SessionType.online);
 
   /** User preference: use online-only mode instead of synced. */
-  onlineOnly: boolean;
+  onlineOnly = signal(false);
 
   constructor() {
     const sessionManager = this.sessionManager;
 
     // restore previous online-only preference from localStorage
-    this.onlineOnly =
+    const initialOnlineOnly =
       localStorage.getItem(LoginComponent.ONLINE_ONLY_KEY) === "true" ||
       environment.session_type === SessionType.online;
-    this.applyOnlineOnlyMode(this.onlineOnly);
+    this.onlineOnly.set(initialOnlineOnly);
+    this.applyOnlineOnlyMode(initialOnlineOnly);
 
-    this.enableOfflineLogin = !this.sessionManager.remoteLoginAvailable();
-    this.showOfflineSection = !navigator.onLine;
+    this.enableOfflineLogin.set(!this.sessionManager.remoteLoginAvailable());
+    this.showOfflineSection.set(!navigator.onLine);
 
     // Only do a silent SSO check — don't redirect to Keycloak yet.
     // This allows the user to see and interact with the login page settings first.
-    sessionManager.checkRemoteSession().then(() => {
-      this.ssoCheckDone = true;
+    sessionManager.checkRemoteSession().finally(() => {
+      this.ssoCheckDone.set(true);
       sessionManager.clearRemoteSessionIfNecessary();
     });
   }
 
   ngOnInit() {
     this.loginState.pipe(untilDestroyed(this)).subscribe((state) => {
-      this.loginInProgress = state === LoginState.IN_PROGRESS;
+      this.loginInProgress.set(state === LoginState.IN_PROGRESS);
       if (state === LoginState.LOGGED_IN) {
         this.routeAfterLogin();
       }
@@ -133,12 +141,15 @@ export class LoginComponent implements OnInit {
       this.loginState.pipe(waitForChangeTo(LoginState.LOGIN_FAILED)),
       timer(10000),
     ).subscribe(() => {
-      this.enableOfflineLogin = true;
+      // Always reveal the fallback after a hard timeout or on login failure,
+      // so a stuck remote login can never trap the user without an escape.
+      this.enableOfflineLogin.set(true);
+      this.showOfflineSection.set(true);
     });
   }
 
   onOnlineOnlyChanged(checked: boolean) {
-    this.onlineOnly = checked;
+    this.onlineOnly.set(checked);
     if (checked) {
       localStorage.setItem(LoginComponent.ONLINE_ONLY_KEY, "true");
     } else {
@@ -174,7 +185,7 @@ export class LoginComponent implements OnInit {
   private routeAfterLogin() {
     const redirectUri = this.route.snapshot.queryParams["redirect_uri"] || "";
     const safeRedirectUri = this.safeRedirectUrl(redirectUri);
-    setTimeout(() => this.router.navigateByUrl(safeRedirectUri), 0);
+    this.router.navigateByUrl(safeRedirectUri);
   }
 
   private safeRedirectUrl(redirectUri: string): string {
@@ -187,17 +198,24 @@ export class LoginComponent implements OnInit {
 
       // validate same origin and path
       if (fullUrl.origin !== base || !fullUrl.pathname.startsWith("/")) {
+        Logging.debug(
+          `Login: rejected redirect_uri (cross-origin or invalid path): ${redirectUri}`,
+        );
         return "/";
       }
 
       return fullUrl.pathname + fullUrl.search + fullUrl.hash;
     } catch (e) {
+      Logging.debug(
+        `Login: rejected redirect_uri (parse error): ${redirectUri}`,
+        e,
+      );
       return "/"; // fallback for invalid urls
     }
   }
 
   tryLogin() {
-    this.showOfflineSection = true;
+    this.showOfflineSection.set(true);
     return this.sessionManager.remoteLogin();
   }
 }

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -94,6 +94,9 @@ export class LoginComponent implements OnInit {
    */
   loginError = signal<string | null>(null);
 
+  /** Raw technical error from the login service, shown as a tooltip on the error message. */
+  loginTechnicalError = signal<string | null>(null);
+
   /**
    * localStorage key under which the online-only preference is persisted.
    * Read by bootstrap-environment.ts on every page load (before Angular DI starts)
@@ -141,6 +144,7 @@ export class LoginComponent implements OnInit {
       this.loginInProgress.set(state === LoginState.IN_PROGRESS);
       if (state === LoginState.LOGGED_IN) {
         this.loginError.set(null);
+        this.loginTechnicalError.set(null);
         this.routeAfterLogin();
       }
       if (state === LoginState.LOGIN_FAILED && this.userInitiatedLogin) {
@@ -244,7 +248,12 @@ export class LoginComponent implements OnInit {
   tryLogin() {
     this.showOfflineSection.set(true);
     this.loginError.set(null);
+    this.loginTechnicalError.set(null);
     this.userInitiatedLogin = true;
-    return this.sessionManager.remoteLogin();
+    this.sessionManager.remoteLogin().catch((err: unknown) => {
+      this.loginTechnicalError.set(
+        err instanceof Error ? err.message : String(err),
+      );
+    });
   }
 }

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -87,6 +87,14 @@ export class LoginComponent implements OnInit {
   ssoCheckDone = signal(false);
 
   /**
+   * Human-readable error to display when a *user-initiated* remote login
+   * fails. Stays null for the silent SSO check on initial page load (whose
+   * "failure" simply means the user is not yet logged in and is the normal
+   * state we expect to render the login form).
+   */
+  loginError = signal<string | null>(null);
+
+  /**
    * localStorage key under which the online-only preference is persisted.
    * Read by bootstrap-environment.ts on every page load (before Angular DI starts)
    * to set environment.session_type before any database instances are created.
@@ -132,7 +140,18 @@ export class LoginComponent implements OnInit {
     this.loginState.pipe(untilDestroyed(this)).subscribe((state) => {
       this.loginInProgress.set(state === LoginState.IN_PROGRESS);
       if (state === LoginState.LOGGED_IN) {
+        this.loginError.set(null);
         this.routeAfterLogin();
+      }
+      if (state === LoginState.LOGIN_FAILED && this.userInitiatedLogin) {
+        // Only surface a visible error after a user actually clicked "Log in".
+        // The silent SSO check on initial page load also ends in LOGIN_FAILED
+        // when the user is simply not logged in yet — that is the normal
+        // path and should not show an error banner.
+        this.userInitiatedLogin = false;
+        this.loginError.set(
+          $localize`:Login error message:Could not reach the login service. Please check your internet connection and try again.`,
+        );
       }
     });
 
@@ -214,8 +233,18 @@ export class LoginComponent implements OnInit {
     }
   }
 
+  /**
+   * True between the moment the user clicks "Log in" and the next
+   * resolution of loginState (LOGGED_IN or LOGIN_FAILED). Used to
+   * distinguish a user-initiated failure (show error) from the silent
+   * initial SSO check failure (do not show error).
+   */
+  private userInitiatedLogin = false;
+
   tryLogin() {
     this.showOfflineSection.set(true);
+    this.loginError.set(null);
+    this.userInitiatedLogin = true;
     return this.sessionManager.remoteLogin();
   }
 }

--- a/src/app/core/session/session-service/session-manager.service.spec.ts
+++ b/src/app/core/session/session-service/session-manager.service.spec.ts
@@ -112,6 +112,7 @@ describe("SessionManagerService", () => {
 
   afterEach(async () => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it("should update the session info once authenticated", async () => {
@@ -259,6 +260,45 @@ describe("SessionManagerService", () => {
     service.clearRemoteSessionIfNecessary();
 
     expect(mockKeycloak.logout).toHaveBeenCalled();
+  });
+
+  it("should set the skip-next-sso-check flag on remote logout", async () => {
+    sessionStorage.removeItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY);
+    await service.remoteLogin();
+
+    await service.logout();
+
+    expect(
+      sessionStorage.getItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY),
+    ).toBe("1");
+  });
+
+  it("should not set the skip-next-sso-check flag if no remote session was active", async () => {
+    sessionStorage.removeItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY);
+    await service.offlineLogin(dbUser);
+
+    await service.logout();
+
+    expect(
+      sessionStorage.getItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY),
+    ).toBeNull();
+  });
+
+  it("should skip the silent SSO check when the skip flag is set", async () => {
+    sessionStorage.setItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY, "1");
+    const remoteLoginAvailableSpy = vi
+      .spyOn(service, "remoteLoginAvailable")
+      .mockReturnValue(true);
+
+    await service.checkRemoteSession();
+
+    expect(loginStateSubject.value).toBe(LoginState.LOGIN_FAILED);
+    // The skip-flag short-circuit means we should not even consult
+    // remoteLoginAvailable() / Keycloak after logout.
+    expect(remoteLoginAvailableSpy).not.toHaveBeenCalled();
+    expect(
+      sessionStorage.getItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY),
+    ).toBeNull();
   });
 
   it("should use current user db if database has content", async () => {

--- a/src/app/core/session/session-service/session-manager.service.ts
+++ b/src/app/core/session/session-service/session-manager.service.ts
@@ -111,7 +111,7 @@ export class SessionManagerService {
         .then((user) => this.handleRemoteLogin(user))
         .catch((err) => {
           this.loginStateSubject.next(LoginState.LOGIN_FAILED);
-          // ignore fall back to offline login - if there was a technical error, the AuthService has already logged/reported it
+          throw err;
         });
     }
     this.loginStateSubject.next(LoginState.LOGIN_FAILED);

--- a/src/app/core/session/session-service/session-manager.service.ts
+++ b/src/app/core/session/session-service/session-manager.service.ts
@@ -52,6 +52,16 @@ export class SessionManagerService {
   private databaseResolver = inject(DatabaseResolverService);
 
   readonly RESET_REMOTE_SESSION_KEY = "RESET_REMOTE";
+  /**
+   * sessionStorage key that, when present, makes the next call to
+   * {@link checkRemoteSession} skip the silent SSO check.
+   *
+   * Set right before a logout so that, after Keycloak redirects back to
+   * /login, we do not run another (now guaranteed to fail) silent check
+   * that would block the UI behind a spinner for several seconds.
+   * Consumed (removed) on the next checkRemoteSession call.
+   */
+  static readonly SKIP_NEXT_SSO_CHECK_KEY = "SKIP_NEXT_SSO_CHECK";
   private remoteLoggedIn = false;
   private updateSubscription: Subscription;
 
@@ -61,6 +71,17 @@ export class SessionManagerService {
    */
   async checkRemoteSession() {
     this.loginStateSubject.next(LoginState.IN_PROGRESS);
+
+    // Skip the silent SSO check on the page load right after a logout.
+    // We already know the remote session is gone; running another silent
+    // check would only add several seconds of spinner before the user can
+    // click "Log in" again.
+    if (sessionStorage.getItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY)) {
+      sessionStorage.removeItem(SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY);
+      this.loginStateSubject.next(LoginState.LOGIN_FAILED);
+      return;
+    }
+
     if (this.remoteLoginAvailable()) {
       return this.remoteAuthService
         .checkSession()
@@ -153,6 +174,14 @@ export class SessionManagerService {
    */
   async logout() {
     if (this.remoteLoggedIn) {
+      // Tell the next page load (after the Keycloak logout redirect round-trip)
+      // not to run another silent SSO check — it would only delay the login
+      // form by several seconds before failing as expected.
+      sessionStorage.setItem(
+        SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY,
+        "1",
+      );
+
       if (this.navigator.onLine) {
         // This will forward to the keycloak logout page
         await this.remoteAuthService.logout();
@@ -175,6 +204,13 @@ export class SessionManagerService {
   clearRemoteSessionIfNecessary() {
     if (localStorage.getItem(this.RESET_REMOTE_SESSION_KEY)) {
       localStorage.removeItem(this.RESET_REMOTE_SESSION_KEY);
+      // The remote logout below redirects through Keycloak and back to /login.
+      // Skip the silent SSO check on that next page load to avoid a needless
+      // multi-second spinner.
+      sessionStorage.setItem(
+        SessionManagerService.SKIP_NEXT_SSO_CHECK_KEY,
+        "1",
+      );
       return this.remoteAuthService.logout();
     }
   }


### PR DESCRIPTION
- see #3916


- [x] signals for LoginComponent to correctly show updates
- [x] timeouts to avoid infinite login checks
- [x] login error displayed to users