### PR TITLE
fix: MarkdownPage does not load entity due to OnPush change detection (#3922)

### DIFF
--- a/src/app/features/markdown-page/markdown-page/markdown-page.component.html
+++ b/src/app/features/markdown-page/markdown-page/markdown-page.component.html
@@ -1,6 +1,6 @@
 @if (markdownEntityId) {
-  @if (markdownContent) {
-    <div markdown [data]="markdownContent"></div>
+  @if (markdownContent()) {
+    <div markdown [data]="markdownContent()"></div>
   } @else {
     <p><em i18n>Content not found.</em></p>
   }

--- a/src/app/features/markdown-page/markdown-page/markdown-page.component.spec.ts
+++ b/src/app/features/markdown-page/markdown-page/markdown-page.component.spec.ts
@@ -52,9 +52,7 @@ describe("MarkdownPageComponent", () => {
   it("renders entity content in the DOM when markdownEntityId resolves to a MarkdownContent entity", async () => {
     const entity = new MarkdownContent("test-entity-1");
     entity.content = "# Hello";
-    (mockEntityMapper.load as ReturnType<typeof vi.fn>).mockResolvedValue(
-      entity,
-    );
+    mockEntityMapper.load.mockResolvedValue(entity);
 
     component.markdownEntityId = "test-entity-1";
     fixture.detectChanges();

--- a/src/app/features/markdown-page/markdown-page/markdown-page.component.spec.ts
+++ b/src/app/features/markdown-page/markdown-page/markdown-page.component.spec.ts
@@ -8,10 +8,12 @@ import { DynamicComponentConfig } from "../../../core/config/dynamic-components/
 import { MarkdownPageModule } from "../markdown-page.module";
 import { ComponentRegistry } from "../../../dynamic-components";
 import { EntityMapperService } from "app/core/entity/entity-mapper/entity-mapper.service";
+import { MarkdownContent } from "../markdown-content";
 
 describe("MarkdownPageComponent", () => {
   let component: MarkdownPageComponent;
   let fixture: ComponentFixture<MarkdownPageComponent>;
+  let mockEntityMapper: { load: ReturnType<typeof vi.fn> };
 
   let mockRouteData: BehaviorSubject<
     DynamicComponentConfig<MarkdownPageConfig>
@@ -22,15 +24,15 @@ describe("MarkdownPageComponent", () => {
       config: { markdownFile: "test.md" },
     });
 
+    mockEntityMapper = { load: vi.fn() };
+
     TestBed.configureTestingModule({
       imports: [MarkdownPageModule, MarkdownPageComponent],
       providers: [
         { provide: ActivatedRoute, useValue: { data: mockRouteData } },
         {
           provide: EntityMapperService,
-          useValue: {
-            load: vi.fn(),
-          },
+          useValue: mockEntityMapper,
         },
         ComponentRegistry,
       ],
@@ -40,10 +42,26 @@ describe("MarkdownPageComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MarkdownPageComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it("should create", () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it("renders entity content in the DOM when markdownEntityId resolves to a MarkdownContent entity", async () => {
+    const entity = new MarkdownContent("test-entity-1");
+    entity.content = "# Hello";
+    (mockEntityMapper.load as ReturnType<typeof vi.fn>).mockResolvedValue(
+      entity,
+    );
+
+    component.markdownEntityId = "test-entity-1";
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector("em")).toBeNull();
+    expect(fixture.nativeElement.querySelector("div[markdown]")).toBeTruthy();
   });
 });

--- a/src/app/features/markdown-page/markdown-page/markdown-page.component.ts
+++ b/src/app/features/markdown-page/markdown-page/markdown-page.component.ts
@@ -21,6 +21,7 @@ import {
   Input,
   OnInit,
   ChangeDetectionStrategy,
+  signal,
 } from "@angular/core";
 import { MarkdownPageModule } from "../markdown-page.module";
 import { RouteTarget } from "../../../route-target";
@@ -43,7 +44,7 @@ export class MarkdownPageComponent implements OnInit {
   /** markdown entity content to be displayed */
   @Input() markdownEntityId?: string;
 
-  markdownContent: string = "";
+  markdownContent = signal<string>("");
 
   private entityMapper = inject(EntityMapperService);
 
@@ -55,7 +56,7 @@ export class MarkdownPageComponent implements OnInit {
       );
 
       if (markdownEntity) {
-        this.markdownContent = markdownEntity.content;
+        this.markdownContent.set(markdownEntity.content);
       }
     }
   }

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -67,6 +67,11 @@
           "link": "/report"
         },
         {
+          "label": "Help",
+          "icon": "question",
+          "link": "/help"
+        },
+        {
           "label": "Admin",
           "icon": "wrench",
           "subMenu": [
@@ -1301,6 +1306,13 @@
     "view:report": {
       "component": "Reporting",
       "_id": "view:report"
+    },
+    "view:help": {
+      "component": "MarkdownPage",
+      "config": {
+        "markdownEntityId": "MarkdownContent:help"
+      },
+      "_id": "view:help"
     },
     "entity:Child": {
       "label": "Child",


### PR DESCRIPTION
Closes #3922

- Root cause: `MarkdownPageComponent` used `ChangeDetectionStrategy.OnPush` but stored loaded entity content in a plain class property. When `ngOnInit`'s async Promise resolved and set `this.markdownContent`, Angular's `OnPush` detector did not re-render the view — leaving "Content not found." visible even after a successful load.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Help menu item to the application's main navigation.
  * Help page located at `/help` displays markdown-formatted documentation and guidance.

* **Refactor**
  * Updated component state management implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->