### PR TITLE
chore: switch renovate to Monday morning schedule and add Final Review label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,25 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
-    "after 00:00 and before 04:00 on Wednesday"
+    "after 06:00 and before 10:00 on Monday"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": [
-    "dependencies"
+    "dependencies",
+    "Final Review"
   ],
+  "vulnerabilityAlerts": {
+    "schedule": [
+      "at any time"
+    ],
+    "labels": [
+      "dependencies",
+      "security",
+      "Final Review"
+    ]
+  },
   "reviewers": [
     "sleidig",
     "Abhinegi2"
@@ -47,7 +58,8 @@
       "dependencyDashboardApproval": true,
       "labels": [
         "dependencies",
-        "major-update"
+        "major-update",
+        "Final Review"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -9,13 +9,12 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
-    "after 06:00 and before 10:00 on Monday"
+    "after 00:00 and before 09:00 on Monday"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": [
-    "dependencies",
     "Final Review"
   ],
   "vulnerabilityAlerts": {
@@ -23,8 +22,6 @@
       "at any time"
     ],
     "labels": [
-      "dependencies",
-      "security",
       "Final Review"
     ]
   },
@@ -57,8 +54,6 @@
       "draftPR": true,
       "dependencyDashboardApproval": true,
       "labels": [
-        "dependencies",
-        "major-update",
         "Final Review"
       ]
     },


### PR DESCRIPTION
## Summary
- Change schedule from Wednesday 00:00–04:00 to **Monday 06:00–10:00 UTC** for all update types
- Add `vulnerabilityAlerts` block with `"schedule": ["at any time"]` so security/critical fixes create PRs immediately
- Add `Final Review` label to all Renovate PRs (regular, major, and vulnerability) to auto-trigger E2E tests and CodeRabbit review via the existing label-triggered workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified dependency update scheduling to occur Monday mornings between 06:00-10:00 (previously Wednesday).
  * Enhanced dependency update labeling configuration with additional review designation alongside standard categorization.
  * Adjusted vulnerability alert labeling to align with updated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->