### PR TITLE
refactor: migrate remaining common-components to signals

### DIFF
--- a/src/app/core/common-components/color-input/color-input.component.html
+++ b/src/app/core/common-components/color-input/color-input.component.html
@@ -30,14 +30,14 @@
     class="color-text-input"
   />
   <ng-container *ngTemplateOutlet="colorPickerButton"></ng-container>
-} @else if (compact) {
+} @else if (compact()) {
   <!-- Compact standalone mode: just the color picker button -->
   <ng-container *ngTemplateOutlet="colorPickerButton"></ng-container>
 } @else {
   <!-- Full standalone mode: own mat-form-field with label and error -->
   <mat-form-field class="full-width" floatLabel="always">
     <mat-label>
-      <span>{{ label }}</span>
+      <span>{{ label() }}</span>
       &nbsp;
       <fa-icon
         icon="question-circle"

--- a/src/app/core/common-components/color-input/color-input.component.spec.ts
+++ b/src/app/core/common-components/color-input/color-input.component.spec.ts
@@ -80,7 +80,7 @@ describe("ColorInputComponent (EditComponent mode)", () => {
 
     fixture = TestBed.createComponent(ColorInputComponent);
     component = fixture.componentInstance;
-    setupCustomFormControlEditComponent(component);
+    setupCustomFormControlEditComponent(component, "testProperty", {}, fixture);
     fixture.detectChanges();
   });
 

--- a/src/app/core/common-components/color-input/color-input.component.ts
+++ b/src/app/core/common-components/color-input/color-input.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
   DestroyRef,
   inject,
-  Input,
+  input,
   OnInit,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
@@ -52,18 +52,18 @@ export class ColorInputComponent
   extends CustomFormControlDirective<string>
   implements EditComponent, OnInit
 {
-  @Input() formFieldConfig?: FormFieldConfig;
+  formFieldConfig = input<FormFieldConfig>();
 
   /**
    * If true, renders only the compact color picker button (no label, no text field, no form field).
    * Useful for inline/icon-only usage.
    */
-  @Input() compact = false;
+  compact = input<boolean>(false);
 
   /**
    * Label for the color input field (used in standalone full mode).
    */
-  @Input() label: string = $localize`Color`;
+  label = input<string>($localize`Color`);
 
   private readonly destroyRef = inject(DestroyRef);
 

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -11,7 +11,7 @@
 <mat-autocomplete #autoSuggestions="matAutocomplete">
   @for (entity of autocompleteEntities | async; track entity.getId()) {
     <mat-option
-      [value]="entity[formFieldConfig()?.id]"
+      [value]="entity[formFieldConfig().id]"
       (onSelectionChange)="$event.source.selected ? selectEntity(entity) : null"
     >
       <app-entity-block

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -1,15 +1,15 @@
 <input
   matInput
-  [readonly]="!!selectedEntity"
+  [readonly]="!!selectedEntity()"
   [formControl]="formControl"
   [matAutocomplete]="autoSuggestions"
-  [matAutocompleteDisabled]="autocompleteDisabled"
+  [matAutocompleteDisabled]="autocompleteDisabled()"
   (keyup)="keyup()"
   (focusin)="updateAutocomplete()"
 />
 
 <mat-autocomplete #autoSuggestions="matAutocomplete">
-  @for (entity of autocompleteEntities | async; track entity.getId()) {
+  @for (entity of autocompleteEntities(); track entity.getId()) {
     <mat-option
       [value]="entity[formFieldConfig().id]"
       (onSelectionChange)="$event.source.selected ? selectEntity(entity) : null"
@@ -22,9 +22,9 @@
   }
 </mat-autocomplete>
 
-@if (!autocompleteDisabled) {
+@if (!autocompleteDisabled()) {
   <div style="font-size: 0.75em; color: rgba(0, 0, 0, 0.6); margin-top: 4px">
-    @if (!selectedEntity) {
+    @if (!selectedEntity()) {
       <span i18n>Creating new record.</span>
     } @else {
       <span i18n>Editing existing record.</span>
@@ -32,7 +32,7 @@
   </div>
 }
 
-@if (!autocompleteDisabled && !selectedEntity) {
+@if (!autocompleteDisabled() && !selectedEntity()) {
   <fa-icon
     (click)="tooltipElement.show()"
     #tooltipElement="matTooltip"
@@ -48,7 +48,7 @@
     "
     class="tooltip-suffix"
   ></fa-icon>
-} @else if (!autocompleteDisabled && !!selectedEntity) {
+} @else if (!autocompleteDisabled() && !!selectedEntity()) {
   <fa-icon
     (click)="resetForm()"
     icon="circle-xmark"

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.html
@@ -11,7 +11,7 @@
 <mat-autocomplete #autoSuggestions="matAutocomplete">
   @for (entity of autocompleteEntities | async; track entity.getId()) {
     <mat-option
-      [value]="entity[formFieldConfig.id]"
+      [value]="entity[formFieldConfig()?.id]"
       (onSelectionChange)="$event.source.selected ? selectEntity(entity) : null"
     >
       <app-entity-block

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
@@ -69,7 +69,7 @@ describe("EditTextWithAutocompleteComponent", () => {
 
     await component.ngOnInit();
 
-    expect(component.entities).toEqual([e1, e2, e3]);
+    expect(component.entities()).toEqual([e1, e2, e3]);
   });
 
   it("should filter entities when searching", async () => {
@@ -82,7 +82,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     component.formControl.setValue("Second");
     component.updateAutocomplete();
 
-    expect(component.autocompleteEntities.value).toEqual([e2]);
+    expect(component.autocompleteEntities()).toEqual([e2]);
   });
 
   it("should correctly set the form controls to the selected entity's values", async () => {
@@ -195,6 +195,6 @@ describe("EditTextWithAutocompleteComponent", () => {
 
     await component.selectEntity(e2);
 
-    expect(component.selectedEntity).toEqual(e2);
+    expect(component.selectedEntity()).toEqual(e2);
   });
 });

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
@@ -67,7 +67,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     const e3 = TestEntity.create("Third Entity");
     loadTypeSpy.mockResolvedValue([e1, e2, e3]);
 
-    await component.ngOnInit();
+    await component.initAutocomplete();
 
     expect(component.entities()).toEqual([e1, e2, e3]);
   });
@@ -78,7 +78,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     const e3 = TestEntity.create("Third Entity");
     loadTypeSpy.mockResolvedValue([e1, e2, e3]);
 
-    await component.ngOnInit();
+    await component.initAutocomplete();
     component.formControl.setValue("Second");
     component.updateAutocomplete();
 
@@ -93,7 +93,7 @@ describe("EditTextWithAutocompleteComponent", () => {
       refMixed: ["group1", "group2"],
     });
     loadTypeSpy.mockResolvedValue([e1]);
-    await component.ngOnInit();
+    await component.initAutocomplete();
 
     await component.selectEntity(e1);
 
@@ -113,7 +113,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     });
     loadTypeSpy.mockResolvedValue([e1]);
     component.parent.get("refMixed").setValue(["testgroup1"]);
-    await component.ngOnInit();
+    await component.initAutocomplete();
     await component.selectEntity(e1);
 
     await component.resetForm();
@@ -135,7 +135,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     loadTypeSpy.mockResolvedValue([e1]);
     component.additional.relevantProperty = "refMixed";
     component.additional.relatedEntitiesParent = parentEntity;
-    await component.ngOnInit();
+    await component.initAutocomplete();
 
     await component.selectEntity(e1);
 
@@ -152,7 +152,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     loadTypeSpy.mockResolvedValue([e1]);
     component.additional.relevantProperty = "refMixed";
     component.additional.relatedEntitiesParent = parentEntity;
-    await component.ngOnInit();
+    await component.initAutocomplete();
 
     await component.selectEntity(e1);
 
@@ -168,7 +168,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     component.formControl.setValue(e1.name);
     loadTypeSpy.mockResolvedValue([e1, e2]);
 
-    await component.ngOnInit();
+    await component.initAutocomplete();
 
     fixture.detectChanges();
     const input: HTMLInputElement = fixture.debugElement.query(
@@ -189,7 +189,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     loadTypeSpy.mockResolvedValue([e1, e2]);
     mockConfirmationDialog.getConfirmation.mockResolvedValue(true);
 
-    await component.ngOnInit();
+    await component.initAutocomplete();
     component.formControl.setValue("test1");
     component.parent.get("ref").setValue("user3");
 

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
@@ -47,12 +47,12 @@ describe("EditTextWithAutocompleteComponent", () => {
       control: nameControl,
     } as any;
 
-    component.formFieldConfig = {
+    fixture.componentRef.setInput("formFieldConfig", {
       id: "name",
       additional: {
         entityType: "TestEntity",
       },
-    };
+    });
 
     fixture.detectChanges();
   });

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
@@ -71,7 +71,7 @@ export class EditTextWithAutocompleteComponent
   private entityMapperService = inject(EntityMapperService);
   private confirmationDialog = inject(ConfirmationDialogService);
 
-  formFieldConfig = input<FormFieldConfig>();
+  formFieldConfig = input.required<FormFieldConfig>();
 
   get parent(): FormGroup {
     return this.formControl.parent as FormGroup;
@@ -145,7 +145,7 @@ export class EditTextWithAutocompleteComponent
 
   async ngOnInit() {
     // Initialize additional configuration from formFieldConfig
-    this.additional = this.formFieldConfig()?.additional;
+    this.additional = this.formFieldConfig().additional;
 
     if (!this.formControl.value) {
       // adding new entry - enable autocomplete

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
@@ -1,11 +1,11 @@
 import { FormFieldConfig } from "#src/app/core/common-components/entity-form/FormConfig";
-import { AsyncPipe } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
   inject,
   input,
   OnInit,
+  signal,
 } from "@angular/core";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
@@ -13,7 +13,6 @@ import { MatFormFieldControl } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
-import { BehaviorSubject } from "rxjs";
 import { EntityBlockComponent } from "../../basic-datatypes/entity/entity-block/entity-block.component";
 import { DynamicComponent } from "../../config/dynamic-components/dynamic-component.decorator";
 import { EditComponent } from "../../entity/entity-field-edit/dynamic-edit/edit-component.interface";
@@ -52,7 +51,6 @@ import { ConfirmationDialogService } from "../confirmation-dialog/confirmation-d
     ReactiveFormsModule,
     MatInputModule,
     MatAutocompleteModule,
-    AsyncPipe,
     EntityBlockComponent,
     FontAwesomeModule,
     MatTooltipModule,
@@ -107,12 +105,12 @@ export class EditTextWithAutocompleteComponent
     relatedEntitiesParent?: Entity;
   };
 
-  entities: Entity[] = [];
-  autocompleteEntities = new BehaviorSubject(this.entities);
-  selectedEntity?: Entity;
+  entities = signal<Entity[]>([]);
+  autocompleteEntities = signal<Entity[]>([]);
+  selectedEntity = signal<Entity | null>(null);
   currentValues;
   originalValues;
-  autocompleteDisabled = true;
+  autocompleteDisabled = signal(true);
   lastValue = "";
   addedFormControls = [];
 
@@ -128,18 +126,18 @@ export class EditTextWithAutocompleteComponent
   updateAutocomplete() {
     let val = this.formControl.value;
     if (
-      !this.autocompleteDisabled &&
+      !this.autocompleteDisabled() &&
       val !== this.currentValues[this.formFieldConfig().id]
     ) {
-      let filteredEntities = this.entities;
+      let filteredEntities = this.entities();
       if (val) {
-        filteredEntities = this.entities.filter(
+        filteredEntities = this.entities().filter(
           (entity) =>
-            entity !== this.selectedEntity &&
+            entity !== this.selectedEntity() &&
             entity.toString().toLowerCase().includes(val.toLowerCase()),
         );
       }
-      this.autocompleteEntities.next(filteredEntities);
+      this.autocompleteEntities.set(filteredEntities);
     }
   }
 
@@ -150,11 +148,13 @@ export class EditTextWithAutocompleteComponent
     if (!this.formControl.value) {
       // adding new entry - enable autocomplete
       const entityType = this.additional.entityType;
-      this.entities = await this.entityMapperService.loadType(entityType);
-      this.entities.sort((e1, e2) =>
+      const entities = await this.entityMapperService.loadType(entityType);
+      const sortedEntities = [...entities].sort((e1, e2) =>
         e1.toString().localeCompare(e2.toString()),
       );
-      this.autocompleteDisabled = false;
+      this.entities.set(sortedEntities);
+      this.autocompleteEntities.set(sortedEntities);
+      this.autocompleteDisabled.set(false);
       this.currentValues = this.parent.getRawValue();
       this.originalValues = this.currentValues;
     }
@@ -162,11 +162,11 @@ export class EditTextWithAutocompleteComponent
 
   async selectEntity(selected: Entity) {
     if (await this.userConfirmsOverwriteIfNecessary(selected)) {
-      this.selectedEntity = selected;
-      this.addRelevantValueToRelevantProperty(this.selectedEntity);
-      this.setAllFormValues(this.selectedEntity);
+      this.selectedEntity.set(selected);
+      this.addRelevantValueToRelevantProperty(selected);
+      this.setAllFormValues(selected);
       this.currentValues = this.parent.getRawValue();
-      this.autocompleteEntities.next([]);
+      this.autocompleteEntities.set([]);
     } else {
       this.formControl.setValue(this.lastValue);
     }
@@ -213,7 +213,7 @@ export class EditTextWithAutocompleteComponent
       .filter((key) => selected.getSchema().has(key))
       .forEach((key) => {
         if (this.parent.controls.hasOwnProperty(key)) {
-          this.parent.controls[key].setValue(this.selectedEntity[key]);
+          this.parent.controls[key].setValue(selected[key]);
         } else {
           // adding missing controls so saving does not lose any data
           this.parent.addControl(key, new FormControl(selected[key]));
@@ -223,14 +223,16 @@ export class EditTextWithAutocompleteComponent
   }
 
   async resetForm() {
-    if (await this.userConfirmsOverwriteIfNecessary(this.selectedEntity)) {
+    const selectedEntity = this.selectedEntity();
+    if (!selectedEntity) return;
+    if (await this.userConfirmsOverwriteIfNecessary(selectedEntity)) {
       this.addedFormControls.forEach((control) =>
         this.parent.removeControl(control),
       );
       this.addedFormControls = [];
       this.formControl.reset();
       this.parent.patchValue(this.originalValues);
-      this.selectedEntity = null;
+      this.selectedEntity.set(null);
       this.currentValues = this.originalValues;
     }
   }

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
@@ -2,9 +2,9 @@ import { FormFieldConfig } from "#src/app/core/common-components/entity-form/For
 import {
   ChangeDetectionStrategy,
   Component,
+  effect,
   inject,
   input,
-  OnInit,
   signal,
 } from "@angular/core";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
@@ -64,7 +64,7 @@ import { ConfirmationDialogService } from "../confirmation-dialog/confirmation-d
 })
 export class EditTextWithAutocompleteComponent
   extends CustomFormControlDirective<string>
-  implements OnInit, EditComponent
+  implements EditComponent
 {
   private entityMapperService = inject(EntityMapperService);
   private confirmationDialog = inject(ConfirmationDialogService);
@@ -118,6 +118,16 @@ export class EditTextWithAutocompleteComponent
     return this.ngControl.control as FormControl<string>;
   }
 
+  constructor() {
+    super();
+    effect(() => {
+      this.additional = this.formFieldConfig().additional;
+      if (!this.formControl.value) {
+        void this.initAutocomplete();
+      }
+    });
+  }
+
   keyup() {
     this.lastValue = this.formControl.value;
     this.updateAutocomplete();
@@ -141,23 +151,17 @@ export class EditTextWithAutocompleteComponent
     }
   }
 
-  async ngOnInit() {
-    // Initialize additional configuration from formFieldConfig
-    this.additional = this.formFieldConfig().additional;
-
-    if (!this.formControl.value) {
-      // adding new entry - enable autocomplete
-      const entityType = this.additional.entityType;
-      const entities = await this.entityMapperService.loadType(entityType);
-      const sortedEntities = [...entities].sort((e1, e2) =>
-        e1.toString().localeCompare(e2.toString()),
-      );
-      this.entities.set(sortedEntities);
-      this.autocompleteEntities.set(sortedEntities);
-      this.autocompleteDisabled.set(false);
-      this.currentValues = this.parent.getRawValue();
-      this.originalValues = this.currentValues;
-    }
+  async initAutocomplete() {
+    const entityType = this.additional.entityType;
+    const entities = await this.entityMapperService.loadType(entityType);
+    const sortedEntities = [...entities].sort((e1, e2) =>
+      e1.toString().localeCompare(e2.toString()),
+    );
+    this.entities.set(sortedEntities);
+    this.autocompleteEntities.set(sortedEntities);
+    this.autocompleteDisabled.set(false);
+    this.currentValues = this.parent.getRawValue();
+    this.originalValues = this.currentValues;
   }
 
   async selectEntity(selected: Entity) {

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.ts
@@ -4,7 +4,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  Input,
+  input,
   OnInit,
 } from "@angular/core";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
@@ -71,7 +71,7 @@ export class EditTextWithAutocompleteComponent
   private entityMapperService = inject(EntityMapperService);
   private confirmationDialog = inject(ConfirmationDialogService);
 
-  @Input() formFieldConfig?: FormFieldConfig;
+  formFieldConfig = input<FormFieldConfig>();
 
   get parent(): FormGroup {
     return this.formControl.parent as FormGroup;
@@ -129,7 +129,7 @@ export class EditTextWithAutocompleteComponent
     let val = this.formControl.value;
     if (
       !this.autocompleteDisabled &&
-      val !== this.currentValues[this.formFieldConfig.id]
+      val !== this.currentValues[this.formFieldConfig().id]
     ) {
       let filteredEntities = this.entities;
       if (val) {
@@ -145,7 +145,7 @@ export class EditTextWithAutocompleteComponent
 
   async ngOnInit() {
     // Initialize additional configuration from formFieldConfig
-    this.additional = this.formFieldConfig?.additional;
+    this.additional = this.formFieldConfig()?.additional;
 
     if (!this.formControl.value) {
       // adding new entry - enable autocomplete
@@ -185,7 +185,7 @@ export class EditTextWithAutocompleteComponent
   private valuesChanged() {
     return Object.entries(this.currentValues).some(
       ([prop, value]) =>
-        prop !== this.formFieldConfig.id &&
+        prop !== this.formFieldConfig().id &&
         value !== this.parent.controls[prop].value,
     );
   }

--- a/src/app/core/common-components/entities-table/entities-table-selection.spec.ts
+++ b/src/app/core/common-components/entities-table/entities-table-selection.spec.ts
@@ -1,0 +1,109 @@
+import { TestEntity } from "#src/app/utils/test-utils/TestEntity";
+import {
+  applyRangeSelection,
+  isCheckboxTarget,
+  isClickableTarget,
+  shouldSkipRowInteraction,
+  toggleRecordSelection,
+  updateSelectionFromMouseDown,
+} from "./entities-table-selection";
+
+describe("entities-table-selection util", () => {
+  it("adds and removes a selected record", () => {
+    const recordA = TestEntity.create("A");
+    const recordB = TestEntity.create("B");
+
+    const added = toggleRecordSelection([recordA], recordB, true);
+    expect(added).toEqual([recordA, recordB]);
+
+    const removed = toggleRecordSelection(added, recordA, false);
+    expect(removed).toEqual([recordB]);
+  });
+
+  it("applies shift-range select and unselect", () => {
+    const recordA = TestEntity.create("A");
+    const recordB = TestEntity.create("B");
+    const recordC = TestEntity.create("C");
+    const selectedRows = [
+      { record: recordA },
+      { record: recordB },
+      { record: recordC },
+    ];
+
+    const rangeSelected = applyRangeSelection(
+      [],
+      selectedRows,
+      { start: 0, end: 2 },
+      true,
+    );
+    expect(rangeSelected).toEqual([recordA, recordB, recordC]);
+
+    const rangeUnselected = applyRangeSelection(
+      rangeSelected,
+      selectedRows,
+      { start: 1, end: 2 },
+      false,
+    );
+    expect(rangeUnselected).toEqual([recordA]);
+  });
+
+  it("detects clickable and checkbox targets", () => {
+    const clickable = document.createElement("button");
+    clickable.classList.add("clickable");
+    const container = document.createElement("div");
+    container.appendChild(clickable);
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+
+    expect(isClickableTarget(clickable)).toBe(true);
+    expect(isCheckboxTarget(checkbox)).toBe(true);
+    expect(isCheckboxTarget(container)).toBe(false);
+  });
+
+  it("skips row interaction for clickable targets or enabled inline edit rows", () => {
+    const record = TestEntity.create("A");
+    const clickable = document.createElement("button");
+    clickable.classList.add("clickable");
+
+    expect(shouldSkipRowInteraction(clickable, { record })).toBe(true);
+    expect(
+      shouldSkipRowInteraction(document.createElement("div"), {
+        record,
+        formGroup: { enabled: true } as any,
+      }),
+    ).toBe(true);
+  });
+
+  it("updates selection state for normal and shift-range mouse down", () => {
+    const recordA = TestEntity.create("A");
+    const recordB = TestEntity.create("B");
+    const recordC = TestEntity.create("C");
+    const rows = [
+      { record: recordA },
+      { record: recordB },
+      { record: recordC },
+    ];
+
+    const firstClick = updateSelectionFromMouseDown({
+      selectedRecords: [],
+      selectedRows: rows,
+      row: rows[0],
+      shiftKey: false,
+      lastSelectedRow: null,
+      lastSelection: null,
+    });
+    expect(firstClick.selectedRecords).toEqual([recordA]);
+    expect(firstClick.lastSelection).toBe(false);
+    expect(firstClick.lastSelectedRow).toBe(rows[0]);
+
+    const shiftClick = updateSelectionFromMouseDown({
+      selectedRecords: firstClick.selectedRecords,
+      selectedRows: rows,
+      row: rows[2],
+      shiftKey: true,
+      lastSelectedRow: firstClick.lastSelectedRow,
+      lastSelection: firstClick.lastSelection,
+    });
+    expect(shiftClick.selectedRecords).toEqual([recordA, recordB, recordC]);
+  });
+});

--- a/src/app/core/common-components/entities-table/entities-table-selection.ts
+++ b/src/app/core/common-components/entities-table/entities-table-selection.ts
@@ -1,0 +1,237 @@
+import { computed, Injectable, signal } from "@angular/core";
+import { Entity } from "../../entity/model/entity";
+import { TableRow } from "./table-row";
+
+/**
+ * Pure selection helpers for entities-table row interaction
+ * and checkbox state.
+ * And EntitiesTableSelectionStore for holding selection state and coordinating updates.
+ */
+
+/**
+ * Result container for a row selection interaction.
+ */
+export interface MouseSelectionUpdate<T extends Entity> {
+  selectedRecords: T[];
+  lastSelectedRow: TableRow<T> | null;
+  lastSelection: boolean | null;
+}
+
+/**
+ * Input values required to calculate mouse-based row selection updates.
+ */
+export interface MouseSelectionInput<T extends Entity> {
+  selectedRecords: T[];
+  selectedRows: TableRow<T>[];
+  row: TableRow<T>;
+  shiftKey: boolean;
+  lastSelectedRow: TableRow<T> | null;
+  lastSelection: boolean | null;
+}
+
+/**
+ * Detects whether the click target is inside an element marked as `.clickable`.
+ */
+export function isClickableTarget(target: EventTarget | null): boolean {
+  const element = target as {
+    closest?: (selector: string) => Element | null;
+  } | null;
+  return !!element?.closest?.(".clickable");
+}
+
+/**
+ * Detects whether the click originated from a checkbox input.
+ */
+export function isCheckboxTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement && target.type === "checkbox";
+}
+
+/**
+ * Determines whether row-click handling should be skipped for this interaction.
+ */
+export function shouldSkipRowInteraction<T extends Entity>(
+  target: EventTarget | null,
+  row: TableRow<T>,
+): boolean {
+  return isClickableTarget(target) || !!row.formGroup?.enabled;
+}
+
+/**
+ * Adds or removes a single record from the selected records collection.
+ */
+export function toggleRecordSelection<T extends Entity>(
+  selectedRecords: T[],
+  record: T,
+  checked: boolean,
+): T[] {
+  if (checked) {
+    return selectedRecords.includes(record)
+      ? selectedRecords
+      : [...selectedRecords, record];
+  }
+
+  return selectedRecords.includes(record)
+    ? selectedRecords.filter((current) => current !== record)
+    : selectedRecords;
+}
+
+/**
+ * Applies a contiguous shift-selection update over a row index range.
+ */
+export function applyRangeSelection<T extends Entity>(
+  selectedRecords: T[],
+  selectedRows: TableRow<T>[],
+  range: { start: number; end: number },
+  shouldCheck: boolean,
+): T[] {
+  const updatedSelection = [...selectedRecords];
+  for (let index = range.start; index <= range.end; index++) {
+    const row = selectedRows[index];
+    const isSelected = updatedSelection.includes(row.record);
+
+    if (shouldCheck && !isSelected) {
+      updatedSelection.push(row.record);
+    } else if (!shouldCheck && isSelected) {
+      updatedSelection.splice(updatedSelection.indexOf(row.record), 1);
+    }
+  }
+  return updatedSelection;
+}
+
+/**
+ * Computes the next selection state for a row `mousedown`, including shift-range behavior.
+ */
+export function updateSelectionFromMouseDown<T extends Entity>(
+  input: MouseSelectionInput<T>,
+): MouseSelectionUpdate<T> {
+  const {
+    selectedRecords,
+    selectedRows,
+    row,
+    shiftKey,
+    lastSelectedRow,
+    lastSelection,
+  } = input;
+  const currentIndex = selectedRows.indexOf(row);
+  const anchorIndex = lastSelectedRow
+    ? selectedRows.indexOf(lastSelectedRow)
+    : -1;
+  const canRangeSelect =
+    shiftKey && !!lastSelectedRow && anchorIndex !== -1 && currentIndex !== -1;
+
+  if (canRangeSelect) {
+    const start = Math.min(anchorIndex, currentIndex);
+    const end = Math.max(anchorIndex, currentIndex);
+    const shouldCheck =
+      lastSelection !== null
+        ? !lastSelection
+        : !selectedRecords.includes(row.record);
+
+    return {
+      selectedRecords: applyRangeSelection(
+        selectedRecords,
+        selectedRows,
+        { start, end },
+        shouldCheck,
+      ),
+      lastSelectedRow: row,
+      lastSelection,
+    };
+  }
+
+  const wasSelected = selectedRecords.includes(row.record);
+  return {
+    selectedRecords: toggleRecordSelection(
+      selectedRecords,
+      row.record,
+      !wasSelected,
+    ),
+    lastSelectedRow: currentIndex !== -1 ? row : null,
+    lastSelection: wasSelected,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Selection Store
+// ---------------------------------------------------------------------------
+
+type ReadSignal<T> = () => T;
+type ModelSignal<T> = ReadSignal<T> & { set(value: T): void };
+
+/**
+ * Input signals consumed by `EntitiesTableSelectionStore`.
+ */
+export interface EntitiesTableSelectionContext<T extends Entity> {
+  selectedRecords: ModelSignal<T[]>;
+  sortedRows: ReadSignal<TableRow<T>[]>;
+  getCurrentPageRows: () => TableRow<T>[];
+}
+
+/**
+ * Component-scoped signal store for entities-table selection state and interaction logic.
+ *
+ * Uses the pure helpers above for all stateless computations;
+ * this store is responsible only for holding the mutable state
+ * (lastSelectedRow, lastSelection) and coordinating updates.
+ */
+@Injectable()
+export class EntitiesTableSelectionStore<T extends Entity> {
+  private context: EntitiesTableSelectionContext<T>;
+  private readonly lastSelectedRow = signal<TableRow<T> | null>(null);
+  private readonly lastSelection = signal<boolean | null>(null);
+
+  readonly allRowsSelected = computed(() => {
+    const selected = this.context?.selectedRecords() ?? [];
+    const total = this.context?.sortedRows().length ?? 0;
+    return selected.length > 0 && selected.length === total;
+  });
+
+  readonly selectionIndeterminate = computed(() => {
+    const selected = this.context?.selectedRecords() ?? [];
+    const total = this.context?.sortedRows().length ?? 0;
+    return selected.length > 0 && selected.length < total;
+  });
+
+  /** Connects component input/model signals to this store. Must be called once from component constructor. */
+  connect(context: EntitiesTableSelectionContext<T>) {
+    this.context = context;
+  }
+
+  /** Selects or unselects a single row record. */
+  selectRow(row: TableRow<T>, checked: boolean) {
+    this.context.selectedRecords.set(
+      toggleRecordSelection(
+        this.context.selectedRecords(),
+        row.record,
+        checked,
+      ),
+    );
+  }
+
+  /** Selects or unselects all currently sorted rows. */
+  selectAllRows(checked: boolean) {
+    this.context.selectedRecords.set(
+      checked ? this.context.sortedRows().map((r) => r.record) : [],
+    );
+  }
+
+  /**
+   * Applies row selection interaction for mouse-down in selectable mode.
+   * Returns whether the event came from a checkbox target.
+   */
+  handleSelectableRowMouseDown(event: MouseEvent, row: TableRow<T>): boolean {
+    const selectedRows = this.context.getCurrentPageRows();
+    const nextState = updateSelectionFromMouseDown({
+      selectedRecords: this.context.selectedRecords(),
+      selectedRows,
+      row,
+      shiftKey: event.shiftKey,
+      lastSelectedRow: this.lastSelectedRow(),
+      lastSelection: this.lastSelection(),
+    });
+    this.context.selectedRecords.set(nextState.selectedRecords);
+    this.lastSelectedRow.set(nextState.lastSelectedRow);
+    this.lastSelection.set(nextState.lastSelection);
+    return isCheckboxTarget(event.target);
+  }
+}

--- a/src/app/core/common-components/entities-table/entities-table-sort.store.spec.ts
+++ b/src/app/core/common-components/entities-table/entities-table-sort.store.spec.ts
@@ -1,0 +1,61 @@
+import { DateDatatype } from "../../basic-datatypes/date/date.datatype";
+import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
+import { DefaultDatatype } from "../../entity/default-datatype/default.datatype";
+import { toFormFieldConfig } from "../entity-form/FormConfig";
+import {
+  applySortingRules,
+  inferDefaultSort,
+} from "./entities-table-sort.store";
+
+describe("applySortingRules", () => {
+  it("marks non-sortable field types", () => {
+    const columns = applySortingRules(
+      [
+        toFormFieldConfig({
+          id: "children",
+          dataType: EntityDatatype.dataType,
+        }),
+        toFormFieldConfig({ id: "tags", isArray: true, dataType: "string" }),
+        toFormFieldConfig({
+          id: "age",
+          viewComponent: "DisplayAge",
+          dataType: "number",
+        }),
+      ],
+      () => new DefaultDatatype(),
+    );
+
+    expect(columns.find((c) => c.id === "children")?.noSorting).toBe(true);
+    expect(columns.find((c) => c.id === "tags")?.noSorting).toBe(true);
+    expect(columns.find((c) => c.id === "age")?.noSorting).toBe(undefined);
+  });
+});
+
+describe("inferDefaultSort", () => {
+  it("infers default sort from first sortable column", () => {
+    const columns = applySortingRules(
+      [
+        toFormFieldConfig({
+          id: "children",
+          dataType: EntityDatatype.dataType,
+        }),
+        toFormFieldConfig({ id: "name", dataType: "string" }),
+      ],
+      () => new DefaultDatatype(),
+    );
+    const sort = inferDefaultSort(
+      ["children", "name"],
+      columns,
+      () => undefined,
+    );
+    expect(sort).toEqual({ active: "name", direction: "asc" });
+  });
+
+  it("uses descending default sort for date columns", () => {
+    const columns = [toFormFieldConfig({ id: "created", dataType: "date" })];
+    const sort = inferDefaultSort(["created"], columns, (dataType) =>
+      dataType === "date" ? new DateDatatype() : undefined,
+    );
+    expect(sort).toEqual({ active: "created", direction: "desc" });
+  });
+});

--- a/src/app/core/common-components/entities-table/entities-table-sort.store.ts
+++ b/src/app/core/common-components/entities-table/entities-table-sort.store.ts
@@ -1,0 +1,265 @@
+import {
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  Injectable,
+  signal,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { MatSort, Sort, SortDirection } from "@angular/material/sort";
+import { DateDatatype } from "../../basic-datatypes/date/date.datatype";
+import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
+import { DefaultDatatype } from "../../entity/default-datatype/default.datatype";
+import { Entity } from "../../entity/model/entity";
+import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { FormFieldConfig } from "../entity-form/FormConfig";
+import { TableRow } from "./table-row";
+import { tableSort } from "./table-sort/table-sort";
+import { TableStateUrlService } from "./table-state-url.service";
+
+type ReadSignal<T> = () => T;
+
+/**
+ * Input signals consumed by `EntitiesTableSortStore`.
+ */
+export interface EntitiesTableSortContext<T extends Entity = Entity> {
+  /** Visible column IDs (updated reactively). */
+  columnsToDisplay: ReadSignal<string[]>;
+  /** Full column definitions (updated reactively). */
+  columns: ReadSignal<FormFieldConfig[]>;
+  /** External sort override from a component input binding. */
+  externalSort: ReadSignal<Sort | undefined>;
+  /** Filtered records to be sorted. */
+  filteredRecords: ReadSignal<T[]>;
+}
+
+/**
+ * Component-scoped store that manages table sort state, MatSort binding,
+ * and URL query-param persistence.
+ */
+@Injectable()
+export class EntitiesTableSortStore<T extends Entity = Entity> {
+  private readonly tableStateUrl = inject(TableStateUrlService);
+  private readonly schemaService = inject(EntitySchemaService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private context: EntitiesTableSortContext<T> | null = null;
+  private readonly sortManuallySet = signal(false);
+  private attachedSort?: MatSort;
+
+  /** Explicitly set sort (via user interaction, URL state, or external input). */
+  readonly sortState = signal<Sort>(undefined);
+
+  /**
+   * Columns with sorting rules applied.
+   * Disables sorting for entity references, untyped columns, and arrays
+   * (unless the array's datatype provides custom sort logic).
+   */
+  readonly columns = computed<FormFieldConfig[]>(() => {
+    if (!this.context) return [];
+    return applySortingRules(this.context.columns(), (dataType) =>
+      this.schemaService.getDatatypeOrDefault(dataType, true),
+    );
+  });
+
+  /**
+   * Default sort inferred from visible sortable columns.
+   * Recomputed whenever columns or columnsToDisplay change.
+   */
+  readonly defaultSort = computed<Sort | undefined>(() => {
+    if (!this.context) return undefined;
+    return inferDefaultSort(
+      this.context.columnsToDisplay(),
+      this.columns(),
+      (dataType) => this.schemaService.getDatatypeOrDefault(dataType),
+    );
+  });
+
+  /**
+   * Effective sort used for row ordering — falls back to the default sort
+   * inferred from columns when no explicit sort has been set.
+   */
+  readonly effectiveSort = computed<Sort | undefined>(
+    () => this.sortState() ?? this.defaultSort(),
+  );
+
+  /**
+   * Map of column id → sort value extractor built from datatype metadata.
+   * Datatypes that override `sortValue` provide custom sort logic;
+   * others return `undefined` and fall back to default sorting in `tableSort`.
+   */
+  readonly sortValueFns = computed<
+    Record<string, (v: any) => number | string | undefined>
+  >(() => {
+    if (!this.context) return {};
+    const fns: Record<string, (v: any) => number | string | undefined> = {};
+    for (const col of this.context.columns()) {
+      const datatype = this.schemaService.getDatatypeOrDefault(
+        col.dataType,
+        true,
+      );
+      fns[col.id] = (v) => datatype.sortValue(v);
+    }
+    return fns;
+  });
+
+  /** Sorted rows derived from filtered records and effective sort. */
+  readonly sortedRows = computed<TableRow<T>[]>(() => {
+    if (!this.context) return [];
+    const rows = this.context.filteredRecords().map((record) => ({ record }));
+    const sort = this.effectiveSort();
+
+    if (!sort?.active || !sort.direction) {
+      return rows;
+    }
+
+    return tableSort<T, keyof T>(rows, {
+      active: sort.active as keyof T,
+      direction: sort.direction,
+      sortValueFns: this.sortValueFns(),
+    });
+  });
+
+  constructor() {
+    // Sync default sort when no manual override and no URL state
+    effect(() => {
+      if (!this.context) return;
+      if (
+        !this.sortManuallySet() &&
+        !this.tableStateUrl.getUrlParam("sortBy")
+      ) {
+        this.sortState.set(this.defaultSort());
+      }
+    });
+
+    // Apply external sort input and persist to URL
+    effect(() => {
+      if (!this.context) return;
+      const externalSort = this.context.externalSort();
+      if (!externalSort) return;
+      this.sortState.set(externalSort);
+      if (externalSort.active) {
+        this.tableStateUrl.updateUrlParams({
+          sortBy: externalSort.active,
+          sortOrder: externalSort.direction ?? "asc",
+        });
+      }
+      this.sortManuallySet.set(true);
+    });
+  }
+
+  /** Connects component signals to this store. Must be called once from component constructor. */
+  connect(context: EntitiesTableSortContext<T>) {
+    this.context = context;
+  }
+
+  /** Attaches `MatSort`, restores URL sort state, and keeps URL in sync with user sort changes. */
+  attachSort(sort: MatSort | undefined) {
+    if (!sort || this.attachedSort === sort) return;
+    this.attachedSort = sort;
+
+    const urlSortBy = this.tableStateUrl.getUrlParam("sortBy");
+    const urlSortOrder = this.tableStateUrl.getUrlParam(
+      "sortOrder",
+    ) as SortDirection;
+    if (urlSortBy) {
+      sort.active = urlSortBy;
+      sort.direction = urlSortOrder || "asc";
+      this.sortState.set({ active: sort.active, direction: sort.direction });
+      this.sortManuallySet.set(true);
+    }
+
+    sort.sortChange
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        this.sortState.set(value);
+        this.sortManuallySet.set(true);
+        this.updateSortUrlParams(value.active, value.direction);
+      });
+  }
+
+  private updateSortUrlParams(active: string, direction: SortDirection) {
+    if (!direction) {
+      this.tableStateUrl.updateUrlParams({
+        sortBy: null,
+        sortOrder: null,
+      });
+      return;
+    }
+
+    if (direction === "desc") {
+      this.tableStateUrl.updateUrlParams({
+        sortBy: active,
+        sortOrder: "desc",
+      });
+      return;
+    }
+
+    this.tableStateUrl.updateUrlParams({
+      sortBy: active,
+      sortOrder: null,
+    });
+  }
+}
+
+/**
+ * Infers a stable default sort from visible sortable columns.
+ * Date-like columns default to descending order.
+ */
+export function inferDefaultSort(
+  colsToDisplay: string[],
+  columns: FormFieldConfig[],
+  getDatatypeOrDefault: (dataType?: string) => unknown,
+): Sort | undefined {
+  const sortBy = colsToDisplay
+    .filter((columnId) => !columnId.startsWith("__"))
+    .find((columnId) => {
+      const column = columns.find((c) => c.id === columnId);
+      return !column?.noSorting;
+    });
+  const sortByColumn = columns.find((c) => c.id === sortBy);
+
+  let sortDirection: SortDirection = "asc";
+  if (
+    sortByColumn?.viewComponent === "DisplayDate" ||
+    sortByColumn?.viewComponent === "DisplayMonth" ||
+    getDatatypeOrDefault(sortByColumn?.dataType) instanceof DateDatatype
+  ) {
+    sortDirection = "desc";
+  }
+
+  return sortBy ? { active: sortBy, direction: sortDirection } : undefined;
+}
+
+/**
+ * Applies sorting rules to columns: disables sorting for entity references,
+ * untyped columns, and arrays (unless the datatype provides custom sort logic).
+ */
+export function applySortingRules(
+  columns: FormFieldConfig[],
+  getDatatypeOrDefault: (dataType?: string) => DefaultDatatype,
+): FormFieldConfig[] {
+  return columns.map((column) => {
+    if (column.viewComponent === "DisplayAge") {
+      return column;
+    }
+
+    if (column.isArray) {
+      const datatype = getDatatypeOrDefault(column.dataType);
+      if (datatype?.sortValue !== DefaultDatatype.prototype.sortValue) {
+        return column;
+      }
+    }
+
+    if (
+      column.isArray ||
+      column.dataType === EntityDatatype.dataType ||
+      !column.dataType
+    ) {
+      return { ...column, noSorting: true };
+    }
+
+    return column;
+  });
+}

--- a/src/app/core/common-components/entities-table/entities-table.component.html
+++ b/src/app/core/common-components/entities-table/entities-table.component.html
@@ -9,8 +9,8 @@
     mat-table
     [dataSource]="recordsDataSource"
     matSort
-    [matSortActive]="_sortBy()?.active"
-    [matSortDirection]="_sortBy()?.direction"
+    [matSortActive]="sortStore.effectiveSort()?.active"
+    [matSortDirection]="sortStore.effectiveSort()?.direction"
     class="full-width table"
   >
     @for (col of _columns(); track col.id) {
@@ -50,16 +50,16 @@
     <ng-container [matColumnDef]="ACTIONCOLUMN_SELECT">
       <th mat-header-cell *matHeaderCellDef style="width: 0">
         <mat-checkbox
-          (change)="selectAllRows($event)"
-          [checked]="isAllSelected()"
-          [indeterminate]="isIndeterminate()"
+          (change)="selectionStore.selectAllRows($event.checked)"
+          [checked]="selectionStore.allRowsSelected()"
+          [indeterminate]="selectionStore.selectionIndeterminate()"
         ></mat-checkbox>
       </th>
 
       <td mat-cell *matCellDef="let row">
         <mat-checkbox
-          (change)="onRowSelect($event, row)"
-          [checked]="selectedRecords()?.includes(row.record)"
+          (change)="selectionStore.selectRow(row, $event.checked)"
+          [checked]="selectedRecords().includes(row.record)"
           (click)="$event.stopPropagation()"
         ></mat-checkbox>
       </td>

--- a/src/app/core/common-components/entities-table/entities-table.component.html
+++ b/src/app/core/common-components/entities-table/entities-table.component.html
@@ -1,16 +1,16 @@
-@if (isLoading) {
+@if (isLoading()) {
   <div class="process-spinner">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
 }
 
-<div [hidden]="isLoading" class="table-container">
+<div [hidden]="isLoading()" class="table-container">
   <table
     mat-table
     [dataSource]="recordsDataSource"
     matSort
-    [matSortActive]="_sortBy?.active"
-    [matSortDirection]="_sortBy?.direction"
+    [matSortActive]="_sortBy()?.active"
+    [matSortDirection]="_sortBy()?.direction"
     class="full-width table"
   >
     @for (col of _columns; track col.id) {
@@ -23,7 +23,7 @@
         >
           <app-entity-field-label
             [field]="col"
-            [entityType]="_entityType"
+            [entityType]="entityType()"
           ></app-entity-field-label>
         </th>
         <td mat-cell *matCellDef="let row">
@@ -59,7 +59,7 @@
       <td mat-cell *matCellDef="let row">
         <mat-checkbox
           (change)="onRowSelect($event, row)"
-          [checked]="selectedRecords?.includes(row.record)"
+          [checked]="selectedRecords()?.includes(row.record)"
           (click)="$event.stopPropagation()"
         ></mat-checkbox>
       </td>
@@ -71,8 +71,8 @@
     <ng-container [matColumnDef]="ACTIONCOLUMN_EDIT">
       <th mat-header-cell *matHeaderCellDef class="remove-padding-left">
         <app-entity-create-button
-          [entityType]="_entityType"
-          [newRecordFactory]="newRecordFactory"
+          [entityType]="entityType()"
+          [newRecordFactory]="newRecordFactory()"
           (entityCreate)="showEntity($event); entityClick.emit($event)"
           [iconOnly]="true"
         ></app-entity-create-button>
@@ -87,12 +87,12 @@
     <!-- custom columns via content projection -->
     <ng-content></ng-content>
 
-    <tr mat-header-row *matHeaderRowDef="_columnsToDisplay"></tr>
+    <tr mat-header-row *matHeaderRowDef="_columnsToDisplay()"></tr>
     <tr
       mat-row
-      *matRowDef="let row; columns: _columnsToDisplay"
+      *matRowDef="let row; columns: _columnsToDisplay()"
       [class.inactive-row]="!row.record.isActive"
-      [style.background-color]="getBackgroundColor?.(row.record)"
+      [style.background-color]="effectiveBackgroundColor()(row.record)"
       class="table-row"
       (mousedown)="onRowMouseDown($event, row)"
       style="cursor: pointer"
@@ -113,8 +113,8 @@
   -->
   <div class="table-footer filter-inactive-toggle">
     <mat-slide-toggle
-      [checked]="_showInactive"
-      (change)="showInactive = $event.checked"
+      [checked]="showInactive()"
+      (change)="showInactive.set($event.checked)"
       i18n="slider|also show entries that are archived"
     >
       Include archived records

--- a/src/app/core/common-components/entities-table/entities-table.component.html
+++ b/src/app/core/common-components/entities-table/entities-table.component.html
@@ -13,7 +13,7 @@
     [matSortDirection]="_sortBy()?.direction"
     class="full-width table"
   >
-    @for (col of _columns; track col.id) {
+    @for (col of _columns(); track col.id) {
       <ng-container [matColumnDef]="col.id">
         <th
           mat-header-cell
@@ -105,7 +105,7 @@
   <app-list-paginator
     class="table-footer"
     [dataSource]="recordsDataSource"
-    [idForSavingPagination]="idForSavingPagination"
+    [idForSavingPagination]="idForSavingPagination()"
   ></app-list-paginator>
 
   <!--

--- a/src/app/core/common-components/entities-table/entities-table.component.spec.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.spec.ts
@@ -74,7 +74,7 @@ describe("EntitiesTableComponent", () => {
 
     fixture = TestBed.createComponent(EntitiesTableComponent);
     component = fixture.componentInstance;
-    component.editable = false;
+    fixture.componentRef.setInput("editable", false);
     fixture.detectChanges();
   });
 
@@ -83,16 +83,16 @@ describe("EntitiesTableComponent", () => {
   });
 
   it("should apply default sort on first column and order dates descending", () => {
-    component.entityType = Note;
-    component.customColumns = [
+    fixture.componentRef.setInput("entityType", Note);
+    fixture.componentRef.setInput("customColumns", [
       { id: "date", dataType: DateDatatype.dataType },
       "subject",
-    ];
-    component.columnsToDisplay = ["date", "subject"];
+    ]);
+    fixture.componentRef.setInput("columnsToDisplay", ["date", "subject"]);
 
     const oldNote = Note.create(moment().subtract(1, "day").toDate());
     const newNote = Note.create(new Date());
-    component.records = [oldNote, newNote];
+    fixture.componentRef.setInput("records", [oldNote, newNote]);
     fixture.detectChanges();
 
     expect(component.recordsDataSource.sort.direction).toBe("desc");
@@ -100,15 +100,17 @@ describe("EntitiesTableComponent", () => {
   });
 
   it("should use input defaultSort if defined", () => {
-    component.customColumns = ["date", "subject"];
-    component.columnsToDisplay = ["date", "subject"];
+    fixture.componentRef.setInput("customColumns", ["date", "subject"]);
+    fixture.componentRef.setInput("columnsToDisplay", ["date", "subject"]);
     const n1 = Note.create(new Date(), "1");
     const n2 = Note.create(new Date(), "2");
     const n3 = Note.create(new Date(), "3");
 
-    component.records = [n3, n1, n2];
-
-    component.sortBy = { active: "subject", direction: "asc" };
+    fixture.componentRef.setInput("records", [n3, n1, n2]);
+    fixture.componentRef.setInput("sortBy", {
+      active: "subject",
+      direction: "asc",
+    });
     fixture.detectChanges();
 
     expect(component.recordsDataSource.sort.direction).toBe("asc");
@@ -116,12 +118,12 @@ describe("EntitiesTableComponent", () => {
   });
 
   it("should skip non-sortable columns when inferring default sort", () => {
-    component.entityType = Note;
-    component.columnsToDisplay = ["children", "subject"];
+    fixture.componentRef.setInput("entityType", Note);
+    fixture.componentRef.setInput("columnsToDisplay", ["children", "subject"]);
 
     const n1 = Note.create(new Date(), "B");
     const n2 = Note.create(new Date(), "A");
-    component.records = [n1, n2];
+    fixture.componentRef.setInput("records", [n1, n2]);
     fixture.detectChanges();
 
     expect(component.recordsDataSource.sort.active).toBe("subject");
@@ -139,9 +141,11 @@ describe("EntitiesTableComponent", () => {
     notes[1].category = { id: "3", label: "C", _ordinal: 1 };
     notes[2].category = { id: "2", label: "Z", _ordinal: 0 };
     notes[3].category = { id: "1", label: "AB", _ordinal: 2 };
-    component.records = notes;
-
-    component.sortBy = { active: "category", direction: "asc" };
+    fixture.componentRef.setInput("records", notes);
+    fixture.componentRef.setInput("sortBy", {
+      active: "category",
+      direction: "asc",
+    });
     fixture.detectChanges();
 
     const sortedIds = component.recordsDataSource
@@ -167,32 +171,32 @@ describe("EntitiesTableComponent", () => {
     c2.dateOfBirth = new DateWithAge(moment().subtract(2, "years").toDate());
     const c3 = TestEntity.create("Matching");
     c3.dateOfBirth = new DateWithAge(moment().subtract(3, "years").toDate());
-    // get type-safety for filters
-    const childComponent =
-      component as any as EntitiesTableComponent<TestEntity>;
-    childComponent.records = [c1, c2, c3];
 
-    childComponent.filter = { name: "Matching" };
+    fixture.componentRef.setInput("records", [c1, c2, c3]);
+    fixture.componentRef.setInput("filter", { name: "Matching" });
+    fixture.detectChanges();
 
-    expect(childComponent.recordsDataSource.data).toEqual([
+    expect(component.recordsDataSource.data).toEqual([
       { record: c1 },
       { record: c3 },
     ]);
 
-    childComponent.filter = {
+    fixture.componentRef.setInput("filter", {
       name: "Matching",
       "dateOfBirth.age": { $gte: 2 },
-    } as any;
+    });
+    fixture.detectChanges();
 
-    expect(childComponent.recordsDataSource.data).toEqual([{ record: c3 }]);
+    expect(component.recordsDataSource.data).toEqual([{ record: c3 }]);
 
     const c4 = TestEntity.create("Matching");
     c4.dateOfBirth = new DateWithAge(moment().subtract(4, "years").toDate());
     const c5 = TestEntity.create("Not Matching");
 
-    childComponent.records = [c1, c2, c3, c4, c5];
+    fixture.componentRef.setInput("records", [c1, c2, c3, c4, c5]);
+    fixture.detectChanges();
 
-    expect(childComponent.recordsDataSource.data).toEqual([
+    expect(component.recordsDataSource.data).toEqual([
       { record: c3 },
       { record: c4 },
     ]);
@@ -201,13 +205,17 @@ describe("EntitiesTableComponent", () => {
   it("should remove an entity if it does not pass the filter anymore", async () => {
     const child = new TestEntity();
     child.category = genders[1];
-    component.records = [child];
-    component.filter = { "category.id": genders[1].id } as any;
+    fixture.componentRef.setInput("records", [child]);
+    fixture.componentRef.setInput("filter", {
+      "category.id": genders[1].id,
+    } as any);
+    fixture.detectChanges();
 
     expect(component.recordsDataSource.data).toEqual([{ record: child }]);
 
     child.category = genders[2];
-    component.records = [child]; // parent component has to update the records Input array
+    fixture.componentRef.setInput("records", [child]); // parent component has to update the records Input array
+    fixture.detectChanges();
 
     expect(component.recordsDataSource.data).toEqual([]);
   });
@@ -218,18 +226,20 @@ describe("EntitiesTableComponent", () => {
     const inactive = new Entity();
     inactive.inactive = true;
 
-    component.records = [active1, inactive];
+    fixture.componentRef.setInput("records", [active1, inactive]);
+    fixture.detectChanges();
 
     expect(component.recordsDataSource.data).toEqual([{ record: active1 }]);
   });
 
   it("should overwrite entity schema fields with customColumn config", async () => {
-    component.entityType = TestEntity;
+    fixture.componentRef.setInput("entityType", TestEntity);
     const customField = {
       id: "name",
       label: "Custom Name Label",
     };
-    component.customColumns = [customField];
+    fixture.componentRef.setInput("customColumns", [customField]);
+    fixture.detectChanges();
 
     expect(component._columns.find((c) => c.id === customField.id).label).toBe(
       customField.label,
@@ -237,7 +247,8 @@ describe("EntitiesTableComponent", () => {
   });
 
   it("should set noSorting if dataType cannot be sorted properly", () => {
-    component.entityType = Note;
+    fixture.componentRef.setInput("entityType", Note);
+    fixture.detectChanges();
 
     expect(component._columns.find((c) => c.id === "children").noSorting).toBe(
       true,
@@ -246,7 +257,8 @@ describe("EntitiesTableComponent", () => {
 
   it("should navigate to '/new' route on newly created entities", () => {
     const navigateSpy = TestBed.inject(Router).navigate;
-    component.clickMode = "navigate";
+    fixture.componentRef.setInput("clickMode", "navigate");
+    fixture.detectChanges();
 
     const child = new TestEntity();
     expect(child.isNew).toBe(true);

--- a/src/app/core/common-components/entities-table/entities-table.component.spec.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.spec.ts
@@ -241,18 +241,18 @@ describe("EntitiesTableComponent", () => {
     fixture.componentRef.setInput("customColumns", [customField]);
     fixture.detectChanges();
 
-    expect(component._columns.find((c) => c.id === customField.id).label).toBe(
-      customField.label,
-    );
+    expect(
+      component._columns().find((c) => c.id === customField.id).label,
+    ).toBe(customField.label);
   });
 
   it("should set noSorting if dataType cannot be sorted properly", () => {
     fixture.componentRef.setInput("entityType", Note);
     fixture.detectChanges();
 
-    expect(component._columns.find((c) => c.id === "children").noSorting).toBe(
-      true,
-    );
+    expect(
+      component._columns().find((c) => c.id === "children").noSorting,
+    ).toBe(true);
   });
 
   it("should navigate to '/new' route on newly created entities", () => {

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -1,12 +1,15 @@
 import {
   AfterContentInit,
   Component,
+  computed,
   ContentChildren,
-  EventEmitter,
+  effect,
   inject,
-  Input,
-  Output,
+  input,
+  model,
+  output,
   QueryList,
+  signal,
   ViewChild,
   ChangeDetectionStrategy,
 } from "@angular/core";
@@ -88,22 +91,45 @@ export class EntitiesTableComponent<
   private schemaService = inject(EntitySchemaService);
   private readonly tableStateUrl = inject(TableStateUrlService);
 
-  @Input() set records(value: T[]) {
-    if (!value) {
-      return;
-    }
-    this._records = value;
+  records = input<T[]>();
+  customColumns = input<ColumnConfig[]>([]);
+  columnsToDisplay = input<string[]>();
+  entityType = input<EntityConstructor<T>>();
+  sortBy = input<Sort>();
+  filter = input<DataFilter<T>>();
+  filterFreetext = input<string>();
+  showEntityColor = input<boolean>(false);
+  getBackgroundColor = input<(rec: T) => string>();
+  clickMode = input<"popup" | "navigate" | "popup-details" | "none">("popup");
+  newRecordFactory = input<() => T>();
+  editable = input<boolean>(true);
+  selectable = input<boolean>(false);
 
-    this.updateFilteredData();
-    this.isLoading = false;
-  }
+  filteredRecordsChange = output<T[]>();
+  entityClick = output<T>();
+  selectedRecords = model<T[]>([]);
+  showInactive = model<boolean>(false);
+
+  readonly effectiveBackgroundColor = computed<(rec: T) => string>(() => {
+    const custom = this.getBackgroundColor();
+    const useEntityColor = this.showEntityColor();
+    return custom ?? ((rec: T) => (useEntityColor ? rec.getColor() : ""));
+  });
 
   private lastSelectedRow: TableRow<T> | null = null;
   private lastSelection: boolean = null;
   _records: T[] = [];
+  _customColumns: FormFieldConfig[] = [];
+  _columns: FormFieldConfig[] = [];
+  _filter: DataFilter<T> = {};
+  idForSavingPagination: string;
+
+  readonly isLoading = signal<boolean>(true);
+  readonly _columnsToDisplay = signal<string[]>([]);
+  readonly _sortBy = signal<Sort>(undefined);
+
   /** data displayed in the template's table */
   recordsDataSource: MatTableDataSource<TableRow<T>>;
-  isLoading: boolean = true;
 
   @ViewChild(MatTable, { static: true }) table: MatTable<T>;
   @ContentChildren(MatColumnDef) projectedColumns: QueryList<MatColumnDef>;
@@ -116,100 +142,10 @@ export class EntitiesTableComponent<
   }
 
   /**
-   * Additional or overwritten field configurations for columns
-   * @param value
+   * Indicates whether the current sort order was manually set by the user
+   * to avoid overwriting it with the default sort
    */
-  @Input() set customColumns(value: ColumnConfig[]) {
-    this._customColumns = (value ?? []).map((c) =>
-      this._entityType
-        ? this.entityFormService.extendFormFieldConfig(c, this._entityType)
-        : toFormFieldConfig(c),
-    );
-    const entityColumns = this._entityType?.schema
-      ? [...this._entityType.schema.entries()].map(
-          ([id, field]) => ({ ...field, id }) as FormFieldConfig,
-        )
-      : [];
-
-    this._columns = [
-      ...entityColumns.filter(
-        // if there is a customColumn for a field from entity config, don't add the base schema field
-        (c) => !this._customColumns.some((customCol) => customCol.id === c.id),
-      ),
-      ...this._customColumns,
-    ];
-    this._columns.forEach((c) => this.disableSortingHeaderForAdvancedFields(c));
-
-    if (!this.columnsToDisplay) {
-      this.columnsToDisplay = this._customColumns
-        .filter((c) => !c.hideFromTable)
-        .map((c) => c.id);
-    }
-
-    this.idForSavingPagination = this._customColumns
-      .map((col) => col.id)
-      .join("");
-  }
-
-  _customColumns: FormFieldConfig[];
-  _columns: FormFieldConfig[] = [];
-
-  /**
-   * Manually define the columns to be shown.
-   *
-   * @param value
-   */
-  @Input() set columnsToDisplay(value: string[]) {
-    if (!value || value.length === 0) {
-      value = (this._customColumns ?? this._columns).map((c) => c.id);
-    }
-    value = value.filter((c) => !c.startsWith("__")); // remove internal action columns
-
-    const cols = [];
-    if (this._selectable) {
-      cols.push(this.ACTIONCOLUMN_SELECT);
-    }
-    if (this._editable) {
-      cols.push(this.ACTIONCOLUMN_EDIT);
-    }
-    cols.push(...value);
-    this._columnsToDisplay = cols;
-
-    if (!this.sortManuallySet && !this.tableStateUrl.getUrlParam("sortBy")) {
-      // Only set default sort if not manually set and/or present in URL
-      this._sortBy = this.inferDefaultSort(); // do not use sortBy setter to avoid persisting to URL
-    }
-  }
-
-  _columnsToDisplay: string[] = [];
-
-  @Input() set entityType(value: EntityConstructor<T>) {
-    this._entityType = value;
-    this.customColumns = this._customColumns;
-  }
-
-  _entityType: EntityConstructor<T>;
-
-  /** how to sort data by default during initialization */
-  @Input() set sortBy(value: Sort) {
-    if (!value) {
-      return;
-    }
-
-    this._sortBy = value;
-
-    // Persist sort state to URL
-    if (value.active) {
-      this.tableStateUrl.updateUrlParams({
-        sortBy: value.active,
-        sortOrder: value.direction ?? "asc",
-      });
-    }
-
-    this.sortManuallySet = true;
-  }
-
-  _sortBy: Sort;
+  private sortManuallySet: boolean;
 
   @ViewChild(MatSort, { static: false }) set sort(sort: MatSort) {
     this.recordsDataSource.sort = sort;
@@ -242,24 +178,97 @@ export class EntitiesTableComponent<
     }
   }
 
-  /**
-   * Indicates whether the current sort order was manually set by the user
-   * to avoid overwriting it with the default sort
-   */
-  private sortManuallySet: boolean;
+  readonly ACTIONCOLUMN_SELECT = "__select";
+  readonly ACTIONCOLUMN_EDIT = "__edit";
 
-  /**
-   * Adds a filter for the displayed data.
-   * Only data, that passes the filter will be shown in the table.
-   */
-  @Input() set filter(value: DataFilter<T>) {
-    this._filter = value ?? {};
-    this.updateFilteredData();
+  constructor() {
+    this.recordsDataSource = this.createDataSource();
+
+    // Column computation effect: recomputes column state when entity type, columns config, or display settings change
+    effect(() => {
+      const entityType = this.entityType();
+      const rawCustomColumns = this.customColumns();
+      const rawColumnsToDisplay = this.columnsToDisplay();
+      const selectable = this.selectable();
+      const editable = this.editable();
+
+      this._customColumns = (rawCustomColumns ?? []).map((c) =>
+        entityType
+          ? this.entityFormService.extendFormFieldConfig(c, entityType)
+          : toFormFieldConfig(c),
+      );
+
+      const entityColumns = entityType?.schema
+        ? [...entityType.schema.entries()].map(
+            ([id, field]) => ({ ...field, id }) as FormFieldConfig,
+          )
+        : [];
+
+      this._columns = [
+        ...entityColumns.filter(
+          (c) =>
+            !this._customColumns.some((customCol) => customCol.id === c.id),
+        ),
+        ...this._customColumns,
+      ];
+      this._columns.forEach((c) =>
+        this.disableSortingHeaderForAdvancedFields(c),
+      );
+
+      this.idForSavingPagination = this._customColumns
+        .map((col) => col.id)
+        .join("");
+
+      let colsToDisplay = rawColumnsToDisplay;
+      if (!colsToDisplay || colsToDisplay.length === 0) {
+        colsToDisplay = this._customColumns
+          .filter((c) => !c.hideFromTable)
+          .map((c) => c.id);
+      }
+      colsToDisplay = colsToDisplay.filter((c) => !c.startsWith("__"));
+
+      const cols: string[] = [];
+      if (selectable) cols.push(this.ACTIONCOLUMN_SELECT);
+      if (editable) cols.push(this.ACTIONCOLUMN_EDIT);
+      cols.push(...colsToDisplay);
+      this._columnsToDisplay.set(cols);
+
+      if (!this.sortManuallySet && !this.tableStateUrl.getUrlParam("sortBy")) {
+        this._sortBy.set(this.inferDefaultSort(cols));
+      }
+    });
+
+    // Data filter effect: re-filters records when data, filter, or showInactive changes
+    effect(() => {
+      const records = this.records();
+      this.showInactive(); // track — consumed inside updateFilteredData via addActiveInactiveFilter
+      if (records === undefined || records === null) return;
+      this._records = records;
+      this._filter = this.filter() ?? {};
+      this.updateFilteredData();
+      this.isLoading.set(false);
+    });
+
+    // Sort input effect: applies external sort input
+    effect(() => {
+      const sortBy = this.sortBy();
+      if (!sortBy) return;
+      this._sortBy.set(sortBy);
+      if (sortBy.active) {
+        this.tableStateUrl.updateUrlParams({
+          sortBy: sortBy.active,
+          sortOrder: sortBy.direction ?? "asc",
+        });
+      }
+      this.sortManuallySet = true;
+    });
+
+    // Freetext filter effect
+    effect(() => {
+      this.recordsDataSource.filter = this.filterFreetext() ?? "";
+      this.emitFilteredRecordsFromDataSource();
+    });
   }
-
-  _filter: DataFilter<T> = {};
-  /** output the currently displayed records, whenever filters for the user change */
-  @Output() filteredRecordsChange = new EventEmitter<T[]>(true);
 
   private updateFilteredData() {
     this.addActiveInactiveFilter(this._filter);
@@ -269,91 +278,36 @@ export class EntitiesTableComponent<
     this.emitFilteredRecordsFromDataSource();
   }
 
-  @Input() set filterFreetext(value: string) {
-    this.recordsDataSource.filter = value;
-    this.emitFilteredRecordsFromDataSource();
+  private createDataSource() {
+    const dataSource = new MatTableDataSource<TableRow<T>>();
+    dataSource.sortData = (data, sort) =>
+      tableSort<T, keyof T>(data, {
+        active: (sort.active as keyof T) ?? "",
+        direction: sort.direction,
+      });
+    dataSource.filterPredicate = (data, filter) =>
+      entityFilterPredicate(data.record, filter);
+    return dataSource;
   }
 
-  /**
-   * Whether the list's default row coloring should reflect each entity's color.
-   */
-  @Input() showEntityColor: boolean = false;
-
-  /** function returns the background color for each row*/
-  @Input() getBackgroundColor?: (rec: T) => string = (rec: T) => {
-    if (this.showEntityColor) return rec.getColor();
-    else return "";
-  };
-  idForSavingPagination: string;
-
-  /**
-   * The action the system triggers when a user clicks on an entry (row):
-   * - popup: open dialog with simplified form with the given fields only
-   * - navigate: route the app to the details view of the entity
-   * - popup-details: open dialog with the full EntityDetails view
-   * - none: do not trigger any automatic action
-   */
-  @Input() clickMode: "popup" | "navigate" | "popup-details" | "none" = "popup";
-
-  /**
-   * Emits the entity being clicked in the table - or the newly created entity from the "create" button.
-   */
-  @Output() entityClick = new EventEmitter<T>();
-
-  /**
-   * BULK SELECT
-   * User can use checkboxes to select multiple rows, so that parent components can execute bulk actions on them.
-   */
-  @Input() set selectable(v: boolean) {
-    this._selectable = v;
-    this.columnsToDisplay = this._columnsToDisplay;
+  private emitFilteredRecordsFromDataSource() {
+    const rows =
+      this.recordsDataSource.filteredData ?? this.recordsDataSource.data ?? [];
+    this.filteredRecordsChange.emit(rows.map((row) => row.record));
   }
-
-  _selectable: boolean = false;
-
-  readonly ACTIONCOLUMN_SELECT = "__select";
-
-  /**
-   * outputs an event containing an array of currently selected records (checkmarked by the user)
-   * Checkboxes to select rows are only displayed if you set "selectable" also.
-   */
-  @Output() selectedRecordsChange: EventEmitter<T[]> = new EventEmitter<T[]>();
-  @Input() selectedRecords: T[] = [];
 
   selectRow(row: TableRow<T>, checked: boolean) {
     if (checked) {
-      if (!this.selectedRecords.includes(row.record)) {
-        this.selectedRecords = [...this.selectedRecords, row.record];
+      if (!this.selectedRecords().includes(row.record)) {
+        this.selectedRecords.set([...this.selectedRecords(), row.record]);
       }
-    } else if (this.selectedRecords.includes(row.record)) {
-      this.selectedRecords = this.selectedRecords.filter(
-        (r) => r !== row.record,
+    } else if (this.selectedRecords().includes(row.record)) {
+      this.selectedRecords.set(
+        this.selectedRecords().filter((r) => r !== row.record),
       );
     }
-    this.selectedRecordsChange.emit(this.selectedRecords);
   }
 
-  /**
-   * INLINE EDIT
-   * User can switch a row into edit mode to change and save field values directly from within the table
-   */
-  @Input() set editable(v: boolean) {
-    this._editable = v;
-    this.columnsToDisplay = this._columnsToDisplay;
-  }
-
-  _editable: boolean = true;
-  readonly ACTIONCOLUMN_EDIT = "__edit";
-  /**
-   * factory method to create a new instance of the displayed Entity type
-   * used when the user adds a new entity to the list.
-   */
-  @Input() newRecordFactory: () => T;
-
-  /**
-   * Show one record's details in a modal dialog (if configured).
-   * @param row The entity whose details should be displayed.
-   */
   onRowClick(row: TableRow<T>, event: MouseEvent) {
     const targetElement = event.target as HTMLElement;
 
@@ -364,8 +318,8 @@ export class EntitiesTableComponent<
     if (row.formGroup && !row.formGroup.disabled) {
       return;
     }
-    if (this._selectable) {
-      this.selectRow(row, !this.selectedRecords?.includes(row.record));
+    if (this.selectable()) {
+      this.selectRow(row, !this.selectedRecords()?.includes(row.record));
       return;
     }
     this.showEntity(row.record);
@@ -373,7 +327,7 @@ export class EntitiesTableComponent<
   }
 
   onRowMouseDown(event: MouseEvent, row: TableRow<T>) {
-    if (!this._selectable) {
+    if (!this.selectable()) {
       this.onRowClick(row, event);
       return;
     }
@@ -400,23 +354,22 @@ export class EntitiesTableComponent<
       const shouldCheck =
         this.lastSelection !== null
           ? !this.lastSelection
-          : !this.selectedRecords.includes(row.record);
+          : !this.selectedRecords().includes(row.record);
 
+      const updated = [...this.selectedRecords()];
       for (let i = start; i <= end; i++) {
         const rowToSelect = selectedRows[i];
-        const isSelected = this.selectedRecords.includes(rowToSelect.record);
+        const isSelected = updated.includes(rowToSelect.record);
 
         if (shouldCheck && !isSelected) {
-          this.selectedRecords.push(rowToSelect.record);
+          updated.push(rowToSelect.record);
         } else if (!shouldCheck && isSelected) {
-          this.selectedRecords = this.selectedRecords.filter(
-            (record) => record !== rowToSelect.record,
-          );
+          updated.splice(updated.indexOf(rowToSelect.record), 1);
         }
       }
-      this.selectedRecordsChange.emit(this.selectedRecords);
+      this.selectedRecords.set(updated);
     } else {
-      const isSelected = this.selectedRecords.includes(row.record);
+      const isSelected = this.selectedRecords().includes(row.record);
       this.selectRow(row, !isSelected);
       this.lastSelection = isSelected;
     }
@@ -433,25 +386,24 @@ export class EntitiesTableComponent<
 
   selectAllRows(event: MatCheckboxChange) {
     if (event.checked) {
-      this.selectedRecords = this.recordsDataSource.data.map(
-        (row) => row.record,
+      this.selectedRecords.set(
+        this.recordsDataSource.data.map((row) => row.record),
       );
     } else {
-      this.selectedRecords = [];
+      this.selectedRecords.set([]);
     }
-    this.selectedRecordsChange.emit(this.selectedRecords);
   }
 
   isAllSelected() {
-    return this.selectedRecords.length === this.recordsDataSource.data.length;
+    return this.selectedRecords().length === this.recordsDataSource.data.length;
   }
 
   isIndeterminate() {
-    return this.selectedRecords.length > 0 && !this.isAllSelected();
+    return this.selectedRecords().length > 0 && !this.isAllSelected();
   }
 
   showEntity(entity: T) {
-    switch (this.clickMode) {
+    switch (this.clickMode()) {
       case "popup":
         this.formDialog.openFormPopup(entity, this._customColumns);
         break;
@@ -465,28 +417,6 @@ export class EntitiesTableComponent<
         ]);
         break;
     }
-  }
-
-  constructor() {
-    this.recordsDataSource = this.createDataSource();
-  }
-
-  private createDataSource() {
-    const dataSource = new MatTableDataSource<TableRow<T>>();
-    dataSource.sortData = (data, sort) =>
-      tableSort<T, keyof T>(data, {
-        active: (sort.active as keyof T) ?? "",
-        direction: sort.direction,
-      });
-    dataSource.filterPredicate = (data, filter) =>
-      entityFilterPredicate(data.record, filter);
-    return dataSource;
-  }
-
-  private emitFilteredRecordsFromDataSource() {
-    const rows =
-      this.recordsDataSource.filteredData ?? this.recordsDataSource.data ?? [];
-    this.filteredRecordsChange.emit(rows.map((row) => row.record));
   }
 
   private getSelectedRows(): TableRow<T>[] {
@@ -509,10 +439,10 @@ export class EntitiesTableComponent<
     return sortedRows.slice(startIndex, startIndex + paginator.pageSize);
   }
 
-  private inferDefaultSort(): Sort {
+  private inferDefaultSort(colsToDisplay: string[]): Sort {
     // Initial sorting by first sortable user column, ignore internal action columns
     // and columns that explicitly disable sorting.
-    const sortBy = this._columnsToDisplay
+    const sortBy = colsToDisplay
       .filter((columnId) => !columnId.startsWith("__"))
       .find((columnId) => {
         const column = this._columns.find((c) => c.id === columnId);
@@ -551,25 +481,8 @@ export class EntitiesTableComponent<
     }
   }
 
-  /**
-   * FILTER ARCHIVED RECORDS
-   * User can hide / show inactive records through a toggle
-   */
-  @Input() set showInactive(value: boolean) {
-    if (value === this._showInactive) {
-      return;
-    }
-
-    this._showInactive = value;
-    this.updateFilteredData();
-    this.showInactiveChange.emit(value);
-  }
-
-  _showInactive: boolean = false;
-  @Output() showInactiveChange = new EventEmitter<boolean>();
-
   addActiveInactiveFilter(filter: DataFilter<T>) {
-    if (this._showInactive) {
+    if (this.showInactive()) {
       delete filter["isActive"];
     } else {
       filter["isActive"] = true;

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -32,7 +32,7 @@ import {
   MatTableModule,
 } from "@angular/material/table";
 import { Router } from "@angular/router";
-import { UntilDestroy } from "@ngneat/until-destroy";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { DateDatatype } from "../../basic-datatypes/date/date.datatype";
 import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
 import { EntityFieldEditComponent } from "../../entity/entity-field-edit/entity-field-edit.component";
@@ -160,21 +160,26 @@ export class EntitiesTableComponent<
         sort.direction = urlSortOrder || "asc";
       }
       // Listen for sort changes to persist to URL
-      sort.sortChange.subscribe(({ active, direction }) => {
-        if (!direction) {
-          this.tableStateUrl.updateUrlParams({ sortBy: null, sortOrder: null });
-        } else if (direction === "desc") {
-          this.tableStateUrl.updateUrlParams({
-            sortBy: active,
-            sortOrder: "desc",
-          });
-        } else {
-          this.tableStateUrl.updateUrlParams({
-            sortBy: active,
-            sortOrder: null,
-          });
-        }
-      });
+      sort.sortChange
+        .pipe(untilDestroyed(this))
+        .subscribe(({ active, direction }) => {
+          if (!direction) {
+            this.tableStateUrl.updateUrlParams({
+              sortBy: null,
+              sortOrder: null,
+            });
+          } else if (direction === "desc") {
+            this.tableStateUrl.updateUrlParams({
+              sortBy: active,
+              sortOrder: "desc",
+            });
+          } else {
+            this.tableStateUrl.updateUrlParams({
+              sortBy: active,
+              sortOrder: null,
+            });
+          }
+        });
     }
   }
 

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -92,11 +92,18 @@ export class EntitiesTableComponent<
   private readonly tableStateUrl = inject(TableStateUrlService);
 
   records = input<T[]>();
-  customColumns = input<ColumnConfig[]>([]);
+  customColumns = input<ColumnConfig[], ColumnConfig[] | undefined>([], {
+    transform: (value) => value ?? [],
+  });
   columnsToDisplay = input<string[]>();
   entityType = input<EntityConstructor<T>>();
   sortBy = input<Sort>();
-  filter = input<DataFilter<T>>();
+  filter = input<DataFilter<T>, DataFilter<T> | undefined>(
+    {},
+    {
+      transform: (value) => value ?? {},
+    },
+  );
   filterFreetext = input<string>();
   showEntityColor = input<boolean>(false);
   getBackgroundColor = input<(rec: T) => string>();
@@ -118,11 +125,13 @@ export class EntitiesTableComponent<
 
   private lastSelectedRow: TableRow<T> | null = null;
   private lastSelection: boolean = null;
-  _records: T[] = [];
-  _customColumns: FormFieldConfig[] = [];
-  _columns: FormFieldConfig[] = [];
-  _filter: DataFilter<T> = {};
-  idForSavingPagination: string;
+  readonly _customColumns = signal<FormFieldConfig[]>([]);
+  readonly _columns = signal<FormFieldConfig[]>([]);
+  readonly idForSavingPagination = computed(() =>
+    this._customColumns()
+      .map((col) => col.id)
+      .join(""),
+  );
 
   readonly isLoading = signal<boolean>(true);
   readonly _columnsToDisplay = signal<string[]>([]);
@@ -197,11 +206,12 @@ export class EntitiesTableComponent<
       const selectable = this.selectable();
       const editable = this.editable();
 
-      this._customColumns = (rawCustomColumns ?? []).map((c) =>
+      const mappedCustomColumns = rawCustomColumns.map((c) =>
         entityType
           ? this.entityFormService.extendFormFieldConfig(c, entityType)
           : toFormFieldConfig(c),
       );
+      this._customColumns.set(mappedCustomColumns);
 
       const entityColumns = entityType?.schema
         ? [...entityType.schema.entries()].map(
@@ -209,24 +219,21 @@ export class EntitiesTableComponent<
           )
         : [];
 
-      this._columns = [
+      const mergedColumns = [
         ...entityColumns.filter(
           (c) =>
-            !this._customColumns.some((customCol) => customCol.id === c.id),
+            !mappedCustomColumns.some((customCol) => customCol.id === c.id),
         ),
-        ...this._customColumns,
+        ...mappedCustomColumns,
       ];
-      this._columns.forEach((c) =>
+      mergedColumns.forEach((c) =>
         this.disableSortingHeaderForAdvancedFields(c),
       );
-
-      this.idForSavingPagination = this._customColumns
-        .map((col) => col.id)
-        .join("");
+      this._columns.set(mergedColumns);
 
       let colsToDisplay = rawColumnsToDisplay;
       if (!colsToDisplay || colsToDisplay.length === 0) {
-        colsToDisplay = this._customColumns
+        colsToDisplay = mappedCustomColumns
           .filter((c) => !c.hideFromTable)
           .map((c) => c.id);
       }
@@ -248,9 +255,8 @@ export class EntitiesTableComponent<
       const records = this.records();
       this.showInactive(); // track — consumed inside updateFilteredData via addActiveInactiveFilter
       if (records === undefined || records === null) return;
-      this._records = records;
-      this._filter = { ...(this.filter() ?? {}) };
-      this.updateFilteredData();
+      const effectiveFilter = { ...this.filter() };
+      this.updateFilteredData(records, effectiveFilter);
       this.isLoading.set(false);
     });
 
@@ -275,10 +281,10 @@ export class EntitiesTableComponent<
     });
   }
 
-  private updateFilteredData() {
-    this.addActiveInactiveFilter(this._filter);
-    const filterPredicate = this.filterService.getFilterPredicate(this._filter);
-    const filteredData = this._records.filter(filterPredicate);
+  private updateFilteredData(records: T[], filter: DataFilter<T>) {
+    this.addActiveInactiveFilter(filter);
+    const filterPredicate = this.filterService.getFilterPredicate(filter);
+    const filteredData = records.filter(filterPredicate);
     this.recordsDataSource.data = filteredData.map((record) => ({ record }));
     this.emitFilteredRecordsFromDataSource();
   }
@@ -410,7 +416,7 @@ export class EntitiesTableComponent<
   showEntity(entity: T) {
     switch (this.clickMode()) {
       case "popup":
-        this.formDialog.openFormPopup(entity, this._customColumns);
+        this.formDialog.openFormPopup(entity, this._customColumns());
         break;
       case "popup-details":
         this.formDialog.openView(entity, "EntityDetails");
@@ -450,10 +456,10 @@ export class EntitiesTableComponent<
     const sortBy = colsToDisplay
       .filter((columnId) => !columnId.startsWith("__"))
       .find((columnId) => {
-        const column = this._columns.find((c) => c.id === columnId);
+        const column = this._columns().find((c) => c.id === columnId);
         return !column?.noSorting;
       });
-    const sortByColumn = this._columns.find((c) => c.id === sortBy);
+    const sortByColumn = this._columns().find((c) => c.id === sortBy);
 
     let sortDirection: SortDirection = "asc";
     if (

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -244,7 +244,7 @@ export class EntitiesTableComponent<
       this.showInactive(); // track — consumed inside updateFilteredData via addActiveInactiveFilter
       if (records === undefined || records === null) return;
       this._records = records;
-      this._filter = this.filter() ?? {};
+      this._filter = { ...(this.filter() ?? {}) };
       this.updateFilteredData();
       this.isLoading.set(false);
     });

--- a/src/app/core/common-components/entities-table/entities-table.component.ts
+++ b/src/app/core/common-components/entities-table/entities-table.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterContentInit,
+  ChangeDetectionStrategy,
   Component,
   computed,
   ContentChildren,
@@ -11,20 +12,11 @@ import {
   QueryList,
   signal,
   ViewChild,
-  ChangeDetectionStrategy,
 } from "@angular/core";
-import {
-  MatCheckboxChange,
-  MatCheckboxModule,
-} from "@angular/material/checkbox";
+import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
-import {
-  MatSort,
-  MatSortModule,
-  Sort,
-  SortDirection,
-} from "@angular/material/sort";
+import { MatSort, MatSortModule, Sort } from "@angular/material/sort";
 import {
   MatColumnDef,
   MatTable,
@@ -32,16 +24,11 @@ import {
   MatTableModule,
 } from "@angular/material/table";
 import { Router } from "@angular/router";
-import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { DateDatatype } from "../../basic-datatypes/date/date.datatype";
-import { DefaultDatatype } from "../../entity/default-datatype/default.datatype";
-import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
 import { EntityFieldEditComponent } from "../../entity/entity-field-edit/entity-field-edit.component";
 import { EntityFieldLabelComponent } from "../../entity/entity-field-label/entity-field-label.component";
 import { EntityFieldViewComponent } from "../../entity/entity-field-view/entity-field-view.component";
-import { Entity, EntityConstructor } from "../../entity/model/entity";
-import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { getEntityRuntimeRoute } from "../../entity/entity-config.service";
+import { Entity, EntityConstructor } from "../../entity/model/entity";
 import { entityFilterPredicate } from "../../filter/filter-generator/filter-predicate";
 import { FilterService } from "../../filter/filter.service";
 import { DataFilter } from "../../filter/filters/filters";
@@ -57,15 +44,19 @@ import { EntityInlineEditActionsComponent } from "./entity-inline-edit-actions/e
 import { ListPaginatorComponent } from "./list-paginator/list-paginator.component";
 import { TableRow } from "./table-row";
 import { tableSort } from "./table-sort/table-sort";
-import { TableStateUrlService } from "./table-state-url.service";
+import {
+  EntitiesTableSelectionStore,
+  shouldSkipRowInteraction,
+} from "./entities-table-selection";
+import { EntitiesTableSortStore } from "./entities-table-sort.store";
 
 /**
- * A simple display component (no logic and transformations) to display a table of entities.
+ * A reusable table component for displaying, sorting, filtering, and selecting entities.
  */
-@UntilDestroy()
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "app-entities-table",
+  providers: [EntitiesTableSortStore, EntitiesTableSelectionStore],
   imports: [
     EntityFieldEditComponent,
     EntityFieldLabelComponent,
@@ -85,13 +76,18 @@ import { TableStateUrlService } from "./table-state-url.service";
 export class EntitiesTableComponent<
   T extends Entity,
 > implements AfterContentInit {
-  private entityFormService = inject(EntityFormService);
-  private formDialog = inject(FormDialogService);
-  private router = inject(Router);
-  private filterService = inject(FilterService);
-  private schemaService = inject(EntitySchemaService);
-  private readonly tableStateUrl = inject(TableStateUrlService);
+  private readonly formDialog = inject(FormDialogService);
+  private readonly router = inject(Router);
+  private readonly filterService = inject(FilterService);
+  private readonly entityFormService = inject(EntityFormService);
+  protected readonly sortStore = inject(
+    EntitiesTableSortStore,
+  ) as EntitiesTableSortStore<T>;
+  protected readonly selectionStore = inject(
+    EntitiesTableSelectionStore,
+  ) as EntitiesTableSelectionStore<T>;
 
+  // --- Inputs ---
   records = input<T[]>();
   customColumns = input<ColumnConfig[], ColumnConfig[] | undefined>([], {
     transform: (value) => value ?? [],
@@ -113,250 +109,166 @@ export class EntitiesTableComponent<
   editable = input<boolean>(true);
   selectable = input<boolean>(false);
 
+  // --- Outputs & Models ---
   filteredRecordsChange = output<T[]>();
   entityClick = output<T>();
   selectedRecords = model<T[]>([]);
   showInactive = model<boolean>(false);
 
+  // --- Internal constants ---
+  readonly ACTIONCOLUMN_SELECT = "__select";
+  readonly ACTIONCOLUMN_EDIT = "__edit";
+
+  // --- Column state ---
+  readonly _customColumns = computed<FormFieldConfig[]>(() =>
+    this.customColumns().map((column) => {
+      const entityType = this.entityType();
+      return entityType
+        ? this.entityFormService.extendFormFieldConfig(column, entityType)
+        : toFormFieldConfig(column);
+    }),
+  );
+  readonly _columnsToDisplay = computed<string[]>(() => {
+    let colsToDisplay = this.columnsToDisplay();
+    if (!colsToDisplay || colsToDisplay.length === 0) {
+      colsToDisplay = this._customColumns()
+        .filter((column) => !column.hideFromTable)
+        .map((column) => column.id);
+    }
+    const columns = colsToDisplay.filter((col) => !col.startsWith("__"));
+    if (this.selectable()) {
+      columns.unshift(this.ACTIONCOLUMN_SELECT);
+    }
+    if (this.editable()) {
+      columns.splice(this.selectable() ? 1 : 0, 0, this.ACTIONCOLUMN_EDIT);
+    }
+    return columns;
+  });
+  /** Columns with sorting rules applied (managed by the sort store). */
+  readonly _columns = this.sortStore.columns;
+  readonly idForSavingPagination = computed(() =>
+    this._customColumns()
+      .map((column) => column.id)
+      .join(""),
+  );
+
+  // --- Filtering (stateless derivation) ---
+  readonly effectiveFilter = computed<DataFilter<T>>(() => {
+    const nextFilter = { ...this.filter() };
+    if (this.showInactive()) {
+      delete nextFilter["isActive"];
+    } else {
+      nextFilter["isActive"] = true;
+    }
+    return nextFilter;
+  });
+
+  readonly filteredRecords = computed<T[]>(() => {
+    const records = this.records() ?? [];
+    const predicate = this.filterService.getFilterPredicate(
+      this.effectiveFilter(),
+    );
+    const domainFiltered = records.filter(predicate);
+
+    const freetext = this.filterFreetext() ?? "";
+    if (!freetext) {
+      return domainFiltered;
+    }
+    return domainFiltered.filter((record) =>
+      entityFilterPredicate(record, freetext),
+    );
+  });
+
+  // --- Background color ---
   readonly effectiveBackgroundColor = computed<(rec: T) => string>(() => {
     const custom = this.getBackgroundColor();
     const useEntityColor = this.showEntityColor();
     return custom ?? ((rec: T) => (useEntityColor ? rec.getColor() : ""));
   });
 
-  private lastSelectedRow: TableRow<T> | null = null;
-  private lastSelection: boolean = null;
-  readonly _customColumns = signal<FormFieldConfig[]>([]);
-  readonly _columns = signal<FormFieldConfig[]>([]);
-  readonly idForSavingPagination = computed(() =>
-    this._customColumns()
-      .map((col) => col.id)
-      .join(""),
-  );
+  // --- Loading state ---
+  readonly isLoading = signal(true);
 
-  readonly isLoading = signal<boolean>(true);
-  readonly _columnsToDisplay = signal<string[]>([]);
-  readonly _sortBy = signal<Sort>(undefined);
-
-  /** data displayed in the template's table */
-  recordsDataSource: MatTableDataSource<TableRow<T>>;
+  // --- Material DataSource (for paginator interop) ---
+  readonly recordsDataSource = this.createDataSource();
 
   @ViewChild(MatTable, { static: true }) table: MatTable<T>;
   @ContentChildren(MatColumnDef) projectedColumns: QueryList<MatColumnDef>;
 
+  @ViewChild(MatSort, { static: false }) set sort(sort: MatSort) {
+    this.sortStore.attachSort(sort);
+    if (sort) {
+      this.recordsDataSource.sort = sort;
+    }
+  }
+
+  constructor() {
+    // Connect sort store
+    this.sortStore.connect({
+      columnsToDisplay: this._columnsToDisplay,
+      columns: computed(() => {
+        const mappedCustomColumns = this._customColumns();
+        const entityType = this.entityType();
+        const entityColumns = entityType?.schema
+          ? [...entityType.schema.entries()].map(
+              ([id, field]) => ({ ...field, id }) as FormFieldConfig,
+            )
+          : [];
+        return [
+          ...entityColumns.filter(
+            (col) =>
+              !mappedCustomColumns.some((custom) => custom.id === col.id),
+          ),
+          ...mappedCustomColumns,
+        ];
+      }),
+      externalSort: this.sortBy,
+      filteredRecords: this.filteredRecords,
+    });
+
+    // Connect selection store
+    this.selectionStore.connect({
+      selectedRecords: this.selectedRecords,
+      sortedRows: this.sortStore.sortedRows,
+      getCurrentPageRows: () => this.getCurrentPageRows(),
+    });
+
+    // Sync sorted rows to Material DataSource
+    effect(() => {
+      this.recordsDataSource.data = this.sortStore.sortedRows();
+    });
+
+    // Track loading state
+    effect(() => {
+      const records = this.records();
+      if (records !== undefined && records !== null) {
+        this.isLoading.set(false);
+      }
+    });
+
+    // Emit filtered records changes
+    effect(() => {
+      this.filteredRecordsChange.emit(
+        this.sortStore.sortedRows().map((row) => row.record),
+      );
+    });
+  }
+
   ngAfterContentInit() {
-    // dynamically add columns from content-projection (https://stackoverflow.com/a/58017564/1473411)
     this.projectedColumns.forEach((columnDef) =>
       this.table.addColumnDef(columnDef),
     );
   }
 
-  /**
-   * Indicates whether the current sort order was manually set by the user
-   * to avoid overwriting it with the default sort
-   */
-  private sortManuallySet: boolean;
-
-  @ViewChild(MatSort, { static: false }) set sort(sort: MatSort) {
-    this.recordsDataSource.sort = sort;
-    if (sort) {
-      // Restore sort state from URL on init
-      const urlSortBy = this.tableStateUrl.getUrlParam("sortBy");
-      const urlSortOrder = this.tableStateUrl.getUrlParam(
-        "sortOrder",
-      ) as SortDirection;
-      if (urlSortBy) {
-        sort.active = urlSortBy;
-        sort.direction = urlSortOrder || "asc";
-      }
-      // Listen for sort changes to persist to URL
-      sort.sortChange
-        .pipe(untilDestroyed(this))
-        .subscribe(({ active, direction }) => {
-          if (!direction) {
-            this.tableStateUrl.updateUrlParams({
-              sortBy: null,
-              sortOrder: null,
-            });
-          } else if (direction === "desc") {
-            this.tableStateUrl.updateUrlParams({
-              sortBy: active,
-              sortOrder: "desc",
-            });
-          } else {
-            this.tableStateUrl.updateUrlParams({
-              sortBy: active,
-              sortOrder: null,
-            });
-          }
-        });
-    }
-  }
-
-  readonly ACTIONCOLUMN_SELECT = "__select";
-  readonly ACTIONCOLUMN_EDIT = "__edit";
-
-  constructor() {
-    this.recordsDataSource = this.createDataSource();
-
-    // Column computation effect: recomputes column state when entity type, columns config, or display settings change
-    effect(() => {
-      const entityType = this.entityType();
-      const rawCustomColumns = this.customColumns();
-      const rawColumnsToDisplay = this.columnsToDisplay();
-      const selectable = this.selectable();
-      const editable = this.editable();
-
-      const mappedCustomColumns = rawCustomColumns.map((c) =>
-        entityType
-          ? this.entityFormService.extendFormFieldConfig(c, entityType)
-          : toFormFieldConfig(c),
-      );
-      this._customColumns.set(mappedCustomColumns);
-
-      const entityColumns = entityType?.schema
-        ? [...entityType.schema.entries()].map(
-            ([id, field]) => ({ ...field, id }) as FormFieldConfig,
-          )
-        : [];
-
-      const mergedColumns = [
-        ...entityColumns.filter(
-          (c) =>
-            !mappedCustomColumns.some((customCol) => customCol.id === c.id),
-        ),
-        ...mappedCustomColumns,
-      ];
-      mergedColumns.forEach((c) =>
-        this.disableSortingHeaderForAdvancedFields(c),
-      );
-      this._columns.set(mergedColumns);
-
-      let colsToDisplay = rawColumnsToDisplay;
-      if (!colsToDisplay || colsToDisplay.length === 0) {
-        colsToDisplay = mappedCustomColumns
-          .filter((c) => !c.hideFromTable)
-          .map((c) => c.id);
-      }
-      colsToDisplay = colsToDisplay.filter((c) => !c.startsWith("__"));
-
-      const cols: string[] = [];
-      if (selectable) cols.push(this.ACTIONCOLUMN_SELECT);
-      if (editable) cols.push(this.ACTIONCOLUMN_EDIT);
-      cols.push(...colsToDisplay);
-      this._columnsToDisplay.set(cols);
-
-      if (!this.sortManuallySet && !this.tableStateUrl.getUrlParam("sortBy")) {
-        this._sortBy.set(this.inferDefaultSort(cols));
-      }
-    });
-
-    // Data filter effect: re-filters records when data, filter, or showInactive changes
-    effect(() => {
-      const records = this.records();
-      this.showInactive(); // track — consumed inside updateFilteredData via addActiveInactiveFilter
-      if (records === undefined || records === null) return;
-      const effectiveFilter = { ...this.filter() };
-      this.updateFilteredData(records, effectiveFilter);
-      this.isLoading.set(false);
-    });
-
-    // Sort input effect: applies external sort input
-    effect(() => {
-      const sortBy = this.sortBy();
-      if (!sortBy) return;
-      this._sortBy.set(sortBy);
-      if (sortBy.active) {
-        this.tableStateUrl.updateUrlParams({
-          sortBy: sortBy.active,
-          sortOrder: sortBy.direction ?? "asc",
-        });
-      }
-      this.sortManuallySet = true;
-    });
-
-    // Freetext filter effect
-    effect(() => {
-      this.recordsDataSource.filter = this.filterFreetext() ?? "";
-      this.emitFilteredRecordsFromDataSource();
-    });
-  }
-
-  private updateFilteredData(records: T[], filter: DataFilter<T>) {
-    this.addActiveInactiveFilter(filter);
-    const filterPredicate = this.filterService.getFilterPredicate(filter);
-    const filteredData = records.filter(filterPredicate);
-    this.recordsDataSource.data = filteredData.map((record) => ({ record }));
-    this.emitFilteredRecordsFromDataSource();
-  }
-
-  private createDataSource() {
-    const dataSource = new MatTableDataSource<TableRow<T>>();
-    dataSource.sortData = (data, sort) =>
-      tableSort<T, keyof T>(data, {
-        active: (sort.active as keyof T) ?? "",
-        direction: sort.direction,
-        sortValueFns: this.buildSortValueFns(),
-      });
-    dataSource.filterPredicate = (data, filter) =>
-      entityFilterPredicate(data.record, filter);
-    return dataSource;
-  }
-
-  /**
-   * Builds a map of column id → sort value extractor.
-   * Every datatype participates through {@link DefaultDatatype.sortValue};
-   * datatypes that don't override it return `undefined` and fall back to
-   * default sorting behavior in {@link tableSort}.
-   */
-  private buildSortValueFns(): Record<
-    string,
-    (v: any) => number | string | undefined
-  > {
-    const sortValueByColumnId: Record<
-      string,
-      (v: any) => number | string | undefined
-    > = {};
-    for (const col of this._columns()) {
-      const datatype = this.schemaService.getDatatypeOrDefault(
-        col.dataType,
-        true,
-      );
-      sortValueByColumnId[col.id] = (v) => datatype.sortValue(v);
-    }
-    return sortValueByColumnId;
-  }
-
-  private emitFilteredRecordsFromDataSource() {
-    const rows =
-      this.recordsDataSource.filteredData ?? this.recordsDataSource.data ?? [];
-    this.filteredRecordsChange.emit(rows.map((row) => row.record));
-  }
-
-  selectRow(row: TableRow<T>, checked: boolean) {
-    if (checked) {
-      if (!this.selectedRecords().includes(row.record)) {
-        this.selectedRecords.set([...this.selectedRecords(), row.record]);
-      }
-    } else if (this.selectedRecords().includes(row.record)) {
-      this.selectedRecords.set(
-        this.selectedRecords().filter((r) => r !== row.record),
-      );
-    }
-  }
-
   onRowClick(row: TableRow<T>, event: MouseEvent) {
-    const targetElement = event.target as HTMLElement;
-
-    // Check if the clicked element has the 'clickable' class
-    if (targetElement && targetElement.closest(".clickable")) {
-      return;
-    }
-    if (row.formGroup && !row.formGroup.disabled) {
+    if (shouldSkipRowInteraction(event.target, row)) {
       return;
     }
     if (this.selectable()) {
-      this.selectRow(row, !this.selectedRecords()?.includes(row.record));
+      this.selectionStore.selectRow(
+        row,
+        !this.selectedRecords()?.includes(row.record),
+      );
       return;
     }
     this.showEntity(row.record);
@@ -369,74 +281,9 @@ export class EntitiesTableComponent<
       return;
     }
 
-    const selectedRows = this.getSelectedRows();
-    const currentIndex = selectedRows.indexOf(row);
-    const anchorIndex = this.lastSelectedRow
-      ? selectedRows.indexOf(this.lastSelectedRow)
-      : -1;
-
-    const isCheckboxClick =
-      event.target instanceof HTMLInputElement &&
-      event.target.type === "checkbox";
-
-    const canRangeSelect =
-      event.shiftKey &&
-      this.lastSelectedRow &&
-      anchorIndex !== -1 &&
-      currentIndex !== -1;
-
-    if (canRangeSelect) {
-      const start = Math.min(anchorIndex, currentIndex);
-      const end = Math.max(anchorIndex, currentIndex);
-      const shouldCheck =
-        this.lastSelection !== null
-          ? !this.lastSelection
-          : !this.selectedRecords().includes(row.record);
-
-      const updated = [...this.selectedRecords()];
-      for (let i = start; i <= end; i++) {
-        const rowToSelect = selectedRows[i];
-        const isSelected = updated.includes(rowToSelect.record);
-
-        if (shouldCheck && !isSelected) {
-          updated.push(rowToSelect.record);
-        } else if (!shouldCheck && isSelected) {
-          updated.splice(updated.indexOf(rowToSelect.record), 1);
-        }
-      }
-      this.selectedRecords.set(updated);
-    } else {
-      const isSelected = this.selectedRecords().includes(row.record);
-      this.selectRow(row, !isSelected);
-      this.lastSelection = isSelected;
-    }
-    this.lastSelectedRow = currentIndex !== -1 ? row : null;
-
-    if (isCheckboxClick) {
+    if (this.selectionStore.handleSelectableRowMouseDown(event, row)) {
       this.onRowClick(row, event);
     }
-  }
-
-  onRowSelect(event: MatCheckboxChange, row: TableRow<T>) {
-    this.selectRow(row, event.checked);
-  }
-
-  selectAllRows(event: MatCheckboxChange) {
-    if (event.checked) {
-      this.selectedRecords.set(
-        this.recordsDataSource.data.map((row) => row.record),
-      );
-    } else {
-      this.selectedRecords.set([]);
-    }
-  }
-
-  isAllSelected() {
-    return this.selectedRecords().length === this.recordsDataSource.data.length;
-  }
-
-  isIndeterminate() {
-    return this.selectedRecords().length > 0 && !this.isAllSelected();
   }
 
   showEntity(entity: T) {
@@ -456,82 +303,27 @@ export class EntitiesTableComponent<
     }
   }
 
-  private getSelectedRows(): TableRow<T>[] {
-    const dataSource = this.recordsDataSource;
-    const filteredRows = dataSource.filteredData ?? dataSource.data ?? [];
-    const workingRows = [...filteredRows];
-
-    const sorter = dataSource.sort;
-    const sortedRows =
-      sorter && sorter.active
-        ? dataSource.sortData(workingRows, sorter)
-        : workingRows;
-
-    const paginator = dataSource.paginator;
+  getCurrentPageRows(): TableRow<T>[] {
+    const rows = this.sortStore.sortedRows();
+    const paginator = this.recordsDataSource.paginator;
     if (!paginator) {
-      return sortedRows;
+      return rows;
     }
 
     const startIndex = paginator.pageIndex * paginator.pageSize;
-    return sortedRows.slice(startIndex, startIndex + paginator.pageSize);
+    return rows.slice(startIndex, startIndex + paginator.pageSize);
   }
 
-  private inferDefaultSort(colsToDisplay: string[]): Sort {
-    // Initial sorting by first sortable user column, ignore internal action columns
-    // and columns that explicitly disable sorting.
-    const sortBy = colsToDisplay
-      .filter((columnId) => !columnId.startsWith("__"))
-      .find((columnId) => {
-        const column = this._columns().find((c) => c.id === columnId);
-        return !column?.noSorting;
+  private createDataSource() {
+    const dataSource = new MatTableDataSource<TableRow<T>>();
+    dataSource.sortData = (data, sort) =>
+      tableSort<T, keyof T>(data, {
+        active: (sort.active as keyof T) ?? "",
+        direction: sort.direction,
+        sortValueFns: this.sortStore.sortValueFns(),
       });
-    const sortByColumn = this._columns().find((c) => c.id === sortBy);
-
-    let sortDirection: SortDirection = "asc";
-    if (
-      sortByColumn?.viewComponent === "DisplayDate" ||
-      sortByColumn?.viewComponent === "DisplayMonth" ||
-      this.schemaService.getDatatypeOrDefault(sortByColumn?.dataType) instanceof
-        DateDatatype
-    ) {
-      // flip default sort order for dates (latest first)
-      sortDirection = "desc";
-    }
-
-    return sortBy ? { active: sortBy, direction: sortDirection } : undefined;
-  }
-
-  /**
-   * Advanced fields like entity references cannot be sorted sensibly yet - disable sort for them.
-   * @param c
-   * @private
-   */
-  private disableSortingHeaderForAdvancedFields(c: FormFieldConfig) {
-    if (c.viewComponent === "DisplayAge") {
-      // we have implemented support for age specifically
-      return;
-    }
-
-    const datatype = this.schemaService.getDatatypeOrDefault(c.dataType, true);
-    if (
-      c.isArray &&
-      datatype?.sortValue !== DefaultDatatype.prototype.sortValue
-    ) {
-      // datatype provides custom sort logic, keep sorting enabled
-      return;
-    }
-
-    // if no dataType is defined, these are dynamic, display-only components
-    if (c.isArray || c.dataType === EntityDatatype.dataType || !c.dataType) {
-      c.noSorting = true;
-    }
-  }
-
-  addActiveInactiveFilter(filter: DataFilter<T>) {
-    if (this.showInactive()) {
-      delete filter["isActive"];
-    } else {
-      filter["isActive"] = true;
-    }
+    dataSource.filterPredicate = (data, filter) =>
+      entityFilterPredicate(data.record, filter);
+    return dataSource;
   }
 }

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.html
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.html
@@ -1,6 +1,6 @@
 <mat-paginator
   (page)="onPaginateChange($event)"
-  [pageSize]="pageSize"
+  [pageSize]="pageSize()"
   [pageSizeOptions]="pageSizeOptions"
   [showFirstLastButtons]="true"
 ></mat-paginator>

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
@@ -55,4 +55,13 @@ describe("ListPaginatorComponent", () => {
     expect(component.pageSize).toBe(12);
     expect(component.paginator.pageSize).toBe(12);
   });
+
+  it("should bind paginator to a replaced dataSource instance", () => {
+    const newDataSource = new MatTableDataSource<any>();
+
+    fixture.componentRef.setInput("dataSource", newDataSource);
+    fixture.detectChanges();
+
+    expect(newDataSource.paginator).toBe(component.paginator);
+  });
 });

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
@@ -18,7 +18,7 @@ describe("ListPaginatorComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ListPaginatorComponent);
     component = fixture.componentInstance;
-    component.dataSource = new MatTableDataSource<any>();
+    fixture.componentRef.setInput("dataSource", new MatTableDataSource<any>());
     fixture.detectChanges();
   });
 
@@ -29,7 +29,8 @@ describe("ListPaginatorComponent", () => {
   });
 
   it("should save pagination settings in the local storage", () => {
-    component.idForSavingPagination = "table-id";
+    fixture.componentRef.setInput("idForSavingPagination", "table-id");
+    fixture.detectChanges();
 
     component.onPaginateChange({ pageSize: 20, pageIndex: 1 } as PageEvent);
 

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.spec.ts
@@ -46,13 +46,13 @@ describe("ListPaginatorComponent", () => {
     fixture.componentRef.setInput("idForSavingPagination", "c1");
     fixture.detectChanges();
 
-    expect(component.pageSize).toBe(11);
+    expect(component.pageSize()).toBe(11);
     expect(component.paginator.pageSize).toBe(11);
 
     fixture.componentRef.setInput("idForSavingPagination", "c2");
     fixture.detectChanges();
 
-    expect(component.pageSize).toBe(12);
+    expect(component.pageSize()).toBe(12);
     expect(component.paginator.pageSize).toBe(12);
   });
 

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
@@ -1,10 +1,10 @@
 import {
   Component,
-  OnInit,
   ViewChild,
   ChangeDetectionStrategy,
   effect,
   input,
+  signal,
 } from "@angular/core";
 import {
   MatPaginator,
@@ -20,16 +20,22 @@ import { MatTableDataSource } from "@angular/material/table";
   styleUrls: ["./list-paginator.component.scss"],
   imports: [MatPaginatorModule],
 })
-export class ListPaginatorComponent<E> implements OnInit {
+export class ListPaginatorComponent<E> {
   readonly LOCAL_STORAGE_KEY = "PAGINATION-";
   readonly pageSizeOptions = [10, 20, 50, 100];
 
   dataSource = input<MatTableDataSource<E>>();
   idForSavingPagination = input<string>();
 
-  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+  private readonly paginatorReady = signal(false);
+  @ViewChild(MatPaginator, { static: true })
+  set paginatorRef(paginator: MatPaginator) {
+    this.paginator = paginator;
+    this.paginatorReady.set(!!paginator);
+  }
+  paginator: MatPaginator;
 
-  pageSize = 10;
+  readonly pageSize = signal(10);
 
   constructor() {
     effect(() => {
@@ -39,24 +45,21 @@ export class ListPaginatorComponent<E> implements OnInit {
     });
 
     effect(() => {
-      if (this.paginator) {
-        this.bindPaginator(this.dataSource());
-      }
+      this.paginatorReady();
+      this.bindPaginator(this.dataSource());
     });
   }
 
-  ngOnInit() {
-    this.bindPaginator(this.dataSource());
-  }
-
   onPaginateChange(event: PageEvent) {
-    this.pageSize = event.pageSize;
-    this.savePageSize(this.pageSize);
+    this.pageSize.set(event.pageSize);
+    this.savePageSize(this.pageSize());
   }
 
   private applyUserPaginationSettings() {
     const savedSize = this.getSavedPageSize();
-    this.pageSize = savedSize && savedSize !== -1 ? savedSize : this.pageSize;
+    this.pageSize.set(
+      savedSize && savedSize !== -1 ? savedSize : this.pageSize(),
+    );
   }
 
   private getSavedPageSize(): number {

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
@@ -37,10 +37,16 @@ export class ListPaginatorComponent<E> implements OnInit {
         this.applyUserPaginationSettings();
       }
     });
+
+    effect(() => {
+      if (this.paginator) {
+        this.bindPaginator(this.dataSource());
+      }
+    });
   }
 
   ngOnInit() {
-    this.dataSource().paginator = this.paginator;
+    this.bindPaginator(this.dataSource());
   }
 
   onPaginateChange(event: PageEvent) {
@@ -66,5 +72,10 @@ export class ListPaginatorComponent<E> implements OnInit {
       this.LOCAL_STORAGE_KEY + this.idForSavingPagination(),
       size?.toString(),
     );
+  }
+
+  private bindPaginator(dataSource: MatTableDataSource<E> | undefined) {
+    if (!dataSource || !this.paginator) return;
+    dataSource.paginator = this.paginator;
   }
 }

--- a/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
+++ b/src/app/core/common-components/entities-table/list-paginator/list-paginator.component.ts
@@ -1,11 +1,10 @@
 import {
   Component,
-  Input,
-  OnChanges,
   OnInit,
-  SimpleChanges,
   ViewChild,
   ChangeDetectionStrategy,
+  effect,
+  input,
 } from "@angular/core";
 import {
   MatPaginator,
@@ -21,25 +20,27 @@ import { MatTableDataSource } from "@angular/material/table";
   styleUrls: ["./list-paginator.component.scss"],
   imports: [MatPaginatorModule],
 })
-export class ListPaginatorComponent<E> implements OnChanges, OnInit {
+export class ListPaginatorComponent<E> implements OnInit {
   readonly LOCAL_STORAGE_KEY = "PAGINATION-";
   readonly pageSizeOptions = [10, 20, 50, 100];
 
-  @Input() dataSource: MatTableDataSource<E>;
-  @Input() idForSavingPagination: string;
+  dataSource = input<MatTableDataSource<E>>();
+  idForSavingPagination = input<string>();
 
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   pageSize = 10;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.hasOwnProperty("idForSavingPagination")) {
-      this.applyUserPaginationSettings();
-    }
+  constructor() {
+    effect(() => {
+      if (this.idForSavingPagination() !== undefined) {
+        this.applyUserPaginationSettings();
+      }
+    });
   }
 
   ngOnInit() {
-    this.dataSource.paginator = this.paginator;
+    this.dataSource().paginator = this.paginator;
   }
 
   onPaginateChange(event: PageEvent) {
@@ -54,13 +55,15 @@ export class ListPaginatorComponent<E> implements OnChanges, OnInit {
 
   private getSavedPageSize(): number {
     return Number.parseInt(
-      localStorage.getItem(this.LOCAL_STORAGE_KEY + this.idForSavingPagination),
+      localStorage.getItem(
+        this.LOCAL_STORAGE_KEY + this.idForSavingPagination(),
+      ),
     );
   }
 
   private savePageSize(size: number) {
     localStorage.setItem(
-      this.LOCAL_STORAGE_KEY + this.idForSavingPagination,
+      this.LOCAL_STORAGE_KEY + this.idForSavingPagination(),
       size?.toString(),
     );
   }

--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.html
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.html
@@ -1,8 +1,8 @@
 <mat-form-field>
   <app-entity-field-select
-    [entityType]="entityType"
+    [entityType]="entityType()"
     [formControl]="selectedFieldsControl"
-    [options]="_availableFields"
+    [options]="_availableFields()"
     [multi]="true"
   />
 </mat-form-field>

--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.spec.ts
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.spec.ts
@@ -31,7 +31,7 @@ describe("EntityFieldsMenuComponent", () => {
   });
 
   it("should let a custom field override a default field", () => {
-    component.availableFields = [
+    fixture.componentRef.setInput("availableFields", [
       "name",
       {
         id: "name",
@@ -41,13 +41,15 @@ describe("EntityFieldsMenuComponent", () => {
         id: "age",
         label: "Age",
       },
-    ];
-    expect(component._availableFields.length).toBe(2);
+    ]);
+    fixture.detectChanges();
 
-    const name = component._availableFields.find((f) => f.id === "name");
+    expect(component._availableFields().length).toBe(2);
+
+    const name = component._availableFields().find((f) => f.id === "name");
     expect(name.label).toBe("Custom Name");
 
-    const age = component._availableFields.find((f) => f.id === "age");
+    const age = component._availableFields().find((f) => f.id === "age");
     expect(age.label).toBe("Age");
   });
 });

--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
@@ -1,13 +1,15 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   input,
   OnInit,
   output,
-  ChangeDetectionStrategy,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { EntityConstructor } from "../../entity/model/entity";
 import {
   ColumnConfig,
@@ -32,6 +34,7 @@ import { EntityFieldSelectComponent } from "app/core/entity/entity-field-select/
 })
 export class EntityFieldsMenuComponent implements OnInit {
   private entityFormService = inject(EntityFormService, { optional: true });
+  private readonly destroyRef = inject(DestroyRef);
 
   entityType = input<EntityConstructor>();
   availableFields = input<ColumnConfig[]>([]);
@@ -86,18 +89,22 @@ export class EntityFieldsMenuComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.selectedFieldsControl.valueChanges.subscribe((value: string[]) => {
-      const mappedFields: ColumnConfig[] = value.map((v) => {
-        const availableField = this._availableFields().find((f) => f.id === v);
+    this.selectedFieldsControl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: string[]) => {
+        const mappedFields: ColumnConfig[] = value.map((v) => {
+          const availableField = this._availableFields().find(
+            (f) => f.id === v,
+          );
 
-        if (availableField?.["_customField"]) {
-          const result = { ...availableField };
-          delete result["_customField"];
-          return result;
-        } else return v;
+          if (availableField?.["_customField"]) {
+            const result = { ...availableField };
+            delete result["_customField"];
+            return result;
+          } else return v;
+        });
+
+        this.activeFieldsChange.emit(mappedFields);
       });
-
-      this.activeFieldsChange.emit(mappedFields);
-    });
   }
 }

--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
@@ -67,12 +67,21 @@ export class EntityFieldsMenuComponent implements OnInit {
 
   constructor() {
     effect(() => {
-      const selectedFields = this.activeFields()?.map((field) =>
+      const selectedFields = (this.activeFields() ?? []).map((field) =>
         typeof field === "string" ? field : field.id,
       );
-      this.selectedFieldsControl.setValue(selectedFields, {
-        emitEvent: false,
-      });
+      const currentSelection = this.selectedFieldsControl.value ?? [];
+
+      if (
+        currentSelection.length === selectedFields.length &&
+        currentSelection.every(
+          (value, index) => value === selectedFields[index],
+        )
+      ) {
+        return;
+      }
+
+      this.selectedFieldsControl.setValue(selectedFields, { emitEvent: false });
     });
   }
 

--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
@@ -1,12 +1,11 @@
 import {
   Component,
-  EventEmitter,
+  computed,
+  effect,
   inject,
-  Input,
-  OnChanges,
+  input,
   OnInit,
-  Output,
-  SimpleChanges,
+  output,
   ChangeDetectionStrategy,
 } from "@angular/core";
 import { EntityConstructor } from "../../entity/model/entity";
@@ -31,19 +30,22 @@ import { EntityFieldSelectComponent } from "app/core/entity/entity-field-select/
   templateUrl: "./entity-fields-menu.component.html",
   styleUrl: "./entity-fields-menu.component.scss",
 })
-export class EntityFieldsMenuComponent implements OnChanges, OnInit {
+export class EntityFieldsMenuComponent implements OnInit {
   private entityFormService = inject(EntityFormService, { optional: true });
 
-  @Input() entityType: EntityConstructor;
-  @Input() set availableFields(value: ColumnConfig[]) {
-    const fieldsConfig: FormFieldConfig[] = value
+  entityType = input<EntityConstructor>();
+  availableFields = input<ColumnConfig[]>([]);
+  activeFields = input<ColumnConfig[]>([]);
+  activeFieldsChange = output<ColumnConfig[]>();
+  selectedFieldsControl = new FormControl<string[]>([]);
+
+  readonly _availableFields = computed<FormFieldConfig[]>(() => {
+    const entityType = this.entityType();
+    const fieldsConfig: FormFieldConfig[] = this.availableFields()
       .map((field) => {
         const mappedField =
-          this.entityFormService && this.entityType
-            ? this.entityFormService.extendFormFieldConfig(
-                field,
-                this.entityType,
-              )
+          this.entityFormService && entityType
+            ? this.entityFormService.extendFormFieldConfig(field, entityType)
             : toFormFieldConfig(field);
 
         if (typeof field === "object") {
@@ -60,18 +62,24 @@ export class EntityFieldsMenuComponent implements OnChanges, OnInit {
         deduplicatedFieldsById[field.id] = field;
       }
     }
-    this._availableFields = Object.values(deduplicatedFieldsById);
-  }
-  _availableFields: FormFieldConfig[] = [];
+    return Object.values(deduplicatedFieldsById);
+  });
 
-  @Input() activeFields: ColumnConfig[] = [];
-  @Output() activeFieldsChange = new EventEmitter<ColumnConfig[]>();
-  selectedFieldsControl = new FormControl<string[]>([]);
+  constructor() {
+    effect(() => {
+      const selectedFields = this.activeFields()?.map((field) =>
+        typeof field === "string" ? field : field.id,
+      );
+      this.selectedFieldsControl.setValue(selectedFields, {
+        emitEvent: false,
+      });
+    });
+  }
 
   ngOnInit() {
     this.selectedFieldsControl.valueChanges.subscribe((value: string[]) => {
       const mappedFields: ColumnConfig[] = value.map((v) => {
-        const availableField = this._availableFields.find((f) => f.id === v);
+        const availableField = this._availableFields().find((f) => f.id === v);
 
         if (availableField?.["_customField"]) {
           const result = { ...availableField };
@@ -82,16 +90,5 @@ export class EntityFieldsMenuComponent implements OnChanges, OnInit {
 
       this.activeFieldsChange.emit(mappedFields);
     });
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.activeFields) {
-      const selectedFields = this.activeFields?.map((field) =>
-        typeof field === "string" ? field : field.id,
-      );
-      this.selectedFieldsControl.setValue(selectedFields, {
-        emitEvent: false,
-      });
-    }
   }
 }

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
@@ -1,15 +1,15 @@
-<form [class.grid-layout]="gridLayout">
-  @for (group of fieldGroups; track $index) {
+<form [class.grid-layout]="gridLayout()">
+  @for (group of filteredFieldGroups(); track $index) {
     <div class="entity-form-cell">
       @if (group.header) {
         <h2>{{ group.header }}</h2>
       }
       @for (field of group.fields; track $index) {
-        <div [class.full-width]="fullWidth">
+        <div [class.full-width]="fullWidth()">
           <app-entity-field-edit
             [field]="field"
-            [entity]="entity"
-            [form]="form"
+            [entity]="entity()"
+            [form]="form()"
           ></app-entity-field-edit>
         </div>
       }

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
@@ -11,7 +11,7 @@
         <div [class.full-width]="fullWidth()">
           <app-entity-field-edit
             [field]="field"
-            [entity]="entity()"
+            [entity]="entityState()"
             [form]="form()"
           ></app-entity-field-edit>
         </div>

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.html
@@ -4,7 +4,10 @@
       @if (group.header) {
         <h2>{{ group.header }}</h2>
       }
-      @for (field of group.fields; track $index) {
+      @for (
+        field of group.fields;
+        track typeof field === "string" ? field : field.id
+      ) {
         <div [class.full-width]="fullWidth()">
           <app-entity-field-edit
             [field]="field"

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.spec.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.spec.ts
@@ -38,13 +38,16 @@ describe("EntityFormComponent", () => {
   });
 
   async function setupInitialForm(entity, columns) {
-    component.entity = entity;
-    component.fieldGroups = columns.map((c) => ({ fields: c }));
-    component.form = await TestBed.inject(EntityFormService).createEntityForm(
+    const form = await TestBed.inject(EntityFormService).createEntityForm(
       columns[0],
-      component.entity,
+      entity,
     );
-    component.ngOnChanges({ entity: true, form: true } as any);
+    fixture.componentRef.setInput("entity", entity);
+    fixture.componentRef.setInput(
+      "fieldGroups",
+      columns.map((c) => ({ fields: c })),
+    );
+    fixture.componentRef.setInput("form", form);
     fixture.detectChanges();
   }
 
@@ -53,11 +56,14 @@ describe("EntityFormComponent", () => {
   });
 
   it("should remove fields without read permissions when entity is not new", async () => {
-    component.fieldGroups = [
+    const existingEntity = new TestEntity();
+    existingEntity._rev = "foo";
+    fixture.componentRef.setInput("entity", existingEntity);
+    fixture.componentRef.setInput("fieldGroups", [
       { fields: ["foo", "bar"] },
       { fields: ["name"] },
       { fields: ["birthday"] },
-    ];
+    ]);
 
     TestBed.inject(EntityAbility).update([
       {
@@ -67,22 +73,20 @@ describe("EntityFormComponent", () => {
       },
     ]);
 
-    component.entity._rev = "foo";
+    fixture.detectChanges();
 
-    component.ngOnChanges({ entity: true, form: true } as any);
-
-    expect(component.fieldGroups).toEqual([
+    expect(component.filteredFieldGroups()).toEqual([
       { fields: ["foo"] },
       { fields: ["name"] },
     ]);
   });
 
   it("should remove fields without create permissions when entity is new", async () => {
-    component.fieldGroups = [
+    fixture.componentRef.setInput("fieldGroups", [
       { fields: ["foo", "bar"] },
       { fields: ["name"] },
       { fields: ["birthday"] },
-    ];
+    ]);
 
     TestBed.inject(EntityAbility).update([
       {
@@ -92,20 +96,20 @@ describe("EntityFormComponent", () => {
       },
     ]);
 
-    component.ngOnChanges({ entity: true, form: true } as any);
+    fixture.detectChanges();
 
-    expect(component.fieldGroups).toEqual([
+    expect(component.filteredFieldGroups()).toEqual([
       { fields: ["foo"] },
       { fields: ["name"] },
     ]);
   });
 
   it("should not remove fields when creating new and conditions are not met yet", async () => {
-    component.fieldGroups = [
+    fixture.componentRef.setInput("fieldGroups", [
       { fields: ["foo", "bar"] },
       { fields: ["name"] },
       { fields: ["birthday"] },
-    ];
+    ]);
 
     TestBed.inject(EntityAbility).update([
       {
@@ -116,9 +120,9 @@ describe("EntityFormComponent", () => {
       },
     ]);
 
-    component.ngOnChanges({ entity: true, form: true } as any);
+    fixture.detectChanges();
 
-    expect(component.fieldGroups).toEqual([
+    expect(component.filteredFieldGroups()).toEqual([
       { fields: ["foo"] },
       { fields: ["name"] },
     ]);
@@ -220,10 +224,10 @@ describe("EntityFormComponent", () => {
 
     mockConfirmation.getConfirmation.mockResolvedValue(popupAction === "yes");
     for (const c in formChanges) {
-      component.form.formGroup.get(c).setValue(formChanges[c]);
-      component.form.formGroup.get(c).markAsDirty();
+      component.form().formGroup.get(c).setValue(formChanges[c]);
+      component.form().formGroup.get(c).markAsDirty();
     }
-    const updatedChild = new TestEntity(component.entity.getId());
+    const updatedChild = new TestEntity(component.entity().getId());
     Object.assign(updatedChild, remoteChanges);
 
     const entityMapper = TestBed.inject(EntityMapperService);
@@ -231,11 +235,11 @@ describe("EntityFormComponent", () => {
 
     const entityAfterSave = Object.assign(
       {},
-      component.entity,
-      component.form.formGroup.getRawValue(),
+      component.entity(),
+      component.form().formGroup.getRawValue(),
     );
     for (const [key, value] of Object.entries(expectedFormValues)) {
-      const form = component.form.formGroup.get(key);
+      const form = component.form().formGroup.get(key);
       if (form) {
         expect(form.value).toEqual(value);
       }

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
@@ -5,10 +5,11 @@ import {
 import { AutomatedFieldUpdateConfigService } from "#src/app/features/inherited-field/automated-field-update/automated-field-update-config.service";
 import {
   Component,
+  computed,
+  effect,
   inject,
-  Input,
-  OnChanges,
-  SimpleChanges,
+  input,
+  untracked,
   ViewEncapsulation,
   ChangeDetectionStrategy,
 } from "@angular/core";
@@ -47,9 +48,7 @@ import { ConfirmationDialogService } from "../../confirmation-dialog/confirmatio
     EntityFieldEditComponent,
   ],
 })
-export class EntityFormComponent<
-  T extends Entity = Entity,
-> implements OnChanges {
+export class EntityFormComponent<T extends Entity = Entity> {
   private entityMapper = inject(EntityMapperService);
   private confirmationDialog = inject(ConfirmationDialogService);
   private ability = inject(EntityAbility);
@@ -60,80 +59,79 @@ export class EntityFormComponent<
   /**
    * The entity which should be displayed and edited
    */
-  @Input() entity: T;
+  entity = input<T>();
 
-  @Input() fieldGroups: FieldGroup[];
+  fieldGroups = input<FieldGroup[]>();
 
-  @Input() form: EntityForm<T>;
+  form = input<EntityForm<T>>();
 
   /**
    * Whether the component should use a grid layout or just rows
    */
-  @Input() gridLayout = true;
+  gridLayout = input<boolean>(true);
 
   /**
    * Whether the fields should use the max width of the container
    */
-  @Input() fullWidth = false;
+  fullWidth = input<boolean>(false);
+
+  /** Field groups filtered by the current user's permissions */
+  readonly filteredFieldGroups = computed<FieldGroup[]>(() => {
+    const groups = this.fieldGroups();
+    const entity = this.entity();
+    if (!groups || !entity) return groups ?? [];
+    return this.filterFieldGroupsByPermissions(groups, entity);
+  });
 
   private initialFormValues: any;
   private changesSubscription: Subscription;
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (this.fieldGroups) {
-      this.fieldGroups = this.filterFieldGroupsByPermissions(
-        this.fieldGroups,
-        this.entity,
-      );
-    }
-
-    if (changes.entity && this.entity) {
+  constructor() {
+    effect((onCleanup) => {
+      const entity = this.entity();
+      if (!entity) return;
       this.changesSubscription?.unsubscribe();
-      this.changesSubscription = this.entityMapper
-        .receiveUpdates(this.entity.getConstructor())
+      const sub = this.entityMapper
+        .receiveUpdates(entity.getConstructor())
         .pipe(
-          filter(({ entity }) => entity.getId() === this.entity.getId()),
+          filter(({ entity: e }) => e.getId() === entity.getId()),
           filter(({ type }) => type !== "remove"),
           untilDestroyed(this),
         )
-        .subscribe(({ entity }) => this.applyChanges(entity));
-    }
+        .subscribe(({ entity: updated }) => this.applyChanges(updated as T));
+      onCleanup(() => sub.unsubscribe());
+    });
 
-    if (changes.form && this.form) {
-      this.initialFormValues = this.form.formGroup.getRawValue();
-      this.disableForLockedEntity();
-      this.subscribeForAutomatingStatusUpdates();
-    }
-  }
+    effect((onCleanup) => {
+      const form = this.form();
+      if (!form) return;
+      this.initialFormValues = form.formGroup.getRawValue();
+      untracked(() => this.disableForLockedEntity());
 
-  private formStateSubscription: Subscription;
-  private subscribeForAutomatingStatusUpdates() {
-    if (this.formStateSubscription) {
-      this.formStateSubscription.unsubscribe();
-    }
-
-    this.formStateSubscription = this.form.onFormStateChange
-      .pipe(
-        untilDestroyed(this),
-        filter((event) => event instanceof EntityFormSavedEvent),
-      )
-      .subscribe(async (event: EntityFormSavedEvent) => {
-        await this.automatedFieldUpdateConfigService.applyRulesToDependentEntities(
-          event.newEntity,
-          event.previousEntity,
-        );
-      });
+      const sub = form.onFormStateChange
+        .pipe(
+          untilDestroyed(this),
+          filter((event) => event instanceof EntityFormSavedEvent),
+        )
+        .subscribe(async (event: EntityFormSavedEvent) => {
+          await this.automatedFieldUpdateConfigService.applyRulesToDependentEntities(
+            event.newEntity,
+            event.previousEntity,
+          );
+        });
+      onCleanup(() => sub.unsubscribe());
+    });
   }
 
   private async applyChanges(externallyUpdatedEntity: T) {
     if (this.formIsUpToDate(externallyUpdatedEntity)) {
-      Object.assign(this.entity, externallyUpdatedEntity);
+      Object.assign(this.entity(), externallyUpdatedEntity);
       return;
     }
 
     const userEditedFields = Object.entries(
-      this.form.formGroup.getRawValue(),
-    ).filter(([key]) => this.form.formGroup.controls[key].dirty);
+      this.form().formGroup.getRawValue(),
+    ).filter(([key]) => this.form().formGroup.controls[key].dirty);
     let userEditsWithoutConflicts = userEditedFields.filter(([key]) =>
       // no conflict with updated values
       this.entityEqualsFormValue(
@@ -153,19 +151,19 @@ export class EntityFormComponent<
     }
 
     // apply update to all pristine (not user-edited) fields and update base entity (to avoid conflicts when saving)
-    Object.assign(this.entity, externallyUpdatedEntity);
+    Object.assign(this.entity(), externallyUpdatedEntity);
     Object.assign(this.initialFormValues, externallyUpdatedEntity);
-    this.form.formGroup.reset(externallyUpdatedEntity as any);
+    this.form().formGroup.reset(externallyUpdatedEntity as any);
 
     // re-apply user-edited fields
     userEditsWithoutConflicts.forEach(([key, value]) => {
-      this.form.formGroup.get(key).setValue(value);
-      this.form.formGroup.get(key).markAsDirty();
+      this.form().formGroup.get(key).setValue(value);
+      this.form().formGroup.get(key).markAsDirty();
     });
   }
 
   private formIsUpToDate(entity: T): boolean {
-    return Object.entries(this.form.formGroup.getRawValue()).every(
+    return Object.entries(this.form().formGroup.getRawValue()).every(
       ([key, value]) => this.entityEqualsFormValue(entity[key], value),
     );
   }
@@ -205,8 +203,8 @@ export class EntityFormComponent<
    * @private
    */
   private disableForLockedEntity() {
-    if (this.entity?.anonymized) {
-      this.form.formGroup.disable();
+    if (this.entity()?.anonymized) {
+      this.form()?.formGroup.disable();
     }
   }
 }

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
@@ -104,9 +104,10 @@ export class EntityFormComponent<T extends Entity = Entity> {
 
     effect((onCleanup) => {
       const form = this.form();
+      const entity = this.entity();
       if (!form) return;
       this.initialFormValues = form.formGroup.getRawValue();
-      untracked(() => this.disableForLockedEntity());
+      untracked(() => this.disableForLockedEntity(entity, form));
 
       const sub = form.onFormStateChange
         .pipe(
@@ -175,16 +176,16 @@ export class EntityFormComponent<T extends Entity = Entity> {
     const action = entity.isNew ? "create" : "read";
 
     return fieldGroups
-      .map((group) => {
-        group.fields = group.fields.filter((field) =>
+      .map((group) => ({
+        ...group,
+        fields: group.fields.filter((field) =>
           this.ability.can(
             action,
             entity,
             typeof field === "string" ? field : field.id,
           ),
-        );
-        return group;
-      })
+        ),
+      }))
       .filter((group) => group.fields.length > 0);
   }
 
@@ -202,9 +203,12 @@ export class EntityFormComponent<T extends Entity = Entity> {
    * Disable the form for certain states of the entity, like it being already anonymized.
    * @private
    */
-  private disableForLockedEntity() {
-    if (this.entity()?.anonymized) {
-      this.form()?.formGroup.disable();
+  private disableForLockedEntity(
+    entity: Entity | undefined,
+    form: EntityForm<T>,
+  ) {
+    if (entity?.anonymized) {
+      form.formGroup.disable();
     }
   }
 }

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.ts
@@ -9,7 +9,7 @@ import {
   effect,
   inject,
   input,
-  untracked,
+  signal,
   ViewEncapsulation,
   ChangeDetectionStrategy,
 } from "@angular/core";
@@ -75,10 +75,13 @@ export class EntityFormComponent<T extends Entity = Entity> {
    */
   fullWidth = input<boolean>(false);
 
+  readonly entityState = signal<T | undefined>(undefined);
+  readonly isEntityLocked = computed(() => !!this.entityState()?.anonymized);
+
   /** Field groups filtered by the current user's permissions */
   readonly filteredFieldGroups = computed<FieldGroup[]>(() => {
     const groups = this.fieldGroups();
-    const entity = this.entity();
+    const entity = this.entityState();
     if (!groups || !entity) return groups ?? [];
     return this.filterFieldGroupsByPermissions(groups, entity);
   });
@@ -87,8 +90,12 @@ export class EntityFormComponent<T extends Entity = Entity> {
   private changesSubscription: Subscription;
 
   constructor() {
+    effect(() => {
+      this.entityState.set(this.entity());
+    });
+
     effect((onCleanup) => {
-      const entity = this.entity();
+      const entity = this.entityState();
       if (!entity) return;
       this.changesSubscription?.unsubscribe();
       const sub = this.entityMapper
@@ -99,15 +106,17 @@ export class EntityFormComponent<T extends Entity = Entity> {
           untilDestroyed(this),
         )
         .subscribe(({ entity: updated }) => this.applyChanges(updated as T));
+      this.changesSubscription = sub;
       onCleanup(() => sub.unsubscribe());
     });
 
     effect((onCleanup) => {
       const form = this.form();
-      const entity = this.entity();
       if (!form) return;
       this.initialFormValues = form.formGroup.getRawValue();
-      untracked(() => this.disableForLockedEntity(entity, form));
+      if (this.isEntityLocked()) {
+        form.formGroup.disable();
+      }
 
       const sub = form.onFormStateChange
         .pipe(
@@ -125,8 +134,13 @@ export class EntityFormComponent<T extends Entity = Entity> {
   }
 
   private async applyChanges(externallyUpdatedEntity: T) {
+    const inputEntity = this.entity();
+
     if (this.formIsUpToDate(externallyUpdatedEntity)) {
-      Object.assign(this.entity(), externallyUpdatedEntity);
+      if (inputEntity) {
+        Object.assign(inputEntity, externallyUpdatedEntity);
+      }
+      this.entityState.set(externallyUpdatedEntity);
       return;
     }
 
@@ -152,7 +166,10 @@ export class EntityFormComponent<T extends Entity = Entity> {
     }
 
     // apply update to all pristine (not user-edited) fields and update base entity (to avoid conflicts when saving)
-    Object.assign(this.entity(), externallyUpdatedEntity);
+    if (inputEntity) {
+      Object.assign(inputEntity, externallyUpdatedEntity);
+    }
+    this.entityState.set(externallyUpdatedEntity);
     Object.assign(this.initialFormValues, externallyUpdatedEntity);
     this.form().formGroup.reset(externallyUpdatedEntity as any);
 
@@ -197,18 +214,5 @@ export class EntityFormComponent<T extends Entity = Entity> {
       entityValue === formValue ||
       JSON.stringify(entityValue) === JSON.stringify(formValue)
     );
-  }
-
-  /**
-   * Disable the form for certain states of the entity, like it being already anonymized.
-   * @private
-   */
-  private disableForLockedEntity(
-    entity: Entity | undefined,
-    form: EntityForm<T>,
-  ) {
-    if (entity?.anonymized) {
-      form.formGroup.disable();
-    }
   }
 }

--- a/src/app/core/common-components/icon-input/icon-input.component.ts
+++ b/src/app/core/common-components/icon-input/icon-input.component.ts
@@ -1,11 +1,10 @@
 import {
   Component,
-  EventEmitter,
-  Input,
-  OnChanges,
+  effect,
+  input,
   OnInit,
-  Output,
-  SimpleChanges,
+  output,
+  untracked,
   inject,
   ChangeDetectionStrategy,
 } from "@angular/core";
@@ -43,23 +42,35 @@ import { resolveIconDefinition } from "../fa-dynamic-icon/fa-icon-utils";
   templateUrl: "./icon-input.component.html",
   styleUrl: "./icon-input.component.scss",
 })
-export class IconComponent implements OnInit, OnChanges {
+export class IconComponent implements OnInit {
   private readonly iconLibrary = inject(FaIconLibrary);
 
-  @Input() icon: string;
-  @Input() control?: FormControl<string | null>;
-  @Output() iconChange = new EventEmitter<string>();
+  icon = input<string>();
+  control = input<FormControl<string | null>>();
+  iconChange = output<string>();
 
   iconControl: FormControl<string | null>;
 
+  constructor() {
+    effect(() => {
+      const iconValue = this.icon();
+      untracked(() => {
+        if (this.iconControl && !this.control()) {
+          this.iconControl.setValue(iconValue || "", { emitEvent: false });
+        }
+      });
+    });
+  }
+
   ngOnInit(): void {
     const iconValidator = this.createIconValidator();
-    if (this.control) {
-      this.control.addValidators(iconValidator);
-      this.control.updateValueAndValidity({ emitEvent: false });
-      this.iconControl = this.control;
+    const ctrl = this.control();
+    if (ctrl) {
+      ctrl.addValidators(iconValidator);
+      ctrl.updateValueAndValidity({ emitEvent: false });
+      this.iconControl = ctrl;
     } else {
-      this.iconControl = new FormControl<string | null>(this.icon || "", {
+      this.iconControl = new FormControl<string | null>(this.icon() || "", {
         validators: [iconValidator],
       });
     }
@@ -67,12 +78,6 @@ export class IconComponent implements OnInit, OnChanges {
     this.iconControl.valueChanges.subscribe((value) =>
       this.iconChange.emit(value || ""),
     );
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes["icon"] && this.iconControl && !this.control) {
-      this.iconControl.setValue(this.icon || "", { emitEvent: false });
-    }
   }
 
   private createIconValidator(): ValidatorFn {

--- a/src/app/core/common-components/icon-input/icon-input.component.ts
+++ b/src/app/core/common-components/icon-input/icon-input.component.ts
@@ -7,7 +7,6 @@ import {
   input,
   OnInit,
   output,
-  untracked,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
@@ -57,11 +56,11 @@ export class IconComponent implements OnInit {
   constructor() {
     effect(() => {
       const iconValue = this.icon();
-      untracked(() => {
-        if (this.iconControl && !this.control()) {
-          this.iconControl.setValue(iconValue || "", { emitEvent: false });
-        }
-      });
+      const externalControl = this.control();
+      if (this.iconControl && !externalControl) {
+        // Imperative FormControl sync is a side effect; keep this in effect (not computed).
+        this.iconControl.setValue(iconValue || "", { emitEvent: false });
+      }
     });
   }
 

--- a/src/app/core/common-components/icon-input/icon-input.component.ts
+++ b/src/app/core/common-components/icon-input/icon-input.component.ts
@@ -1,13 +1,15 @@
 import {
+  ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   effect,
+  inject,
   input,
   OnInit,
   output,
   untracked,
-  inject,
-  ChangeDetectionStrategy,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   AbstractControl,
   FormControl,
@@ -44,6 +46,7 @@ import { resolveIconDefinition } from "../fa-dynamic-icon/fa-icon-utils";
 })
 export class IconComponent implements OnInit {
   private readonly iconLibrary = inject(FaIconLibrary);
+  private readonly destroyRef = inject(DestroyRef);
 
   icon = input<string>();
   control = input<FormControl<string | null>>();
@@ -75,9 +78,9 @@ export class IconComponent implements OnInit {
       });
     }
 
-    this.iconControl.valueChanges.subscribe((value) =>
-      this.iconChange.emit(value || ""),
-    );
+    this.iconControl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => this.iconChange.emit(value || ""));
   }
 
   private createIconValidator(): ValidatorFn {

--- a/src/app/core/common-components/view-title/view-title.component.html
+++ b/src/app/core/common-components/view-title/view-title.component.html
@@ -1,6 +1,6 @@
 <ng-template #template>
   <div class="container flex-row">
-    @if ((parentUrl || !navigateToParentBehaviour) && !disableBackButton) {
+    @if ((parentUrl || !navigateToParentBehaviour) && !isBackButtonDisabled()) {
       <button
         mat-icon-button
         (click)="navigateBack()"
@@ -17,6 +17,6 @@
   </div>
 </ng-template>
 
-@if (!viewContext || displayInPlace) {
+@if (!viewContext || displayInPlace()) {
   <ng-container *ngTemplateOutlet="template"></ng-container>
 }

--- a/src/app/core/common-components/view-title/view-title.component.html
+++ b/src/app/core/common-components/view-title/view-title.component.html
@@ -1,6 +1,8 @@
 <ng-template #template>
   <div class="container flex-row">
-    @if ((parentUrl || !navigateToParentBehaviour) && !isBackButtonDisabled()) {
+    @if (
+      (parentUrl() || !navigateToParentBehaviour()) && !isBackButtonDisabled()
+    ) {
       <button
         mat-icon-button
         (click)="navigateBack()"

--- a/src/app/core/common-components/view-title/view-title.component.ts
+++ b/src/app/core/common-components/view-title/view-title.component.ts
@@ -1,8 +1,9 @@
 import {
   AfterViewInit,
   Component,
+  computed,
   HostBinding,
-  Input,
+  input,
   TemplateRef,
   ViewChild,
   inject,
@@ -40,10 +41,10 @@ export class ViewTitleComponent implements AfterViewInit {
   @ViewChild("template") template: TemplateRef<any>;
 
   /** The page title to be displayed */
-  @Input() title: string;
+  title = input<string>();
 
   /** (Optional) do not show button to navigate back to the parent page */
-  @Input() disableBackButton: boolean = false;
+  disableBackButton = input<boolean>(false);
 
   /**
    * whether instead of a basic back to previous page navigation the back button should navigate to logical parent page
@@ -52,16 +53,18 @@ export class ViewTitleComponent implements AfterViewInit {
 
   readonly parentUrl: string;
 
+  protected readonly isBackButtonDisabled = computed(
+    () => this.disableBackButton() || !!this.viewContext?.isDialog,
+  );
+
+  displayInPlace = input<boolean>(false);
+
   constructor() {
     this.parentUrl = this.findParentUrl();
-
-    if (this.viewContext?.isDialog) {
-      this.disableBackButton = true;
-    }
   }
 
   ngAfterViewInit(): void {
-    if (this.viewContext && !this.displayInPlace) {
+    if (this.viewContext && !this.displayInPlace()) {
       setTimeout(() => this.viewContext.setTitle(this));
     }
   }
@@ -86,5 +89,4 @@ export class ViewTitleComponent implements AfterViewInit {
   }
 
   @HostBinding("class") extraClasses = "mat-title";
-  @Input() displayInPlace!: boolean;
 }

--- a/src/app/core/common-components/view-title/view-title.component.ts
+++ b/src/app/core/common-components/view-title/view-title.component.ts
@@ -49,19 +49,15 @@ export class ViewTitleComponent implements AfterViewInit {
   /**
    * whether instead of a basic back to previous page navigation the back button should navigate to logical parent page
    */
-  navigateToParentBehaviour: boolean = false;
+  navigateToParentBehaviour = input<boolean>(false);
 
-  readonly parentUrl: string;
+  readonly parentUrl = computed(() => this.findParentUrl());
 
   protected readonly isBackButtonDisabled = computed(
     () => this.disableBackButton() || !!this.viewContext?.isDialog,
   );
 
   displayInPlace = input<boolean>(false);
-
-  constructor() {
-    this.parentUrl = this.findParentUrl();
-  }
 
   ngAfterViewInit(): void {
     if (this.viewContext && !this.displayInPlace()) {
@@ -81,8 +77,9 @@ export class ViewTitleComponent implements AfterViewInit {
   }
 
   async navigateBack() {
-    if (this.navigateToParentBehaviour && this.parentUrl) {
-      await this.router.navigate([this.parentUrl]);
+    const parentUrl = this.parentUrl();
+    if (this.navigateToParentBehaviour() && parentUrl) {
+      await this.router.navigate([parentUrl]);
     } else {
       this.location.back();
     }

--- a/src/app/core/entity/entity-field-edit/dynamic-edit/edit-component.interface.ts
+++ b/src/app/core/entity/entity-field-edit/dynamic-edit/edit-component.interface.ts
@@ -1,3 +1,4 @@
+import { InputSignal } from "@angular/core";
 import { Entity } from "#src/app/core/entity/model/entity";
 import { FormFieldConfig } from "#src/app/core/common-components/entity-form/FormConfig";
 
@@ -6,6 +7,6 @@ import { FormFieldConfig } from "#src/app/core/common-components/entity-form/For
  * The inputs are passed on by the DynamicEditComponent.
  */
 export interface EditComponent {
-  formFieldConfig?: FormFieldConfig;
-  entity?: Entity;
+  formFieldConfig?: FormFieldConfig | InputSignal<FormFieldConfig | undefined>;
+  entity?: Entity | InputSignal<Entity | undefined>;
 }


### PR DESCRIPTION
- closes #3917

### PR Checklist

_Before you request a manual PR review from someone, please go through all of this list, check the points and mark them checked here.
This helps us reduce the number of review cycles and use the time of our core reviewers more effectively._

- [ ] all automatic CI checks pass (🟢)
  - i.e. code formatting (`ng lint`) passes
  - i.e. unit tests (`ng test`) passes
  - in some cases unit test coverage can be difficult to achieve. If that or any other CI check fails, you can also leave a short comment here why this should be accepted anyway.
- [ ] manually tested (all) required functionality described in the issue manually yourself on the final version of the code (developer)
- [ ] reviewed the "Files changed" section of the PR briefly yourself to check for any unwanted changes
  - e.g. clean up debugging console.log statements, disabled tests, ...
  - please also avoid changes that are not directly related to the issue of the PR, even small code reformatting changes make the review process much more complex
- [ ] 🚦 PR status is changed to "Ready for Review"
  - while you are still working on initial implementation, keep the PR in "Draft" status
  - once you are done with your initial work, change to "Ready for Review". This will trigger some additional automated checks.
  - (PR = "Ready for Review" does not immediately request a manual review yet, first complete the further checks below)
- [ ] add label **"Final Review"** to trigger Argos visual review and CodeRabbit AI review (can also be done while still in Draft)
- [ ] marked each code review comment as resolved OR commented on it with a question, if unsure
  - both implementing suggestions of automatic code review or discarding them as not applicable is okay
- [ ] all checkboxes in this checklist are checked (to show the reviewer this really is ready)
- [ ] 🚦 moved the issue related to this PR to Status "Functional Review" to request a personal review

⏪ if issues are commented from testing or code review, make changes. Please then re-check every item of the checklist here again.

---

### Remaining TODOs:

- [ ] unit tests

---

### Phase Scope

PR5 from issue #3917 comment plan: migrate remaining `core/common-components` targets to signal APIs.

### Migrated Components

| Component | Location | Key change |
|---|---|---|
| `ColorInputComponent` | `src/app/core/common-components/color-input/` | `@Input()` fields migrated to `input()`; template updated to signal calls |
| `EditTextWithAutocompleteComponent` | `src/app/core/common-components/edit-text-with-autocomplete/` | `formFieldConfig` migrated to signal input and usages updated |
| `ListPaginatorComponent` | `src/app/core/common-components/entities-table/list-paginator/` | `@Input()` migrated to `input()` with reactive paginator rebinding |
| `ViewTitleComponent` | `src/app/core/common-components/view-title/` | inputs migrated to signals and back-button visibility derived via `computed()` |
| `IconComponent` | `src/app/core/common-components/icon-input/` | input/output migrated to signal APIs; reactive control sync via `effect()` |
| `EntityFieldsMenuComponent` | `src/app/core/common-components/entity-fields-menu/` | inputs/outputs migrated to signals; available fields derived with `computed()` |
| `EntityFormComponent` | `src/app/core/common-components/entity-form/entity-form/` | migrated to signal inputs + `computed()`/`effect()`; permission filtering made immutable; stable `@for` tracking |
| `EntitiesTableComponent` | `src/app/core/common-components/entities-table/` | migrated to signal inputs/models/outputs + `computed()`/`effect()`; filter cloning and subscription cleanup |

### Components NOT migrated in this PR (deferred)

| Component | Reason |
|---|---|
| `src/app/core/common-components/template-tooltip/template-tooltip.component.ts` | `template-tooltip.directive.ts` currently depends on direct instance assignment (`tooltipRef.instance.contentTemplate = ...`) and Observable-style output usage (`hide.pipe(...)`, `show.pipe(...)`). Migrating this component alone to `input()/output()` would break directive contract without a coordinated directive+component refactor. |

### Manual Testing Checklist

- [ ] Open any entity list view using `entities-table` (e.g. Children, Notes) and verify rows render, sorting works, and filters update results.
- [ ] Verify paginator behavior: page size changes persist after reload and replacing datasource still keeps pagination working.
- [ ] Verify inactive toggle updates visible records correctly.
- [ ] Verify row selection behavior (`selectedRecords`), select-all, and row click actions (`popup`, `navigate`, inline edit).
- [ ] In entity details form, verify field groups render correctly and hidden fields are removed according to permissions.
- [ ] In entity details form, verify anonymized/locked entity state disables the form correctly without stale state.
- [ ] In views using `entity-fields-menu`, verify selecting/unselecting fields updates visible columns immediately.
- [ ] Verify `edit-text-with-autocomplete`: suggestions load, entity selection fills form, reset/unload works.
- [ ] Verify `color-input`: text input + picker keep value in sync and invalid hex validation still works.
- [ ] Verify `icon-input`: validation works for valid/invalid icon names and emitted value updates parent control.
- [ ] Verify `view-title`: back button visibility and behavior are correct in routed view and dialog context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal component architecture to improve performance and maintainability. Application functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aam-Digital/ndb-core/pull/3954)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->