### PR TITLE
fix: avoid entity parsing issues when loading SiteSettings before Config

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -22,6 +22,7 @@ import {
 } from "#src/app/core/entity/database-entity.decorator.js";
 import { DefaultDatatype } from "#src/app/core/entity/default-datatype/default.datatype.js";
 import { EntityConfigService } from "#src/app/core/entity/entity-config.service.js";
+import { EntityConfigReadyService } from "#src/app/core/entity/entity-config-ready.service.js";
 import type { Entity } from "#src/app/core/entity/model/entity.js";
 import { EntitySchemaService } from "#src/app/core/entity/schema/entity-schema.service.js";
 import { LocationDatatype } from "#src/app/features/location/location.datatype.js";
@@ -132,6 +133,7 @@ function serializeEntities(entities: Entity[]): unknown[] {
       { provide: EntityActionsService, useValue: undefined },
       { provide: ConfigService, useValue: undefined },
       { provide: EntitySchemaService, useClass: EntitySchemaService },
+      { provide: EntityConfigReadyService, useClass: EntityConfigReadyService },
       { provide: EntityConfigService, useClass: EntityConfigService },
       { provide: EntityRegistry, useValue: entityRegistry },
       { provide: DefaultDatatype, useClass: DefaultDatatype, multi: true },

--- a/src/app/core/entity/entity-config-ready.service.ts
+++ b/src/app/core/entity/entity-config-ready.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@angular/core";
+import { ReplaySubject } from "rxjs";
+
+/**
+ * Synchronization signal for when dynamic entity schemas have been applied.
+ *
+ * Emits after {@link EntityConfigService.setupEntitiesFromConfig} completes,
+ * ensuring consumers do not parse entity data before config-defined schema
+ * overrides are applied. Use this to gate operations that depend on full schema
+ * information (e.g., {@link SiteSettingsService}, {@link SessionManagerService}).
+ *
+ * @see EntityConfigService
+ * @see ConfigService
+ */
+@Injectable({ providedIn: "root" })
+export class EntityConfigReadyService {
+  private setupCompleted = new ReplaySubject<void>(1);
+
+  /**
+   * Emits once whenever dynamic entity schemas/configs have been applied at runtime.
+   * Replays the signal to late subscribers, ensuring they can still act on the completion.
+   */
+  readonly setupCompleted$ = this.setupCompleted.asObservable();
+
+  /**
+   * Signal that entity schema setup (dynamic fields, overrides, etc.) has completed.
+   * Called by {@link EntityConfigService} after all config-defined schema changes
+   * have been applied to the entity registry.
+   * @internal
+   */
+  markSetupCompleted() {
+    this.setupCompleted.next();
+  }
+}

--- a/src/app/core/entity/entity-config.service.ts
+++ b/src/app/core/entity/entity-config.service.ts
@@ -19,6 +19,7 @@ import { EntityDetailsConfig } from "../entity-details/EntityDetailsConfig";
 import { EntityListConfig } from "../entity-list/EntityListConfig";
 import { EntitySchemaService } from "./schema/entity-schema.service";
 import { Logging } from "../logging/logging.service";
+import { EntityConfigReadyService } from "./entity-config-ready.service";
 
 /**
  * A service that allows to work with configuration-objects
@@ -32,6 +33,7 @@ export class EntityConfigService {
   private readonly configService = inject(ConfigService);
   private readonly entities = inject(EntityRegistry);
   private readonly entitySchemaService = inject(EntitySchemaService);
+  private readonly entityConfigReady = inject(EntityConfigReadyService);
 
   /** @deprecated will become private, use the service to access the data */
   static readonly PREFIX_ENTITY_CONFIG = "entity:";
@@ -93,6 +95,8 @@ export class EntityConfigService {
       this.setCoreSchemaAttributes(ctor, config.extends);
       this.addConfigAttributes(ctor, config);
     }
+
+    this.entityConfigReady.markSetupCompleted();
   }
 
   private createNewEntity(id: string, parent: string) {

--- a/src/app/core/import/additional-actions/import-additional.service.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.ts
@@ -15,6 +15,7 @@ import { Note } from "../../../child-dev-project/notes/model/note";
 import { Todo } from "../../../features/todos/model/todo";
 import { EntityRelationsService } from "../../entity/entity-mapper/entity-relations.service";
 import { asArray } from "../../../utils/asArray";
+import { EntityConfigReadyService } from "../../entity/entity-config-ready.service";
 
 /**
  * Service to handle additional import actions
@@ -25,6 +26,7 @@ import { asArray } from "../../../utils/asArray";
 })
 export class ImportAdditionalService {
   private configService = inject(ConfigService);
+  private entityConfigReady = inject(EntityConfigReadyService);
 
   private readonly entityMapper = inject(EntityMapperService);
   private readonly entityRegistry = inject(EntityRegistry);
@@ -34,10 +36,8 @@ export class ImportAdditionalService {
 
   constructor() {
     this.updateLinkableEntities();
-    this.configService.configUpdates.subscribe(() =>
-      // need to wait until EntityConfigService has updated the entityRegistry after the configUpdate
-      // TODO: better way to wait for EntityConfig updates?
-      setTimeout(() => this.updateLinkableEntities()),
+    this.entityConfigReady.setupCompleted$.subscribe(() =>
+      this.updateLinkableEntities(),
     );
   }
 

--- a/src/app/core/session/session-service/session-manager.service.spec.ts
+++ b/src/app/core/session/session-service/session-manager.service.spec.ts
@@ -18,11 +18,10 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { TEST_USER } from "../../user/demo-user-generator.service";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
-import { Config } from "../../config/config";
-import { ConfigService } from "../../config/config.service";
 import { Subject } from "rxjs";
 import { UpdatedEntity } from "../../entity/model/entity-update";
 import type { Mock } from "vitest";
+import { EntityConfigReadyService } from "../../entity/entity-config-ready.service";
 
 type KeycloakAuthServiceMock = Pick<
   KeycloakAuthService,
@@ -175,8 +174,7 @@ describe("SessionManagerService", () => {
       service.remoteLogin();
       await vi.advanceTimersByTimeAsync(0);
 
-      // we somehow need this in the Test as the replay doesn't trigger
-      TestBed.inject(ConfigService).entityUpdated.next(new Config());
+      TestBed.inject(EntityConfigReadyService).markSetupCompleted();
       await vi.advanceTimersByTimeAsync(0);
 
       expect(currentUser.value).toEqual(loggedInUser);
@@ -229,8 +227,7 @@ describe("SessionManagerService", () => {
       service.remoteLogin();
       await vi.advanceTimersByTimeAsync(0);
 
-      // we somehow need this in the Test as the replay doesn't trigger
-      TestBed.inject(ConfigService).entityUpdated.next(new Config());
+      TestBed.inject(EntityConfigReadyService).markSetupCompleted();
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mockedEntityMapper.load).not.toHaveBeenCalled();

--- a/src/app/core/session/session-service/session-manager.service.ts
+++ b/src/app/core/session/session-service/session-manager.service.ts
@@ -32,8 +32,8 @@ import { NAVIGATOR_TOKEN } from "../../../utils/di-tokens";
 import { environment } from "../../../../environments/environment";
 import { CurrentUserSubject } from "../current-user-subject";
 import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.service";
-import { filter, take } from "rxjs/operators";
-import { Subscription } from "rxjs";
+import { filter, take, takeUntil } from "rxjs/operators";
+import { Subject, Subscription } from "rxjs";
 import { Entity } from "../../entity/model/entity";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
 import { EntityConfigReadyService } from "../../entity/entity-config-ready.service";
@@ -72,6 +72,7 @@ export class SessionManagerService {
   private updateSubscription: Subscription;
   /** Subscription waiting for first sync completion before registering the user for offline login. */
   private syncSaveSubscription: Subscription | undefined;
+  private readonly logout$ = new Subject<void>();
 
   /**
    * Silently check for an existing SSO session without redirecting.
@@ -152,10 +153,12 @@ export class SessionManagerService {
     await this.databaseResolver.initDatabasesForSession(session);
     this.sessionInfo.next(session);
     this.loginStateSubject.next(LoginState.LOGGED_IN);
-    this.entityConfigReady.setupCompleted$.pipe(take(1)).subscribe(() =>
-      // requires dynamic entity config to be applied first!
-      this.initUserEntity(session.entityId),
-    );
+    this.entityConfigReady.setupCompleted$
+      .pipe(takeUntil(this.logout$), take(1))
+      .subscribe(() => {
+        // requires dynamic entity config to be applied first!
+        this.initUserEntity(session.entityId);
+      });
   }
 
   private initUserEntity(entityId: string) {
@@ -192,6 +195,8 @@ export class SessionManagerService {
    * If offline, reset the state and forward to login page.
    */
   async logout() {
+    this.logout$.next();
+
     if (this.remoteLoggedIn) {
       // Tell the next page load (after the Keycloak logout redirect round-trip)
       // not to run another silent SSO check — it would only delay the login

--- a/src/app/core/session/session-service/session-manager.service.ts
+++ b/src/app/core/session/session-service/session-manager.service.ts
@@ -35,8 +35,8 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { filter, take } from "rxjs/operators";
 import { Subscription } from "rxjs";
 import { Entity } from "../../entity/model/entity";
-import { ConfigService } from "../../config/config.service";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
+import { EntityConfigReadyService } from "../../entity/entity-config-ready.service";
 
 /**
  * This service handles the user session.
@@ -53,7 +53,7 @@ export class SessionManagerService {
   private loginStateSubject = inject(LoginStateSubject);
   private router = inject(Router);
   private navigator = inject<Navigator>(NAVIGATOR_TOKEN);
-  private configService = inject(ConfigService);
+  private entityConfigReady = inject(EntityConfigReadyService);
   private databaseResolver = inject(DatabaseResolverService);
   private readonly syncStateSubject = inject(SyncStateSubject);
 
@@ -152,8 +152,8 @@ export class SessionManagerService {
     await this.databaseResolver.initDatabasesForSession(session);
     this.sessionInfo.next(session);
     this.loginStateSubject.next(LoginState.LOGGED_IN);
-    this.configService.configUpdates.pipe(take(1)).subscribe(() =>
-      // requires initial config to be loaded first!
+    this.entityConfigReady.setupCompleted$.pipe(take(1)).subscribe(() =>
+      // requires dynamic entity config to be applied first!
       this.initUserEntity(session.entityId),
     );
   }

--- a/src/app/core/site-settings/site-settings.service.spec.ts
+++ b/src/app/core/site-settings/site-settings.service.spec.ts
@@ -13,6 +13,7 @@ import { ConfigurableEnumModule } from "../basic-datatypes/configurable-enum/con
 import { EntityAbility } from "../permissions/ability/entity-ability";
 import { CoreTestingModule } from "../../utils/core-testing.module";
 import { Config } from "../config/config";
+import { EntityConfigReadyService } from "../entity/entity-config-ready.service";
 
 describe("SiteSettingsService", () => {
   let service: SiteSettingsService;
@@ -29,6 +30,7 @@ describe("SiteSettingsService", () => {
       ],
     });
     service = TestBed.inject(SiteSettingsService);
+    TestBed.inject(EntityConfigReadyService).markSetupCompleted();
 
     entityMapper = TestBed.inject(
       EntityMapperService,
@@ -130,7 +132,7 @@ describe("SiteSettingsService", () => {
 
       const titleSpy = vi.spyOn(TestBed.inject(Title), "setTitle");
 
-      service.init();
+      TestBed.runInInjectionContext(() => new SiteSettingsService());
       await vi.advanceTimersByTimeAsync(0);
 
       expect(titleSpy).toHaveBeenCalledWith(settings.siteName);

--- a/src/app/core/site-settings/site-settings.service.spec.ts
+++ b/src/app/core/site-settings/site-settings.service.spec.ts
@@ -12,6 +12,7 @@ import { availableLocales } from "../language/languages";
 import { ConfigurableEnumModule } from "../basic-datatypes/configurable-enum/configurable-enum.module";
 import { EntityAbility } from "../permissions/ability/entity-ability";
 import { CoreTestingModule } from "../../utils/core-testing.module";
+import { Config } from "../config/config";
 
 describe("SiteSettingsService", () => {
   let service: SiteSettingsService;
@@ -22,7 +23,10 @@ describe("SiteSettingsService", () => {
 
     TestBed.configureTestingModule({
       imports: [CoreTestingModule, ConfigurableEnumModule],
-      providers: [...mockEntityMapperProvider(), EntityAbility],
+      providers: [
+        ...mockEntityMapperProvider([new Config(Config.CONFIG_KEY, {})]),
+        EntityAbility,
+      ],
     });
     service = TestBed.inject(SiteSettingsService);
 

--- a/src/app/core/site-settings/site-settings.service.ts
+++ b/src/app/core/site-settings/site-settings.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from "@angular/core";
 import { SiteSettings } from "./site-settings";
 import { Observable, skipWhile } from "rxjs";
-import { distinctUntilChanged, map, shareReplay } from "rxjs/operators";
+import { distinctUntilChanged, map, shareReplay, take } from "rxjs/operators";
 import { Title } from "@angular/platform-browser";
 import materialColours from "@aytek/material-color-picker";
 import { EntityMapperService } from "../entity/entity-mapper/entity-mapper.service";
@@ -11,6 +11,7 @@ import { Entity } from "../entity/model/entity";
 import { EntitySchemaService } from "../entity/schema/entity-schema.service";
 import { availableLocales } from "../language/languages";
 import { ConfigurableEnumService } from "../basic-datatypes/configurable-enum/configurable-enum.service";
+import { ConfigService } from "../config/config.service";
 
 /**
  * Access to site settings stored in the database, like styling, site name and logo.
@@ -36,6 +37,8 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
   displayLanguageSelect = this.getPropertyObservable("displayLanguageSelect");
   dateFormat = this.getPropertyObservable("dateFormat");
 
+  private configService = inject(ConfigService);
+
   constructor() {
     const entityMapper = inject(EntityMapperService);
 
@@ -43,11 +46,15 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
 
     this.init();
 
-    super.startLoading().catch((err) => {
-      const error = new Error("Failed to load site settings", { cause: err });
-      error.name = "SiteSettingsLoadError";
-      Logging.error(error);
-    });
+    // Wait for config schemas to be applied before loading from DB,
+    // so any config-defined SiteSettings fields are transformed correctly.
+    this.configService.configUpdates.pipe(take(1)).subscribe(() =>
+      super.startLoading().catch((err) => {
+        const error = new Error("Failed to load site settings", { cause: err });
+        error.name = "SiteSettingsLoadError";
+        Logging.error(error);
+      }),
+    );
   }
 
   init() {

--- a/src/app/core/site-settings/site-settings.service.ts
+++ b/src/app/core/site-settings/site-settings.service.ts
@@ -11,7 +11,7 @@ import { Entity } from "../entity/model/entity";
 import { EntitySchemaService } from "../entity/schema/entity-schema.service";
 import { availableLocales } from "../language/languages";
 import { ConfigurableEnumService } from "../basic-datatypes/configurable-enum/configurable-enum.service";
-import { ConfigService } from "../config/config.service";
+import { EntityConfigReadyService } from "../entity/entity-config-ready.service";
 
 /**
  * Access to site settings stored in the database, like styling, site name and logo.
@@ -37,7 +37,7 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
   displayLanguageSelect = this.getPropertyObservable("displayLanguageSelect");
   dateFormat = this.getPropertyObservable("dateFormat");
 
-  private configService = inject(ConfigService);
+  private entityConfigReady = inject(EntityConfigReadyService);
 
   constructor() {
     const entityMapper = inject(EntityMapperService);
@@ -46,15 +46,16 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
 
     this.init();
 
-    // Wait for config schemas to be applied before loading from DB,
-    // so any config-defined SiteSettings fields are transformed correctly.
-    this.configService.configUpdates.pipe(take(1)).subscribe(() =>
+    // Wait for dynamic entity schemas to be applied before parsing/loading settings,
+    // so config-defined SiteSettings fields are transformed correctly.
+    this.entityConfigReady.setupCompleted$.pipe(take(1)).subscribe(() => {
+      this.initFromLocalStorage();
       super.startLoading().catch((err) => {
         const error = new Error("Failed to load site settings", { cause: err });
         error.name = "SiteSettingsLoadError";
         Logging.error(error);
-      }),
-    );
+      });
+    });
   }
 
   init() {
@@ -67,7 +68,6 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
     this.subscribeColorChanges("error");
     this.subscribeDateFormatChanges();
 
-    this.initFromLocalStorage();
     this.cacheInLocalStorage();
   }
 

--- a/src/app/features/dashboard-widgets/progress-dashboard-widget/progress-dashboard/progress-dashboard.component.spec.ts
+++ b/src/app/features/dashboard-widgets/progress-dashboard-widget/progress-dashboard/progress-dashboard.component.spec.ts
@@ -27,6 +27,7 @@ describe("ProgressDashboardComponent", () => {
   let component: ProgressDashboardComponent;
   let fixture: ComponentFixture<ProgressDashboardComponent>;
   let mockEntityMapper: EntityMapperMock;
+  let defaultLoadImplementation: EntityMapperMock["load"];
   let loadSpy: ReturnType<typeof vi.spyOn>;
   const mockDialog: MatDialogMock = {
     open: vi.fn().mockName("matDialog.open"),
@@ -56,13 +57,22 @@ describe("ProgressDashboardComponent", () => {
 
   beforeEach(() => {
     mockEntityMapper = TestBed.inject(EntityMapperService);
+    defaultLoadImplementation = mockEntityMapper.load.bind(mockEntityMapper);
     const mockConfig = {
       title: "test",
       parts: [],
       getId: vi.fn().mockReturnValue("test-id"),
     } as any as ProgressDashboardConfig;
 
-    loadSpy = vi.spyOn(mockEntityMapper, "load").mockResolvedValue(mockConfig);
+    loadSpy = vi
+      .spyOn(mockEntityMapper, "load")
+      .mockImplementation((entityType, id) => {
+        if (entityType === ProgressDashboardConfig) {
+          return Promise.resolve(mockConfig);
+        }
+
+        return defaultLoadImplementation(entityType, id);
+      });
     vi.spyOn(mockEntityMapper, "save").mockResolvedValue(undefined);
     fixture = TestBed.createComponent(ProgressDashboardComponent);
     component = fixture.componentInstance;
@@ -94,13 +104,25 @@ describe("ProgressDashboardComponent", () => {
   it("should retry loading the config after sync has finished", async () => {
     vi.useFakeTimers();
     try {
-      loadSpy.mockRejectedValue(new Error());
+      loadSpy.mockImplementation((entityType, id) => {
+        if (entityType === ProgressDashboardConfig) {
+          return Promise.reject(new Error());
+        }
+
+        return defaultLoadImplementation(entityType, id);
+      });
       fixture.componentRef.setInput("dashboardConfigId", "someId");
       fixture.detectChanges();
       await vi.advanceTimersByTimeAsync(0);
 
       const config = new ProgressDashboardConfig("someId");
-      loadSpy.mockResolvedValue(config);
+      loadSpy.mockImplementation((entityType, id) => {
+        if (entityType === ProgressDashboardConfig) {
+          return Promise.resolve(config);
+        }
+
+        return defaultLoadImplementation(entityType, id);
+      });
       mockSync.next(SyncState.COMPLETED);
 
       expect(component.data()).toEqual(config);
@@ -112,7 +134,13 @@ describe("ProgressDashboardComponent", () => {
   it("should create a new progress dashboard config if no configuration could be found after initial sync", async () => {
     vi.useFakeTimers();
     try {
-      loadSpy.mockRejectedValue(new Error());
+      loadSpy.mockImplementation((entityType, id) => {
+        if (entityType === ProgressDashboardConfig) {
+          return Promise.reject(new Error());
+        }
+
+        return defaultLoadImplementation(entityType, id);
+      });
       mockSync.next(SyncState.COMPLETED);
 
       fixture.componentRef.setInput("dashboardConfigId", "config-id");


### PR DESCRIPTION
- Sentry showed some errors related to SiteSettings failing to load / throwing errors because entity attributes couldn't be parsed. This gating tries to prevent that.

We assume a system is in a void or broken state if Config doc cannot be loaded. There is no need to try to load anything else unless the config is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure site settings, session initialization, and import/linkable actions wait for entity schema setup before loading data.

* **New Features**
  * Introduced a readiness signal to coordinate when dynamic entity schemas are considered ready at startup.

* **Tests**
  * Updated specs to use the readiness signal and refined test stubs for config/entity loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aam-Digital/ndb-core/pull/3989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->