### PR TITLE
refactor(Reporting): align frontend with canonical ReportConfig model

### DIFF
--- a/doc/compodoc_sources/summary.json
+++ b/doc/compodoc_sources/summary.json
@@ -129,7 +129,7 @@
       },
       {
         "title": "Create a Report",
-        "file": "how-to-guides/reports.md"
+        "file": "../../src/app/features/reports/README.md"
       },
       {
         "title": "Load and Save Data",

--- a/src/app/features/reporting/README.md
+++ b/src/app/features/reporting/README.md
@@ -13,14 +13,14 @@ There are currently two systems available to generate reports, both using the sa
 This feature requires the [aam-services backend](https://github.com/Aam-Digital/aam-services).
 It is based on [structured-query-service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
 (this creates a read-only copy of the data in the CouchDB and allows to run SQLite queries against it).
-SQS enables the possibility to create SQL based queries in reports.
+SQS enables the possibility to create SQL-based queries in reports.
 The SQS image is not available as open source and needs a licence. It is pulled from a private container registry.
 
 Follow the instructions on the _aam-services_ repository to set up and enable the API.
 
 ### Using AI agents to generate SQL Queries
 
-LLMs like ChatGPT or Cluade can generate Report queries for you.
+LLMs like ChatGPT or Claude can generate report queries for you.
 We have a [guide / context document for this](https://docs.google.com/document/d/13yxJkqqoA9tBTbld65Y1FYA51l0W057m4D1wvoCILeQ/edit?usp=sharing).
 
 ## Configuration

--- a/src/app/features/reporting/README.md
+++ b/src/app/features/reporting/README.md
@@ -8,50 +8,20 @@ There are currently two systems available to generate reports, both using the sa
 - SQL-based queries executed server-side using the SQS server
 - (legacy) client-side generator using the aggregation & query syntax below
 
-# SQL Reports
+## SQL Reports
 
-For this feature, we have integrated the (optional) [structured-query-service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
-(this creates a read-only copy of the data in the CouchDB and allows to run Sqlite queries against it).
+This feature requires the [aam-services backend](https://github.com/Aam-Digital/aam-services).
+It is based on [structured-query-service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
+(this creates a read-only copy of the data in the CouchDB and allows to run SQLite queries against it).
 SQS enables the possibility to create SQL based queries in reports.
-
 The SQS image is not available as open source and needs a licence. It is pulled from a private container registry.
 
-## Using Copilot to generate SQL Queries
+Follow the instructions on the _aam-services_ repository to set up and enable the API.
 
-```javascript
-// copy the full Config:CONFIG_ENTITY doc from the database
-// and use the following code to extract the entities as context for Copilot
-entities = Object.entries(x.data)
-  .filter(([k, v]) => k.startsWith("entity:"))
-  .map(([k, v]) => v);
-```
+### Using AI agents to generate SQL Queries
 
-Use the following prompt sample (for "v1" SQL reports, which have multiple columns as output):
-
-```text
-The database schema is defined in the entities.json file:
-[ "entity:<TYPE>", { attributes: { "<FIELD_NAME>": { ...FIELD_DETAILS } }}].
-
-- <TYPE> matches the table name in SQL.
-- <FIELD_NAME> matches the column name within that table.
-
-For some queries there are example snippets available: https://docs.google.com/document/d/14JqS6xgZzC1xHUogDho5n1kyNLzX1Eoyv6MeZtRejuM/edit?tab=t.0#heading=h.fgg5yam3yaf1
-
-
-Write a native SQL query (SQLite), no Angular or Typescript code.
-Output both a formatted SQL and also as a
-single line for easier copying (using single instead of double quotes; no semicolon at end).
-
-The query should output the following:
-
-All equipments with the following columns:
-- Description of Item
-- Specifications
-```
-
-## Deployment
-
-To activate it for an application, simply activate "aam-backend-service" profile (`COMPOSE_PROFILES=aam-backend-service`) in the applications `.env` file and run `docker compose up -d`.
+LLMs like ChatGPT or Cluade can generate Report queries for you.
+We have a [guide / context document for this](https://docs.google.com/document/d/13yxJkqqoA9tBTbld65Y1FYA51l0W057m4D1wvoCILeQ/edit?usp=sharing).
 
 ## Configuration
 
@@ -73,14 +43,17 @@ Some useful SQL query snippets for Aam Digital contexts are collected here: [Aam
   "_id": "ReportConfig:test-report",
   "title": "Test Report",
   "mode": "sql",
-  "aggregationDefinition": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c",
-  "neededArgs": []
+  "reportDefinition": [
+    {
+      "query": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c"
+    }
+  ]
 }
 ```
 
 #### SQL Report With Arguments
 
-Additional arguments for the query (like a from and to date parameter) can be used in the SQL query directly using "?". The "neededArgs" array defines what arguments are filled for the "?" placeholders in the given order.
+Use named placeholders in the SQL query (for example `$startDate` and `$endDate`) and map these args via `transformations`.
 
 ```json
 // app/ReportConfig:test-report
@@ -88,12 +61,59 @@ Additional arguments for the query (like a from and to date parameter) can be us
   "_id": "ReportConfig:test-report",
   "title": "Test Report",
   "mode": "sql",
-  "aggregationDefinition": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c WHERE created_at BETWEEN ? AND ?",
-  "neededArgs": ["from", "to"]
+  "transformations": {
+    "startDate": ["SQL_FROM_DATE"],
+    "endDate": ["SQL_TO_DATE"]
+  },
+  "reportDefinition": [
+    {
+      "query": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c WHERE created_at BETWEEN $startDate AND $endDate"
+    }
+  ]
 }
 ```
 
-# JSON-Query Reports (legacy)
+#### Nested SQL Report (Grouped)
+
+`reportDefinition` supports nested groups. Each item is either:
+
+- a query item: `{ "query": "SELECT ..." }`
+- or a group item: `{ "groupTitle": "...", "items": [...] }`
+
+Groups can contain queries and other groups recursively.
+
+The hierarchical SQL view is rendered as a `Name` + `Count` table.
+That means each row should represent one metric value (typically a single numeric column such as `COUNT(*) as count`).
+If a query returns multiple columns, only one value is shown as the row value and the other fields are used as row label details.
+
+```json
+// app/ReportConfig:test-report-grouped
+{
+  "_id": "ReportConfig:test-report-grouped",
+  "title": "Test Report Grouped",
+  "mode": "sql",
+  "reportDefinition": [
+    {
+      "query": "SELECT COUNT(*) as count FROM Child c"
+    },
+    {
+      "groupTitle": "By School Type",
+      "items": [
+        {
+          "query": "SELECT COUNT(*) as count FROM Child c JOIN School s ON s._id = c.schoolId WHERE s.privateSchool = 0"
+        },
+        {
+          "query": "SELECT COUNT(*) as count FROM Child c JOIN School s ON s._id = c.schoolId WHERE s.privateSchool = 1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+In the UI, grouped SQL reports are rendered as a hierarchical report view, while single-query SQL reports are shown as a flat table.
+
+### JSON-Query Reports (legacy)
 
 #### Aggregation structure
 

--- a/src/app/features/reporting/report-config.spec.ts
+++ b/src/app/features/reporting/report-config.spec.ts
@@ -1,0 +1,43 @@
+import { isHierarchicalReport, ReportEntity, SqlReport } from "./report-config";
+
+describe("isHierarchicalReport", () => {
+  it("returns false when the report is undefined", () => {
+    expect(isHierarchicalReport(undefined)).toBe(false);
+  });
+
+  it("returns false when the report has no reportDefinition (legacy v1)", () => {
+    const report = new ReportEntity() as SqlReport;
+    report.mode = "sql";
+
+    expect(isHierarchicalReport(report)).toBe(false);
+  });
+
+  it("returns false for a single ungrouped query (tabular)", () => {
+    const report = new ReportEntity() as SqlReport;
+    report.mode = "sql";
+    report.reportDefinition = [{ query: "SELECT a, b FROM foo" }];
+
+    expect(isHierarchicalReport(report)).toBe(false);
+  });
+
+  it("returns true when any item has a groupTitle", () => {
+    const report = new ReportEntity() as SqlReport;
+    report.mode = "sql";
+    report.reportDefinition = [
+      { groupTitle: "Group A", items: [{ query: "SELECT count(*) FROM foo" }] },
+    ];
+
+    expect(isHierarchicalReport(report)).toBe(true);
+  });
+
+  it("returns true when there is more than one top-level item", () => {
+    const report = new ReportEntity() as SqlReport;
+    report.mode = "sql";
+    report.reportDefinition = [
+      { query: "SELECT count(*) FROM foo" },
+      { query: "SELECT count(*) FROM bar" },
+    ];
+
+    expect(isHierarchicalReport(report)).toBe(true);
+  });
+});

--- a/src/app/features/reporting/report-config.ts
+++ b/src/app/features/reporting/report-config.ts
@@ -26,9 +26,10 @@ class ReportConfig extends Entity {
   @DatabaseField() mode?: string;
 
   /**
-   * version of ReportConfig syntax. Just relevant for SqlReports
+   * version of ReportConfig syntax. Just relevant for SqlReports.
+   * Omitted for canonical configs (backend normalizes legacy v1 docs on read).
    */
-  @DatabaseField() version?: number = 1;
+  @DatabaseField() version?: number;
 
   /**
    * (sql v1 only) list of arguments needed for the sql query. Placeholder "?" will be replaced.
@@ -39,7 +40,7 @@ class ReportConfig extends Entity {
   @DatabaseField() aggregationDefinitions: any[];
 
   /** (sql v1 only) the definition to calculate the report */
-  @DatabaseField() aggregationDefinition: string | undefined;
+  @DatabaseField() aggregationDefinition?: string;
 
   /**
    *  (sql v2 only) transformations that are applied to input variables (e.g. startDate, endDate)
@@ -109,19 +110,19 @@ export interface SqlReport extends ReportConfig {
   mode: "sql";
 
   /**
-   * version of the ReportConfiguration, currently 1 or 2
+   * Legacy version field. Omitted in canonical configs; backend normalizes on read.
    */
-  version: number;
+  version?: number;
 
   /**
-   * a valid SQL SELECT statements, can contain "?" placeholder for arguments (only v1)
+   * (v1 only) a valid SQL SELECT statement, can contain "?" or "$name" placeholders
    */
-  aggregationDefinition: string;
+  aggregationDefinition?: string;
 
   /**
-   * a list of arguments, passed into the sql statement (only v1)
+   * (v1 only) list of argument names passed into the sql statement
    */
-  neededArgs: string[];
+  neededArgs?: string[];
 
   /**
    * see ReportConfig docs

--- a/src/app/features/reporting/report-config.ts
+++ b/src/app/features/reporting/report-config.ts
@@ -26,12 +26,13 @@ class ReportConfig extends Entity {
   @DatabaseField() mode?: string;
 
   /**
-   * version of ReportConfig syntax. Just relevant for SqlReports.
+   * @deprecated (will be removed completely after server-side migration)
    * Omitted for canonical configs (backend normalizes legacy v1 docs on read).
    */
   @DatabaseField() version?: number;
 
   /**
+   * @deprecated (will be removed completely after server-side migration)
    * (sql v1 only) list of arguments needed for the sql query. Placeholder "?" will be replaced.
    */
   @DatabaseField() neededArgs?: string[] = [];
@@ -39,7 +40,10 @@ class ReportConfig extends Entity {
   /** (reporting/exporting only, in browser reports) the definitions to calculate the report's aggregations */
   @DatabaseField() aggregationDefinitions: any[];
 
-  /** (sql v1 only) the definition to calculate the report */
+  /**
+   * @deprecated (will be removed completely after server-side migration)
+   * (sql v1 only) the definition to calculate the report
+   */
   @DatabaseField() aggregationDefinition?: string;
 
   /**
@@ -110,16 +114,19 @@ export interface SqlReport extends ReportConfig {
   mode: "sql";
 
   /**
+   * @deprecated (will be removed completely after server-side migration)
    * Legacy version field. Omitted in canonical configs; backend normalizes on read.
    */
   version?: number;
 
   /**
+   * @deprecated (will be removed completely after server-side migration)
    * (v1 only) a valid SQL SELECT statement, can contain "?" or "$name" placeholders
    */
   aggregationDefinition?: string;
 
   /**
+   * @deprecated (will be removed completely after server-side migration)
    * (v1 only) list of argument names passed into the sql statement
    */
   neededArgs?: string[];
@@ -135,4 +142,26 @@ export interface SqlReport extends ReportConfig {
    *  see ReportConfig docs
    */
   reportDefinition: ReportDefinitionDto[];
+}
+
+/**
+ * Whether a report's results should be rendered as a hierarchical group/count
+ * table (`sql-v2-table`) rather than a flat tabular table (`object-table`).
+ *
+ * Derived purely from the canonical config structure (no version flag):
+ * a report is hierarchical when its `reportDefinition` contains a group
+ * (`groupTitle`) or more than one top-level item; otherwise it is tabular.
+ * Legacy v1 configs (normalized to a single ungrouped query) resolve to tabular.
+ */
+export function isHierarchicalReport(
+  report: ReportEntity | undefined,
+): boolean {
+  const reportDefinition = report?.reportDefinition;
+  if (!reportDefinition?.length) {
+    return false;
+  }
+  return (
+    reportDefinition.length > 1 ||
+    reportDefinition.some((item) => !!item.groupTitle)
+  );
 }

--- a/src/app/features/reporting/reporting/reporting.component.html
+++ b/src/app/features/reporting/reporting/reporting.component.html
@@ -109,14 +109,14 @@
   <app-report-row [rows]="data()"></app-report-row>
 }
 
-@if (
-  data()?.length > 0 &&
-  (mode() === "exporting" ||
-    (mode() === "sql" && currentReport()?.version !== 2))
-) {
+@if (data()?.length > 0 && mode() === "exporting") {
   <app-object-table [objects]="data()"></app-object-table>
 }
 
-@if (data()?.length > 0 && mode() === "sql" && currentReport()?.version === 2) {
+@if (data()?.length > 0 && mode() === "sql" && !isHierarchicalReport()) {
+  <app-object-table [objects]="sqlTableRows()"></app-object-table>
+}
+
+@if (data()?.length > 0 && mode() === "sql" && isHierarchicalReport()) {
   <app-sql-v2-table [reportData]="data()"></app-sql-v2-table>
 }

--- a/src/app/features/reporting/reporting/reporting.component.spec.ts
+++ b/src/app/features/reporting/reporting/reporting.component.spec.ts
@@ -384,17 +384,46 @@ describe("ReportingComponent", () => {
     expect(component.data()).toEqual([]);
   });
 
-  it("should return raw data for version 1 SQL reports", () => {
-    const mockData = [
+  it("should unwrap backend row-wrapping for non-hierarchical (tabular) SQL reports", () => {
+    const rows = [
       { child_gender: "M", child_name: "child1" },
       { child_gender: "X", child_name: "child2" },
     ];
 
     const report = new ReportEntity() as SqlReport;
     report.mode = "sql";
+    report.reportDefinition = [{ query: "SELECT child_gender, child_name" }];
+
+    // backend wraps each query's rows in an outer array: [[ {...}, {...} ]]
+    const result = component["getSqlExportableData"]([rows], report);
+
+    expect(result).toEqual(rows);
+  });
+
+  it("should expose unwrapped tabular rows for the object table", () => {
+    const rows = [{ child_name: "child1" }, { child_name: "child2" }];
+
+    component.data.set([rows]);
+
+    expect(component.sqlTableRows()).toEqual(rows);
+  });
+
+  it("should return CSV for hierarchical (grouped) SQL reports", () => {
+    const mockData = [{ value: 5 }];
+    const flattened = [{ label: "Group A", result: 5, level: 0 }];
+    mockSqlReportService.flattenData.mockReturnValue(flattened);
+    mockSqlReportService.getCsvforV2.mockReturnValue("csv-output");
+
+    const report = new ReportEntity() as SqlReport;
+    report.mode = "sql";
+    report.reportDefinition = [
+      { groupTitle: "Group A", items: [{ query: "SELECT count(*)" }] },
+    ];
 
     const result = component["getSqlExportableData"](mockData, report);
 
-    expect(result).toEqual(mockData);
+    expect(mockSqlReportService.flattenData).toHaveBeenCalledWith(mockData);
+    expect(mockSqlReportService.getCsvforV2).toHaveBeenCalledWith(flattened);
+    expect(result).toBe("csv-output");
   });
 });

--- a/src/app/features/reporting/reporting/reporting.component.ts
+++ b/src/app/features/reporting/reporting/reporting.component.ts
@@ -20,7 +20,7 @@ import { ReportRowComponent } from "./report-row/report-row.component";
 import { ObjectTableComponent } from "./object-table/object-table.component";
 import { DataTransformationService } from "../../../core/export/data-transformation-service/data-transformation.service";
 import { EntityMapperService } from "../../../core/entity/entity-mapper/entity-mapper.service";
-import { ReportEntity } from "../report-config";
+import { isHierarchicalReport, ReportEntity } from "../report-config";
 import {
   ReportCalculation,
   ReportCalculationError,
@@ -89,6 +89,10 @@ export class ReportingComponent {
   mode = computed<ReportEntity["mode"]>(
     () => this.currentReport()?.mode ?? "reporting",
   );
+  /** whether the current SQL report renders as a hierarchical group/count table */
+  isHierarchicalReport = computed(() =>
+    isHierarchicalReport(this.currentReport()),
+  );
 
   isLoading = signal(false);
   isError = signal(false);
@@ -103,6 +107,21 @@ export class ReportingComponent {
   });
 
   data = signal<any[]>([]);
+  /**
+   * Flat rows for the tabular `object-table` renderer.
+   *
+   * The backend wraps each query's result rows in an outer array (e.g. `[[ {..}, {..} ]]`),
+   * so a single-query (tabular) report arrives one level too deep. Flatten that wrapping
+   * into a plain row list; the hierarchical renderer keeps the nested shape via `flattenData`.
+   */
+  sqlTableRows = computed<any[]>(() => this.unwrapTabularRows(this.data()));
+
+  private unwrapTabularRows(data: any[]): any[] {
+    return (data ?? []).flatMap((item) =>
+      Array.isArray(item) ? item : [item],
+    );
+  }
+
   exportableData = computed<any>(() => {
     const data = this.data();
     if (data.length === 0) return undefined;
@@ -173,11 +192,11 @@ export class ReportingComponent {
     data: any[],
     report: ReportEntity | undefined,
   ): any {
-    return report?.version == 1
-      ? data
-      : this.sqlReportService.getCsvforV2(
+    return isHierarchicalReport(report)
+      ? this.sqlReportService.getCsvforV2(
           this.sqlReportService.flattenData(data),
-        );
+        )
+      : this.unwrapTabularRows(data);
   }
 
   private async getReportResults(
@@ -252,8 +271,7 @@ export class ReportingComponent {
       title: report.title,
       mode: report.mode,
     };
-    // explicitly map the relevant properties
-    if (report.version) reportDetails.version = report.version;
+    // explicitly map the relevant properties (canonical only; version is deprecated)
     if (report.reportDefinition)
       reportDetails.reportDefinition = report.reportDefinition;
     if (report.aggregationDefinition)

--- a/src/app/features/reporting/reporting/select-report/select-report.component.ts
+++ b/src/app/features/reporting/reporting/select-report/select-report.component.ts
@@ -106,18 +106,13 @@ export class SelectReportComponent {
     const report = this.selectedReport();
     if (!report) return false;
     if (report.mode !== "sql") return true;
-    if (report.version == 1 || report.version == undefined) {
-      return (
-        report.neededArgs.indexOf("from") !== -1 ||
-        report.neededArgs.indexOf("to") !== -1
-      );
-    } else if (report.version == 2) {
-      return (
-        !!report.transformations["startDate"] ||
-        !!report.transformations["endDate"]
-      );
-    }
-    return false;
+    // v1 configs use neededArgs; v2/canonical use transformations
+    return (
+      !!report.neededArgs?.find((a) => a === "from" || a === "startDate") ||
+      !!report.neededArgs?.find((a) => a === "to" || a === "endDate") ||
+      !!report.transformations?.["startDate"] ||
+      !!report.transformations?.["endDate"]
+    );
   });
 
   dateRangeFilterConfig = computed<DateFilter<any> | undefined>(() => {

--- a/src/app/features/reporting/sql-report/sql-report.service.ts
+++ b/src/app/features/reporting/sql-report/sql-report.service.ts
@@ -306,8 +306,9 @@ export class SqlReportService {
     from: Date,
     to: Date,
   ): boolean {
-    let argFrom = value.args["from"];
-    let argTo = value.args["to"];
+    // Backend stores args as "startDate"/"endDate" (canonical); legacy calculations may use "from"/"to"
+    const argFrom = value.args["startDate"] ?? value.args["from"];
+    const argTo = value.args["endDate"] ?? value.args["to"];
 
     if (!argFrom || !argTo) {
       return false;


### PR DESCRIPTION
- closes https://github.com/Aam-Digital/aam-services/issues/77

## Summary

Companion frontend changes for the aam-services backend refactor (Aam-Digital/aam-services#135) that consolidated ReportConfig handling into a single canonical model (dropping version-based branching).

- **`filterFromToDates` fix**: The backend now stores calculation args as `startDate`/`endDate` (canonical keys). The old lookup only checked `args["from"]`/`args["to"]`, so the service would never find an existing calculation and would create a new one on every query — fixed to check both key formats
- **`isDateRangeReport` simplification**: Removed version-based branching; now checks both `neededArgs` (v1) and `transformations` (v2/canonical) regardless of version, making it robust to any config shape
- **`SqlReport` interface cleanup**: `version`, `aggregationDefinition`, and `neededArgs` are now optional since canonical configs use `reportDefinition`/`transformations` instead
- **`ReportConfig.version` default removed**: Dropped the `= 1` default so new entities don't incorrectly tag canonical configs as v1

## Test plan

- [ ] `sql-report.service.spec.ts` — 7 tests pass (includes `filterFromToDates` behaviour)
- [ ] `select-report.component.spec.ts` — 7 tests pass (includes `isDateRangeReport` for all config shapes)
- [ ] Manual: trigger a SQL report calculation and verify it reuses an existing calculation on re-run rather than creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent report-type detection to choose hierarchical vs tabular rendering and export behavior.

* **Bug Fixes**
  * Support for both legacy and current date parameter names.
  * Corrected SQL export handling: tabular rows unwrapped and hierarchical reports flattened for CSV.

* **Tests**
  * Added tests covering report-type detection and export behaviors.

* **Documentation**
  * Updated reporting guide with new SQL Reports section and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->