### PR TITLE
fix(Admin UI): prevent invalid field IDs starting with underscore

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -95,8 +95,8 @@
               @if (fieldIdForm.hasError("pattern")) {
                 <mat-error>
                   <span i18n>
-                    Invalid ID pattern. Only letters, numbers, and underscores
-                    are allowed.</span
+                    Invalid ID: must start with a letter or number, and may only
+                    contain letters, numbers, and underscores.</span
                   >
                 </mat-error>
               }

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -462,4 +462,16 @@ describe("AdminEntityFieldComponent", () => {
       uniqueProperty: expect.any(String),
     });
   });
+
+  it("should reject a field ID starting with underscore", async () => {
+    component.fieldIdForm.setValue("_invalid");
+    await fixture.whenStable();
+    expect(component.fieldIdForm.errors).toEqual({
+      pattern: expect.anything(),
+    });
+
+    component.fieldIdForm.setValue("valid_id");
+    await fixture.whenStable();
+    expect(component.fieldIdForm.errors).toBeNull();
+  });
 });

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -167,7 +167,10 @@ export class AdminEntityFieldComponent implements OnInit {
 
   private initSettings() {
     this.fieldIdForm = this.fb.control(this.data.entitySchemaField.id, {
-      validators: [Validators.required, Validators.pattern(/^[a-zA-Z0-9_]*$/)],
+      validators: [
+        Validators.required,
+        Validators.pattern(/^[a-zA-Z0-9][a-zA-Z0-9_]*$/),
+      ],
       asyncValidators: [
         uniquePropertyValidator({
           getExistingValues: async () =>

--- a/src/app/utils/generate-id-from-label/generate-id-from-label.spec.ts
+++ b/src/app/utils/generate-id-from-label/generate-id-from-label.spec.ts
@@ -7,14 +7,11 @@ describe("generateIdFromLabel", () => {
       ["Name", "name"],
       ["FirstName", "firstName"],
       ["name of", "nameOf"],
-      ["test's name", "test_sName"],
+      ["test's name", "testsName"],
       ["name 123", "name123"],
       ["123 name", "123Name"], // this is possible in JavaScript
       ["trailing space ", "trailingSpace"],
-      [
-        "special chars !@#$%^&*()_+{}|:\"<>?`-=[]\\;',./",
-        "specialChars_______________________________",
-      ],
+      ["special chars !@#$%^&*()_+{}|:\"<>?`-=[]\\;',./", "specialChars"],
     ];
 
     for (const testCase of labelIdPairs) {

--- a/src/app/utils/generate-id-from-label/generate-id-from-label.ts
+++ b/src/app/utils/generate-id-from-label/generate-id-from-label.ts
@@ -1,6 +1,6 @@
 /**
  * Create a simplified id string from the given text.
- * This generates a camelCase string and replacing special characters with underscores.
+ * This generates a camelCase string, removing special characters.
  * @param label The input string to be transformed
  */
 export function generateIdFromLabel(label: string): string | undefined {
@@ -9,7 +9,7 @@ export function generateIdFromLabel(label: string): string | undefined {
   }
 
   return label
-    .replace(/[^a-zA-Z0-9\s]/g, "_")
+    .replace(/[^a-zA-Z0-9\s]/g, "")
     .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
       return index === 0 ? word.toLowerCase() : word.toUpperCase();
     })


### PR DESCRIPTION
closes #4032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Field ID validation now correctly requires IDs to start with a letter or number, preventing invalid patterns.
  * Updated field ID validation error message for clarity on allowed characters.

* **Tests**
  * Added test coverage for stricter field ID validation rules.
  * Updated ID generation tests to reflect improved special character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->