### PR TITLE
test(e2e): stabilize screenshots by hiding tooltips

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -62,15 +62,21 @@ export const test = base.extend<{ forEachTest: void }>({
   ],
 });
 
+const ARGOS_BASE_CSS =
+  // Hide Material tooltips, which can appear from prior hover interactions and cause flaky screenshots
+  ".mat-mdc-tooltip { display: none !important; }";
+
 export async function argosScreenshot(
   page: Page,
   name: string,
   options?: ArgosScreenshotOptions,
 ): Promise<void> {
   if (process.env.CI || process.env.SCREENSHOT) {
+    const { argosCSS, ...restOptions } = options || {};
     await argosScreenshotBase(page, name, {
       fullPage: true,
-      ...(options || {}),
+      argosCSS: argosCSS ? `${ARGOS_BASE_CSS}\n${argosCSS}` : ARGOS_BASE_CSS,
+      ...restOptions,
     });
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test screenshot helper to ensure consistent visual testing by hiding tooltips during screenshot capture in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->