### PR TITLE
fix(Public Forms): prevent unauthorized errors on slow-network form submission

### DIFF
--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -141,6 +141,80 @@ describe("RemotePouchDatabase tests", () => {
     expect(callCount).toBe(1);
   });
 
+  it("should retry AbortError for GET requests", async () => {
+    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
+    (database as any).FETCH_TIMEOUT_MS = 60000;
+
+    const abortError = new DOMException("Fetch is aborted", "AbortError");
+
+    let callCount = 0;
+    (PouchDB.fetch as Mock).mockImplementation(async () => {
+      callCount++;
+      if (callCount < 2) {
+        throw abortError;
+      }
+      return new Response("{}", { status: HttpStatusCode.Ok });
+    });
+
+    const result = await (database as any).fetchWithTransientRetry(
+      `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
+      { method: "GET", headers: new Headers() },
+    );
+
+    expect(callCount).toBe(2);
+    expect(result.status).toBe(HttpStatusCode.Ok);
+  });
+
+  it("should not retry write operations on any transient error (avoids create-then-unauthorized-update)", async () => {
+    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
+    (database as any).FETCH_TIMEOUT_MS = 60000;
+
+    const transientErrors = [
+      new DOMException("Fetch is aborted", "AbortError"),
+      new TypeError("Failed to fetch"), // e.g. ERR_NETWORK_CHANGED
+    ];
+
+    for (const method of ["PUT", "POST", "DELETE"]) {
+      for (const err of transientErrors) {
+        let callCount = 0;
+        (PouchDB.fetch as Mock).mockImplementation(async () => {
+          callCount++;
+          throw err;
+        });
+
+        await expect(
+          (database as any).fetchWithTransientRetry(
+            `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
+            { method, headers: new Headers() },
+          ),
+        ).rejects.toBe(err);
+
+        // writes are never auto-retried — the server may have already committed
+        expect(callCount).toBe(1);
+      }
+    }
+  });
+
+  it("should not impose the abort timeout on write operations", async () => {
+    // a tiny timeout would abort almost immediately if it were applied to writes
+    (database as any).FETCH_TIMEOUT_MS = 0;
+
+    let capturedOpts: any;
+    (PouchDB.fetch as Mock).mockImplementation(async (_url, opts) => {
+      capturedOpts = opts;
+      return new Response("{}", { status: HttpStatusCode.Ok });
+    });
+
+    const result = await (database as any).fetchWithTransientRetry(
+      `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
+      { method: "PUT", headers: new Headers() },
+    );
+
+    expect(result.status).toBe(HttpStatusCode.Ok);
+    // no AbortController signal is attached to writes, so a slow write is not aborted
+    expect(capturedOpts?.signal).toBeUndefined();
+  });
+
   it("should use periodic polling for changes feed instead of live long-polling", async () => {
     vi.useFakeTimers();
     try {

--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -100,10 +100,11 @@ export class RemotePouchDatabase extends PouchDatabase {
   private readonly TRANSIENT_ERROR_DELAY_MS = 2000;
 
   /**
-   * Per-request timeout in ms. If the server sends no response within this
-   * window, the fetch is aborted. This prevents long-idle connections from
-   * being killed unpredictably by Chrome (ERR_NETWORK_CHANGED) or proxies.
-   * PouchDB will retry from its last checkpoint on abort.
+   * Per-request timeout in ms for READ requests only. If the server sends no
+   * response within this window, the read fetch is aborted (and retried). This
+   * prevents long-idle connections from being killed unpredictably by Chrome
+   * (ERR_NETWORK_CHANGED) or proxies. Writes are never aborted or retried — see
+   * fetchWithTransientRetry.
    */
   private readonly FETCH_TIMEOUT_MS = 15000;
 
@@ -187,11 +188,28 @@ export class RemotePouchDatabase extends PouchDatabase {
    * Fetch with automatic retry for transient network errors (e.g. ERR_NETWORK_CHANGED)
    * and a per-request timeout to abort long-idle connections cleanly.
    * Network errors manifest as TypeErrors from the Fetch API.
+   *
+   * Only safe/idempotent read methods (GET, HEAD) get the abort timeout and the
+   * transient-error retry. Non-idempotent writes (PUT, POST, DELETE) are run
+   * exactly once with no client-side timeout: a write may have already committed
+   * on the server even when the client never sees the response, so aborting or
+   * retrying it can turn a "create" into a forbidden "update" (the public role is
+   * create-only) or create a duplicate — surfacing as spurious "unauthorized"
+   * errors. Letting the write run to completion ensures the client reliably
+   * learns the new `_rev`.
    */
   private async fetchWithTransientRetry(
     url: string,
     opts: RequestInit,
   ): Promise<Response> {
+    const method = (opts.method ?? "GET").toUpperCase();
+    const isSafeMethod = method === "GET" || method === "HEAD";
+
+    if (!isSafeMethod) {
+      // Write: run once, to completion, without abort timeout or retry.
+      return PouchDB.fetch(url, opts);
+    }
+
     for (let attempt = 0; ; attempt++) {
       const controller = new AbortController();
       const timeoutId = setTimeout(

--- a/src/app/features/public-form/public-form.component.spec.ts
+++ b/src/app/features/public-form/public-form.component.spec.ts
@@ -5,6 +5,7 @@ import { PublicFormComponent } from "./public-form.component";
 import { MockedTestingModule } from "../../utils/mocked-testing.module";
 import { PublicFormConfig } from "./public-form-config";
 import { ActivatedRoute, Router } from "@angular/router";
+import { FormGroup } from "@angular/forms";
 import { EntityFormService } from "../../core/common-components/entity-form/entity-form.service";
 import { ConfigService } from "../../core/config/config.service";
 import { EntityMapperService } from "../../core/entity/entity-mapper/entity-mapper.service";
@@ -208,6 +209,45 @@ describe("PublicFormComponent", () => {
       expect(
         component.entityFormEntries()[0].form.formGroup.get("name").value,
       ).toEqual("some name");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should skip already-saved entries on re-submit but still save the not-yet-saved ones", async () => {
+    vi.useFakeTimers();
+    try {
+      initComponent();
+      await vi.advanceTimersByTimeAsync(0);
+      const saveSpy = vi.spyOn(
+        TestBed.inject(EntityFormService),
+        "saveChanges",
+      );
+      saveSpy.mockResolvedValue(undefined);
+
+      // Simulate a partially-successful multi-entity submission being retried:
+      // the first entry was already saved (has a _rev, isNew === false), the
+      // second entry still needs saving.
+      const savedEntry = component.entityFormEntries()[0];
+      savedEntry.entity._rev = "1-abc";
+      const unsavedEntry = {
+        ...savedEntry,
+        entity: new TestEntity(),
+        form: { formGroup: new FormGroup({}) } as any,
+      };
+      component.entityFormEntries.set([savedEntry, unsavedEntry]);
+
+      await component.submit();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // the already-saved entity must be skipped (avoids a forbidden "update"
+      // for the create-only public role, and avoids creating a duplicate),
+      // while the not-yet-saved entity is still saved
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(saveSpy).toHaveBeenCalledWith(
+        unsavedEntry.form,
+        unsavedEntry.entity,
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/app/features/public-form/public-form.component.ts
+++ b/src/app/features/public-form/public-form.component.ts
@@ -100,6 +100,15 @@ export class PublicFormComponent<E extends Entity> implements OnInit {
     }
     try {
       for (const entry of this.entityFormEntries()) {
+        // Skip entries that were already saved in a previous submit attempt.
+        // After a successful save the entity has a `_rev` (isNew === false).
+        // Re-saving it would be treated as an "update" — which the "public"
+        // role is not permitted to do (it only has "create") — and would also
+        // risk creating a duplicate. This makes a retry after a partially
+        // successful submission resume cleanly instead of failing.
+        if (entry.entity && !entry.entity.isNew) {
+          continue;
+        }
         entry.entity.created = new UpdateMetadata(formMetadataBy);
         await this.entityFormService.saveChanges(entry.form, entry.entity);
       }


### PR DESCRIPTION
## Summary

Fixes #4043

Public form submissions intermittently failed with two Sentry errors on slow mobile connections (confirmed on `giz-ds4ji.aam-digital.app` baseline survey form):

- **AAM-DIGITAL-6Z4**: `Error: Could not save Individual: unauthorized` (~2300 occurrences)
- **AAM-DIGITAL-6P4**: `Error: Current user is not permitted to save these changes: []` (~21 occurrences)

Both share one root cause: **a committed `create` was re-attempted under a create-only public role**, turning it into a forbidden `update`.

**What was happening:**
1. `RemotePouchDatabase` applied a 15s `AbortController` timeout to *all* fetches including writes (PUT).
2. On a slow mobile connection: write reaches backend → document created in CouchDB → response is slow → 15s timeout fires → `AbortError` → `fetchWithTransientRetry` retried the same PUT.
3. Retry: backend finds existing document → checks *update* permission → public role is create-only → `401 Unauthorized`.
4. For multi-entity forms (Individual + outcomeSurvey + Participant2Event): first entity saves and gets a `_rev` → if the user manually re-submits, `assertPermissionsToSave` picks `action = "update"` for the already-saved entity → `rulesFor("update")` returns `[]` → throws synchronously (11ms after click, no network call).

## Changes

**`RemotePouchDatabase`** — writes are never aborted or auto-retried:
- Writes (PUT/POST/DELETE) run exactly once with no client-side timeout.
- Reads (GET/HEAD) keep the 15s abort + transient retry unchanged.
- Also closes the `TypeError` (ERR_NETWORK_CHANGED) retry path for writes.

**`PublicFormComponent.submit()`** — idempotent resume on retry:
- Entries with `entity._rev` set (`isNew === false`) are skipped in the submit loop.
- A partially-successful multi-entity submission can be safely retried without re-saving already-created entities as forbidden updates or duplicates.

## Test plan

- [x] `remote-pouch-database.spec.ts`: GET retries on AbortError and TypeError; PUT/POST/DELETE not retried on either; writes receive no AbortController signal (no timeout). (24 tests pass)
- [x] `public-form.component.spec.ts`: 2-entry case — already-saved entry skipped, not-yet-saved entry still saved. (18 tests pass)
- [x] Full database test suite: 102 tests pass.

## Accepted residual

A genuine connection *drop* after the server commits (response truly lost, not just slow) still leaves the client without a `_rev`; a manual retry can still 401. Backend idempotent create-replay (option B) fully closes this but is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database reliability by optimizing transient error handling—retries now apply only to read operations while write operations complete without client-side timeouts.
  * Form submissions now correctly skip re-saving entries already persisted from previous attempts, preventing unintended duplicate operations.

* **Tests**
  * Added test coverage for database transient error handling and form re-submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->