### PR TITLE
fix: do not log entity-select error caused by missing permissions

### DIFF
--- a/src/app/core/basic-datatypes/entity/edit-entity/edit-entity.component.ts
+++ b/src/app/core/basic-datatypes/entity/edit-entity/edit-entity.component.ts
@@ -293,7 +293,7 @@ export class EditEntityComponent<
     const entity = await this.entityMapperService
       .load<E>(type, selectedId)
       .catch((err: any) => {
-        if (err?.status === 404) {
+        if (err?.status === 404 || err?.status === 401) {
           Logging.debug(
             "[ENTITY_SELECT] Selected entity not found.",
             selectedId,


### PR DESCRIPTION
avoid all those "warning" logs for public forms and other cases where the user has limited access to certain entities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error handling for entity loading operations. HTTP 401 (Unauthorized) and 404 (Not Found) error responses now receive consistent treatment with improved logging practices and graceful failure behavior, ensuring more predictable application responses when attempting to access restricted or unavailable entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->