### PR TITLE
feat(Admin UI): Unused ConfigurableEnums should also give option to view/edit options

### DIFF
--- a/src/app/core/admin/config-cleanup/configurable-enum-cleanup/configurable-enum-cleanup.component.html
+++ b/src/app/core/admin/config-cleanup/configurable-enum-cleanup/configurable-enum-cleanup.component.html
@@ -112,6 +112,17 @@
                   <button
                     mat-icon-button
                     color="accent"
+                    (click)="openEnumOptions(unusedEnum.enumEntity, $event)"
+                    i18n-aria-label
+                    aria-label="Configure enum options"
+                    i18n-matTooltip
+                    matTooltip="Configure options"
+                  >
+                    <fa-icon icon="wrench"></fa-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="accent"
                     (click)="deleteEnum(unusedEnum)"
                     [disabled]="isDeleting(unusedEnum.enumEntity.getId(true))"
                     i18n-aria-label


### PR DESCRIPTION
- closes #4035

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an options action button to the unused ConfigurableEnums list, enabling users to access additional enum configuration actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->