### PR TITLE
Attendance field should display labels for each internal field

### DIFF
--- a/src/app/features/attendance/attendance-export.service.spec.ts
+++ b/src/app/features/attendance/attendance-export.service.spec.ts
@@ -36,7 +36,7 @@ class AttendanceTestEntity extends Entity {
   @DatabaseField({ label: "Linked Entity", dataType: "entity" })
   linkedEntity: string;
 
-  @DatabaseField({ label: "status" })
+  @DatabaseField({ label: "Status" })
   recordStatus: string;
 }
 
@@ -281,7 +281,7 @@ describe("AttendanceExportService", () => {
 
       const [rows] = mockDownloadService.triggerDownload.mock.calls[0];
       const statusColumns = Object.entries(rows[0]).filter(([key]) =>
-        key.startsWith("status"),
+        key.startsWith("Status"),
       );
 
       expect(statusColumns).toHaveLength(2);

--- a/src/app/features/attendance/edit-attendance/edit-attendance.component.html
+++ b/src/app/features/attendance/edit-attendance/edit-attendance.component.html
@@ -24,7 +24,7 @@
 
           <td>
             <mat-form-field class="margin-small">
-              <mat-label i18n="Attendance Status field label">Status</mat-label>
+              <mat-label>{{ statusFieldConfig().label }}</mat-label>
               <app-edit-configurable-enum
                 [formControl]="getStatusControl(item.participant)"
                 [formFieldConfig]="statusFieldConfig()"
@@ -34,7 +34,7 @@
 
           <td class="full-width">
             <mat-form-field class="adjust-top margin-small">
-              <mat-label i18n>Remarks</mat-label>
+              <mat-label>{{ remarksLabel() }}</mat-label>
               <input
                 #inputElement
                 matInput
@@ -87,14 +87,14 @@
 
           <div class="attendance-item--content">
             <mat-form-field class="margin-small">
-              <mat-label i18n="Attendance Status field label">Status</mat-label>
+              <mat-label>{{ statusFieldConfig().label }}</mat-label>
               <app-edit-configurable-enum
                 [formControl]="getStatusControl(item.participant)"
                 [formFieldConfig]="statusFieldConfig()"
               ></app-edit-configurable-enum>
             </mat-form-field>
             <mat-form-field>
-              <mat-label i18n>Remarks</mat-label>
+              <mat-label>{{ remarksLabel() }}</mat-label>
               <input
                 #inputElement
                 matInput

--- a/src/app/features/attendance/edit-attendance/edit-attendance.component.html
+++ b/src/app/features/attendance/edit-attendance/edit-attendance.component.html
@@ -24,6 +24,7 @@
 
           <td>
             <mat-form-field class="margin-small">
+              <mat-label i18n="Attendance Status field label">Status</mat-label>
               <app-edit-configurable-enum
                 [formControl]="getStatusControl(item.participant)"
                 [formFieldConfig]="statusFieldConfig()"

--- a/src/app/features/attendance/edit-attendance/edit-attendance.component.spec.ts
+++ b/src/app/features/attendance/edit-attendance/edit-attendance.component.spec.ts
@@ -59,6 +59,33 @@ describe("EditAttendanceComponent", () => {
     expect(elements).toHaveLength(2);
   });
 
+  it("should label the status and remarks fields from the embedded schema", () => {
+    const labels = fixture.debugElement
+      .queryAll(By.css("mat-label"))
+      .map((l) => l.nativeElement.textContent.trim());
+
+    expect(labels).toContain("Status");
+    expect(labels).toContain("Remarks");
+  });
+
+  it("should use the status label overwritten in the field config", () => {
+    fixture.componentRef.setInput("formFieldConfig", {
+      id: "attendance",
+      additional: {
+        participant: { dataType: "entity", additional: "TestEntity" },
+        status: { label: "Anwesenheit" },
+      },
+    });
+    fixture.detectChanges();
+
+    const labels = fixture.debugElement
+      .queryAll(By.css("mat-label"))
+      .map((l) => l.nativeElement.textContent.trim());
+
+    expect(labels).toContain("Anwesenheit");
+    expect(labels).not.toContain("Status");
+  });
+
   it("should add a participant when addParticipant is called", () => {
     component.addParticipant("child3");
     expect(attendanceForm.value).toHaveLength(3);

--- a/src/app/features/attendance/edit-attendance/edit-attendance.component.ts
+++ b/src/app/features/attendance/edit-attendance/edit-attendance.component.ts
@@ -97,8 +97,18 @@ export class EditAttendanceComponent
   statusFieldConfig = computed<FormFieldConfig>(() => ({
     id: "status",
     dataType: "configurable-enum",
+    label:
+      this.formFieldConfig()?.additional?.status?.label ??
+      AttendanceItem.schema.get("status")?.label,
     additional: this.statusEnumId(),
   }));
+
+  /** Label for the remarks field, overridable via the field config */
+  remarksLabel = computed(
+    () =>
+      this.formFieldConfig()?.additional?.remarks?.label ??
+      AttendanceItem.schema.get("remarks")?.label,
+  );
 
   /** FormFieldConfig for the internal entity autocomplete */
   participantFieldConfig = computed<FormFieldConfig>(() => ({

--- a/src/app/features/attendance/model/attendance-item.ts
+++ b/src/app/features/attendance/model/attendance-item.ts
@@ -14,6 +14,7 @@ export class AttendanceItem {
 
   private _status: AttendanceStatusType;
   @DatabaseField({
+    label: $localize`:Attendance status field label:Status`,
     dataType: "configurable-enum",
     additional: ATTENDANCE_STATUS_CONFIG_ID,
   })
@@ -44,7 +45,10 @@ export class AttendanceItem {
   })
   participant?: string;
 
-  @DatabaseField() remarks: string;
+  @DatabaseField({
+    label: $localize`:Attendance remarks field label:Remarks`,
+  })
+  remarks: string;
 
   constructor(
     status: AttendanceStatusType = NullAttendanceStatusType,


### PR DESCRIPTION
- closes  #4016

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Localized the “Status” and “Remarks” field labels for attendance.
  * Improved label rendering so custom per-form labels (when provided) are shown consistently on both desktop and mobile, with sensible defaults otherwise.
* **Testing**
  * Added coverage to verify default and overridden “Status”/“Remarks” labels render correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->