### PR TITLE
feat(Export): export address parts as separate columns

### DIFF
--- a/src/app/core/export/download-service/download.service.spec.ts
+++ b/src/app/core/export/download-service/download.service.spec.ts
@@ -13,6 +13,8 @@ import { EntityMapperService } from "app/core/entity/entity-mapper/entity-mapper
 import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
 import { GeoLocation } from "app/features/location/geo-location";
+import { LocationDatatype } from "app/features/location/location.datatype";
+import { GeoService } from "app/features/location/geo.service";
 import { ConfigurableEnumValue } from "app/core/basic-datatypes/configurable-enum/configurable-enum.types";
 import { Papa } from "ngx-papaparse";
 import { parse, unparse } from "papaparse";
@@ -66,6 +68,15 @@ describe("DownloadService", () => {
         {
           provide: DefaultDatatype,
           useClass: AttendanceDatatype,
+          multi: true,
+        },
+        {
+          provide: GeoService,
+          useValue: { enrichGeoLocation: (loc: GeoLocation) => loc },
+        },
+        {
+          provide: DefaultDatatype,
+          useClass: LocationDatatype,
           multi: true,
         },
         {
@@ -428,6 +439,35 @@ describe("DownloadService", () => {
     expect(rows[0]).toContain("School (readable)");
     expect(rows[1]).toContain(testSchool.getId());
     expect(rows[1]).toContain(testSchool.toString());
+  });
+
+  it("should add separate columns for each address part of a location field", async () => {
+    class XlsxLocationTestEntity extends Entity {
+      @DatabaseField({ dataType: LocationDatatype.dataType, label: "Address" })
+      address: GeoLocation;
+    }
+
+    const testEntity = new XlsxLocationTestEntity();
+    testEntity.address = {
+      locationString: "Impact Hub, Rollbergstraße 28A, 12053 Berlin",
+      road: "Rollbergstraße",
+      house_number: "28A",
+      postcode: "12053",
+      city: "Berlin",
+    };
+
+    const rows = await service.prepareExportData([testEntity]);
+
+    expect(rows[0]).toContain("Address");
+    expect(rows[0]).toContain("Address (street)");
+    expect(rows[0]).toContain("Address (house number)");
+    expect(rows[0]).toContain("Address (postcode)");
+    expect(rows[0]).toContain("Address (city)");
+    expect(rows[1]).toContain("Impact Hub, Rollbergstraße 28A, 12053 Berlin");
+    expect(rows[1]).toContain("Rollbergstraße");
+    expect(rows[1]).toContain("28A");
+    expect(rows[1]).toContain("12053");
+    expect(rows[1]).toContain("Berlin");
   });
 
   it("should return empty rows array for empty data in export", async () => {

--- a/src/app/core/export/download-service/download.service.spec.ts
+++ b/src/app/core/export/download-service/download.service.spec.ts
@@ -16,8 +16,6 @@ import { DateWithAge } from "../../basic-datatypes/date-with-age/dateWithAge";
 import { calculateAge } from "../../../utils/utils";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
 import { GeoLocation } from "app/features/location/geo-location";
-import { LocationDatatype } from "app/features/location/location.datatype";
-import { GeoService } from "app/features/location/geo.service";
 import { ConfigurableEnumValue } from "app/core/basic-datatypes/configurable-enum/configurable-enum.types";
 import { Papa } from "ngx-papaparse";
 import { parse, unparse } from "papaparse";
@@ -71,15 +69,6 @@ describe("DownloadService", () => {
         {
           provide: DefaultDatatype,
           useClass: AttendanceDatatype,
-          multi: true,
-        },
-        {
-          provide: GeoService,
-          useValue: { enrichGeoLocation: (loc: GeoLocation) => loc },
-        },
-        {
-          provide: DefaultDatatype,
-          useClass: LocationDatatype,
           multi: true,
         },
         {
@@ -447,35 +436,6 @@ describe("DownloadService", () => {
     expect(rows[0]).toContain("School (readable)");
     expect(rows[1]).toContain(testSchool.getId());
     expect(rows[1]).toContain(testSchool.toString());
-  });
-
-  it("should add separate columns for each address part of a location field", async () => {
-    class XlsxLocationTestEntity extends Entity {
-      @DatabaseField({ dataType: LocationDatatype.dataType, label: "Address" })
-      address: GeoLocation;
-    }
-
-    const testEntity = new XlsxLocationTestEntity();
-    testEntity.address = {
-      locationString: "Impact Hub, Rollbergstraße 28A, 12053 Berlin",
-      road: "Rollbergstraße",
-      house_number: "28A",
-      postcode: "12053",
-      city: "Berlin",
-    };
-
-    const rows = await service.prepareExportData([testEntity]);
-
-    expect(rows[0]).toContain("Address");
-    expect(rows[0]).toContain("Address (street)");
-    expect(rows[0]).toContain("Address (house number)");
-    expect(rows[0]).toContain("Address (postcode)");
-    expect(rows[0]).toContain("Address (city)");
-    expect(rows[1]).toContain("Impact Hub, Rollbergstraße 28A, 12053 Berlin");
-    expect(rows[1]).toContain("Rollbergstraße");
-    expect(rows[1]).toContain("28A");
-    expect(rows[1]).toContain("12053");
-    expect(rows[1]).toContain("Berlin");
   });
 
   it("should export a non-empty age column for date-with-age fields", async () => {

--- a/src/app/features/location/location.datatype.spec.ts
+++ b/src/app/features/location/location.datatype.spec.ts
@@ -307,23 +307,26 @@ describe("Schema data type: location", () => {
     expect(columns[4].resolveValue(value, schemaField)).toBe("Berlin");
   });
 
-  it("should fall back to geoLookup address parts when top-level parts are missing", () => {
+  it("should export the address parts that transformToObjectFormat flattens from geoLookup", () => {
     const schemaField = {
       id: "address",
       label: "Address",
     } as EntitySchemaField;
     const columns = service.getExportColumns(schemaField);
-    const value: GeoLocation = {
+
+    // raw value as stored before enrichment: only geoLookup.address is populated,
+    // postcode is numeric and the city is a "village"
+    const value = service.transformToObjectFormat({
       locationString: "Impact Hub, Rollbergstraße 28A, 12053 Berlin",
       geoLookup: {
         address: {
           road: "Rollbergstraße",
           house_number: "28A",
-          postcode: "12053",
-          city: "Berlin",
+          postcode: 12053,
+          village: "Berlin",
         },
-      } as OpenStreetMapsSearchResult,
-    };
+      } as unknown as OpenStreetMapsSearchResult,
+    });
 
     expect(columns[1].resolveValue(value, schemaField)).toBe("Rollbergstraße");
     expect(columns[2].resolveValue(value, schemaField)).toBe("28A");

--- a/src/app/features/location/location.datatype.spec.ts
+++ b/src/app/features/location/location.datatype.spec.ts
@@ -3,6 +3,7 @@ import { of, throwError } from "rxjs";
 import { GeoLocation, enrichGeoLocation } from "./geo-location";
 import { OpenStreetMapsSearchResult, GeoService } from "./geo.service";
 import { LocationDatatype } from "./location.datatype";
+import { EntitySchemaField } from "../../core/entity/schema/entity-schema-field";
 
 describe("Schema data type: location", () => {
   let service: LocationDatatype;
@@ -264,5 +265,84 @@ describe("Schema data type: location", () => {
     };
 
     expect(service.transformToObjectFormat(location)).toEqual(location);
+  });
+
+  it("should not return any export columns when the field has no label", () => {
+    expect(
+      service.getExportColumns({ id: "address" } as EntitySchemaField),
+    ).toEqual([]);
+  });
+
+  it("should export the display name plus separate columns for each address part", () => {
+    const schemaField = {
+      id: "address",
+      label: "Address",
+    } as EntitySchemaField;
+    const columns = service.getExportColumns(schemaField);
+
+    expect(columns.map((c) => c.keySuffix)).toEqual([
+      "",
+      "_street",
+      "_house_number",
+      "_postcode",
+      "_city",
+    ]);
+    expect(columns[0].label).toBe("Address");
+    expect(columns.slice(1).every((c) => c.label.startsWith("Address"))).toBe(
+      true,
+    );
+
+    const value: GeoLocation = {
+      locationString: "Impact Hub, Rollbergstraße 28A, 12053 Berlin",
+      road: "Rollbergstraße",
+      house_number: "28A",
+      postcode: "12053",
+      city: "Berlin",
+    };
+
+    expect(columns[0].resolveValue(value, schemaField)).toBe(value);
+    expect(columns[1].resolveValue(value, schemaField)).toBe("Rollbergstraße");
+    expect(columns[2].resolveValue(value, schemaField)).toBe("28A");
+    expect(columns[3].resolveValue(value, schemaField)).toBe("12053");
+    expect(columns[4].resolveValue(value, schemaField)).toBe("Berlin");
+  });
+
+  it("should fall back to geoLookup address parts when top-level parts are missing", () => {
+    const schemaField = {
+      id: "address",
+      label: "Address",
+    } as EntitySchemaField;
+    const columns = service.getExportColumns(schemaField);
+    const value: GeoLocation = {
+      locationString: "Impact Hub, Rollbergstraße 28A, 12053 Berlin",
+      geoLookup: {
+        address: {
+          road: "Rollbergstraße",
+          house_number: "28A",
+          postcode: "12053",
+          city: "Berlin",
+        },
+      } as OpenStreetMapsSearchResult,
+    };
+
+    expect(columns[1].resolveValue(value, schemaField)).toBe("Rollbergstraße");
+    expect(columns[2].resolveValue(value, schemaField)).toBe("28A");
+    expect(columns[3].resolveValue(value, schemaField)).toBe("12053");
+    expect(columns[4].resolveValue(value, schemaField)).toBe("Berlin");
+  });
+
+  it("should resolve missing address parts to undefined", () => {
+    const schemaField = {
+      id: "address",
+      label: "Address",
+    } as EntitySchemaField;
+    const partColumns = service.getExportColumns(schemaField).slice(1);
+
+    for (const column of partColumns) {
+      expect(column.resolveValue(undefined, schemaField)).toBeUndefined();
+      expect(
+        column.resolveValue({ locationString: "x" }, schemaField),
+      ).toBeUndefined();
+    }
   });
 });

--- a/src/app/features/location/location.datatype.ts
+++ b/src/app/features/location/location.datatype.ts
@@ -27,6 +27,12 @@ export class LocationDatatype extends DefaultDatatype<
    * Export the human-readable location string (default column) plus separate
    * columns for the individual address parts (street, house number, postcode, city)
    * so they can be used flexibly for mail merge and similar processes (see #3715).
+   *
+   * The address parts are read from the flat top-level fields, which
+   * {@link transformToObjectFormat} / {@link importMapFunction} populate via
+   * `enrichGeoLocation` (copying `geoLookup.address` up, folding village/town
+   * into city and stringifying postcode). Every value reaching export is
+   * therefore already enriched, so no `geoLookup.address` fallback is needed.
    */
   override getExportColumns(
     schemaField: EntitySchemaField,
@@ -56,30 +62,22 @@ export class LocationDatatype extends DefaultDatatype<
       part(
         "_street",
         $localize`:Location export column:street`,
-        (value) => value.road ?? value.geoLookup?.address?.road,
+        (value) => value.road,
       ),
       part(
         "_house_number",
         $localize`:Location export column:house number`,
-        (value) => value.house_number ?? value.geoLookup?.address?.house_number,
+        (value) => value.house_number,
       ),
       part(
         "_postcode",
         $localize`:Location export column:postcode`,
-        (value) =>
-          value.postcode ??
-          (value.geoLookup?.address?.postcode != null
-            ? String(value.geoLookup.address.postcode)
-            : undefined),
+        (value) => value.postcode,
       ),
       part(
         "_city",
         $localize`:Location export column:city`,
-        (value) =>
-          value.city ??
-          value.geoLookup?.address?.city ??
-          value.geoLookup?.address?.village ??
-          value.geoLookup?.address?.town,
+        (value) => value.city,
       ),
     ];
   }

--- a/src/app/features/location/location.datatype.ts
+++ b/src/app/features/location/location.datatype.ts
@@ -1,9 +1,13 @@
 import { Injectable, inject } from "@angular/core";
 import { lastValueFrom } from "rxjs";
-import { DefaultDatatype } from "../../core/entity/default-datatype/default.datatype";
+import {
+  DefaultDatatype,
+  ExportColumnMapping,
+} from "../../core/entity/default-datatype/default.datatype";
 import { GeoLocation } from "./geo-location";
 import { OpenStreetMapsSearchResult, GeoService } from "./geo.service";
 import { LocationImportConfig } from "./location-import-config/location-import-config.component";
+import { EntitySchemaField } from "../../core/entity/schema/entity-schema-field";
 
 @Injectable()
 export class LocationDatatype extends DefaultDatatype<
@@ -18,6 +22,67 @@ export class LocationDatatype extends DefaultDatatype<
   override editComponent = "EditLocation";
   override viewComponent = "ViewLocation";
   override importConfigComponent = "LocationImportConfig";
+
+  /**
+   * Export the human-readable location string (default column) plus separate
+   * columns for the individual address parts (street, house number, postcode, city)
+   * so they can be used flexibly for mail merge and similar processes (see #3715).
+   */
+  override getExportColumns(
+    schemaField: EntitySchemaField,
+  ): ExportColumnMapping<GeoLocation>[] {
+    if (!schemaField.label) {
+      return [];
+    }
+
+    const label = schemaField.label;
+    const part = (
+      keySuffix: string,
+      partLabel: string,
+      pick: (value: GeoLocation) => string | undefined,
+    ): ExportColumnMapping<GeoLocation> => ({
+      keySuffix,
+      label: `${label} (${partLabel})`,
+      resolveValue: (value) => (value ? pick(value) : undefined),
+    });
+
+    return [
+      {
+        keySuffix: "",
+        label,
+        // return the whole object so the CSV/XLSX transformation extracts the locationString
+        resolveValue: (value) => value,
+      },
+      part(
+        "_street",
+        $localize`:Location export column:street`,
+        (value) => value.road ?? value.geoLookup?.address?.road,
+      ),
+      part(
+        "_house_number",
+        $localize`:Location export column:house number`,
+        (value) => value.house_number ?? value.geoLookup?.address?.house_number,
+      ),
+      part(
+        "_postcode",
+        $localize`:Location export column:postcode`,
+        (value) =>
+          value.postcode ??
+          (value.geoLookup?.address?.postcode != null
+            ? String(value.geoLookup.address.postcode)
+            : undefined),
+      ),
+      part(
+        "_city",
+        $localize`:Location export column:city`,
+        (value) =>
+          value.city ??
+          value.geoLookup?.address?.city ??
+          value.geoLookup?.address?.village ??
+          value.geoLookup?.address?.town,
+      ),
+    ];
+  }
 
   override transformToObjectFormat(value: GeoLocation): GeoLocation {
     if (typeof value !== "object") {


### PR DESCRIPTION
- closes #3715

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## What changed
The `location` datatype now contributes separate export columns for the individual address parts, in addition to the existing display-name column. For a field labelled `Address` the export produces:

| Column | Value |
| --- | --- |
| `Address` | full display name / location string (unchanged) |
| `Address (street)` | `road` |
| `Address (house number)` | `house_number` |
| `Address (postcode)` | `postcode` |
| `Address (city)` | `city` (falls back to village/town) |

Parts read the flattened `GeoLocation` fields and fall back to `geoLookup.address.*`. This reuses the same multi-column mechanism already used for entity-reference fields (`getExportColumns`). Only the default list/spreadsheet export is affected; the config-driven report builder is unchanged.

## Manual testing steps
1. Open a record type that has a **location/address** field (e.g. a Child or School with an address) and make sure at least one record has a looked-up address with street, house number, postcode and city.
2. Go to the entity list of that type.
3. Click **Export Data** → choose **CSV** (repeat for **XLSX**).
4. Open the downloaded file and confirm:
   - the original address column is still present with the full location string, **and**
   - there are 4 new columns: `<Label> (street)`, `<Label> (house number)`, `<Label> (postcode)`, `<Label> (city)`, each filled with the matching part.
5. Check a record whose address has **no** geo-lookup / missing parts → the part columns are empty (not errors), display-name column still shows the manual string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Location fields now export with separate CSV/XLSX columns for each address component (street, house number, postcode, city), alongside a column containing the complete, human-readable address.

* **Tests**
  * Added/updated unit coverage to confirm export column generation only when a field label is present, correct label/key suffixes for address parts, and expected handling of missing/undefined location data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->