### PR TITLE
 fix: exclude archived participants from created event record

### DIFF
--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -45,7 +45,8 @@ describe("RollCallComponent", () => {
 
   let participant1: TestEntity,
     participant2: TestEntity,
-    participant3: TestEntity;
+    participant3: TestEntity,
+    archivedParticipant: TestEntity;
 
   let mockEnumService: any;
 
@@ -68,6 +69,8 @@ describe("RollCallComponent", () => {
     participant1 = new TestEntity("child1");
     participant2 = new TestEntity("child2");
     participant3 = new TestEntity("child3");
+    archivedParticipant = new TestEntity("archivedChild");
+    archivedParticipant.inactive = true;
 
     mockEnumService = {
       getEnumValues: vi
@@ -84,7 +87,12 @@ describe("RollCallComponent", () => {
         FontAwesomeTestingModule,
       ],
       providers: [
-        ...mockEntityMapperProvider([participant1, participant2, participant3]),
+        ...mockEntityMapperProvider([
+          participant1,
+          participant2,
+          participant3,
+          archivedParticipant,
+        ]),
         { provide: EntityRegistry, useValue: entityRegistry },
         EntitySchemaService,
         { provide: ConfigurableEnumService, useValue: mockEnumService },
@@ -199,10 +207,6 @@ describe("RollCallComponent", () => {
   });
 
   it("should exclude archived participants from event attendanceItems by default", async () => {
-    const archivedParticipant = new TestEntity("archivedChild");
-    archivedParticipant.inactive = true;
-    await TestBed.inject(EntityMapperService).save(archivedParticipant);
-
     const note = new Note();
     addParticipant(note, participant1);
     addParticipant(note, archivedParticipant);
@@ -222,8 +226,9 @@ describe("RollCallComponent", () => {
 
     expect(component.participants()).toEqual([participant1]);
     expect(component.inactiveParticipants()).toEqual([archivedParticipant]);
-    expect(note.childrenAttendance).toHaveLength(1);
-    expect(note.childrenAttendance[0].participant).toBe(participant1.getId());
+    const attendanceItems = component.event()!.attendanceItems;
+    expect(attendanceItems).toHaveLength(1);
+    expect(attendanceItems[0].participant).toBe(participant1.getId());
   });
 
   it("should correctly assign the attendance", async () => {

--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -198,6 +198,34 @@ describe("RollCallComponent", () => {
     ).toBe(false);
   });
 
+  it("should exclude archived participants from event attendanceItems by default", async () => {
+    const archivedParticipant = new TestEntity("archivedChild");
+    archivedParticipant.inactive = true;
+    await TestBed.inject(EntityMapperService).save(archivedParticipant);
+
+    const note = new Note();
+    addParticipant(note, participant1);
+    addParticipant(note, archivedParticipant);
+
+    fixture.componentRef.setInput(
+      "eventEntity",
+      new EventWithAttendance(
+        note,
+        "childrenAttendance",
+        "date",
+        "relatesTo",
+        "authors",
+        undefined,
+      ),
+    );
+    await stabilize();
+
+    expect(component.participants()).toEqual([participant1]);
+    expect(component.inactiveParticipants()).toEqual([archivedParticipant]);
+    expect(note.childrenAttendance).toHaveLength(1);
+    expect(note.childrenAttendance[0].participant).toBe(participant1.getId());
+  });
+
   it("should correctly assign the attendance", async () => {
     const note = new Note("noteWithAttendance");
     addParticipant(note, participant1);

--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -318,11 +318,11 @@ export class RollCallComponent {
         continue;
       }
 
-      validAttendanceItems.push(attendanceItem);
       attendanceMap[participantId] = attendanceItem;
 
       if (participant.isActive) {
         active.push(participant);
+        validAttendanceItems.push(attendanceItem);
       } else {
         inactive.push(participant);
       }
@@ -445,6 +445,13 @@ export class RollCallComponent {
       $localize`This event has some participants who are "archived". We automatically remove them from the attendance list for you. Do you want to also include archived participants for this event?`,
     );
     if (confirmation) {
+      const event = this.event();
+      if (event) {
+        const inactiveItems = this.inactiveParticipants()
+          .map((p) => this.attendanceByParticipant()[p.getId()])
+          .filter((item): item is AttendanceItem => item !== undefined);
+        event.attendanceItems = [...event.attendanceItems, ...inactiveItems];
+      }
       this.participants.update((p) => [...p, ...this.inactiveParticipants()]);
       this.inactiveParticipants.set([]);
       this.sortParticipants();


### PR DESCRIPTION
- closes https://github.com/Aam-Digital/ndb-core/issues/4071

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

## What we fixed

Bug location: roll-call.component.ts — loadParticipants() was adding all loaded participants (active + archived) to validAttendanceItems, which gets persisted as event.attendanceItems. So when the event was saved/viewed, archived participants appeared in it even though the roll-call UI had hidden them.

## Changes made

roll-call.component.ts — 2 fixes:

1. loadParticipants(): Moved validAttendanceItems.push(attendanceItem) inside the if (participant.isActive) block — archived participants are now excluded from the event's attendance items from the start.
2. includeInactive(): When the user opts in to include archived participants, their AttendanceItems are now also added back to event.attendanceItems (not just to the display signal) — so they'll be properly persisted if the user chooses to include them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archived participants are now properly separated from active participants, allowing selective inclusion when needed.

* **Tests**
  * Added test coverage verifying correct filtering and handling of archived participants in roll-call functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->