### PR TITLE
feat: add toggle to show only fields with differences in merge view

### DIFF
--- a/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.html
+++ b/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.html
@@ -13,7 +13,7 @@
             [entityConstructor]="entityConstructor"
           />
         }
-        @for (field of fieldsToMerge; track field.id) {
+        @for (field of filteredFieldsToMerge(); track field.id) {
           <div class="label-cell">
             <strong>{{ field.label }}</strong>
           </div>
@@ -48,6 +48,12 @@
   >
     Merge
   </button>
+  <mat-slide-toggle
+    [checked]="showOnlyDifferences()"
+    (change)="showOnlyDifferences.set($event.checked)"
+  >
+    <span i18n>Only show fields with differences</span>
+  </mat-slide-toggle>
   @if (mergeForm?.formGroup.invalid) {
     <mat-error i18n>
       The data you selected to merge is invalid, please check the fields in the

--- a/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.scss
+++ b/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.scss
@@ -43,5 +43,5 @@
 }
 
 mat-dialog-actions mat-slide-toggle {
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }

--- a/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.scss
+++ b/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.scss
@@ -41,3 +41,7 @@
     }
   }
 }
+
+mat-dialog-actions mat-slide-toggle {
+  margin-left: 1rem;
+}

--- a/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.ts
+++ b/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.ts
@@ -4,8 +4,10 @@ import {
   ChangeDetectorRef,
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   OnInit,
+  signal,
   viewChild,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
@@ -18,6 +20,7 @@ import {
   MatDialogRef,
 } from "@angular/material/dialog";
 import { MatError, MatFormFieldModule } from "@angular/material/form-field";
+import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { ConfirmationDialogService } from "app/core/common-components/confirmation-dialog/confirmation-dialog.service";
 import { FormFieldConfig } from "app/core/common-components/entity-form/FormConfig";
 import { EntityFormService } from "app/core/common-components/entity-form/entity-form.service";
@@ -41,6 +44,7 @@ import { MergeAccountSectionComponent } from "./merge-account-section/merge-acco
     WarningNotOptimizedForSmallScreenComponent,
     MatFormFieldModule,
     MergeAccountSectionComponent,
+    MatSlideToggleModule,
   ],
   templateUrl: "./bulk-merge-records.component.html",
   styleUrls: ["./bulk-merge-records.component.scss"],
@@ -57,8 +61,21 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
   entityConstructor: EntityConstructor;
   entitiesToMerge: E[];
   mergedEntity: E;
-  fieldsToMerge: FormFieldConfig[] = [];
+  fieldsToMerge = signal<FormFieldConfig[]>([]);
   mergeForm: EntityForm<E>;
+
+  showOnlyDifferences = signal(false);
+
+  filteredFieldsToMerge = computed(() => {
+    if (!this.showOnlyDifferences()) return this.fieldsToMerge();
+    return this.fieldsToMerge().filter(
+      (field) =>
+        !this.valuesAreIdentical(
+          this.entitiesToMerge[0][field.id],
+          this.entitiesToMerge[1][field.id],
+        ),
+    );
+  });
 
   /** whether the entitiesToMerge contain some file attachments that would be lost during a merge */
   hasDiscardedFileOrPhoto: boolean = false;
@@ -79,7 +96,7 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
   async ngOnInit(): Promise<void> {
     this.initFieldsToMerge();
     this.mergeForm = await this.entityFormService.createEntityForm(
-      this.fieldsToMerge,
+      this.fieldsToMerge(),
       this.mergedEntity,
       false,
       true,
@@ -89,6 +106,7 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
   }
 
   private initFieldsToMerge(): void {
+    const fields: FormFieldConfig[] = [];
     this.entityConstructor.schema.forEach((field, key) => {
       const hasValue = this.entitiesToMerge.some((entity) =>
         this.hasValue(entity[key]),
@@ -107,11 +125,16 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
             { id: key },
             this.entityConstructor,
           );
-        this.fieldsToMerge.push({
+        fields.push({
           ...formField,
         });
       }
     });
+    this.fieldsToMerge.set(fields);
+  }
+
+  private valuesAreIdentical(a: any, b: any): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
   }
 
   /**


### PR DESCRIPTION
- closes https://github.com/Aam-Digital/ndb-core/issues/4050

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

## Manual Testing
Steps to test:
1. Go to Review Possible Duplicates
2. Select an entity type and fields, then search for duplicates
3. Click "Compare & Merge" on any pair to open the merge dialog
4. Toggle "Only show fields with differences" in the action bar (next to the Merge button)
5. Verify only differing fields are shown, and that merging still works correctly with the toggle on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Only show fields with differences” toggle in the bulk merge dialog to filter the merge preview to fields that differ between the selected records.

* **Style**
  * Adjusted spacing for the slide toggle in the dialog actions for a cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->