### PR TITLE
fix(Admin UI): allow number fields in the entity toString title

### DIFF
--- a/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.ts
@@ -44,6 +44,7 @@ import { HintBoxComponent } from "#src/app/core/common-components/hint-box/hint-
 import { MatExpansionModule } from "@angular/material/expansion";
 import { EntityFieldSelectComponent } from "#src/app/core/entity/entity-field-select/entity-field-select.component";
 import { ConditionalColorConfigComponent } from "./conditional-color-config/conditional-color-config.component";
+import { NumberDatatype } from "#src/app/core/basic-datatypes/number/number.datatype";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -114,6 +115,7 @@ export class AdminEntityGeneralSettingsComponent {
         ([, field]) =>
           [
             StringDatatype.dataType,
+            NumberDatatype.dataType,
             ConfigurableEnumDatatype.dataType,
             DateOnlyDatatype.dataType,
           ].includes(field.dataType) && field.label,

--- a/src/bootstrap-environment.ts
+++ b/src/bootstrap-environment.ts
@@ -64,7 +64,7 @@ async function initConfigJsonToEnvironment() {
     Logging.error(err, "failed to load config.json");
 
     alert(
-      "We couldn't load the configuration for your system. Trying to reload the app for you. If this problem persists, please contact your tech support.",
+      "We couldn't load the base configuration for your system. Trying to reload the app for you. If this problem persists, please contact your tech support.",
     );
     window.location.reload();
   }


### PR DESCRIPTION
- make "number" fields available as a "to string attribute" in the general entity configuration Admin UI (that configures how an entity is shown in entity select  dropdowns / titles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin settings now allow number fields to be included in string attribute selection options.

* **Bug Fixes**
  * Updated the configuration load error message shown when the base configuration can’t be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->