### PR TITLE
refactor(reporting): consolidate aggregationDefinitions into reportDefinition (#4085)

### DIFF
--- a/cli/lib/org-runner.ts
+++ b/cli/lib/org-runner.ts
@@ -54,19 +54,6 @@ export class OrgRunner {
     return results;
   }
 
-  async runForEach<T>(
-    orgs: SystemCredentials[],
-    callback: (couchdb: Couchdb, org: SystemCredentials) => Promise<T>,
-  ): Promise<OrgOutcome<T>[]> {
-    const outcomes: OrgOutcome<T>[] = [];
-    for (const org of orgs) {
-      const couchdb = new Couchdb(org.url, org.password, org.username);
-      const result = await callback(couchdb, org);
-      outcomes.push({ org, result });
-    }
-    return outcomes;
-  }
-
   static filterOrgs(
     orgs: SystemCredentials[],
     options: { org?: string; category?: string },

--- a/cli/lib/timeout.spec.ts
+++ b/cli/lib/timeout.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { withTimeout } from "./timeout";
+
+describe("withTimeout", () => {
+  it("resolves with the underlying value when it settles in time", async () => {
+    const result = await withTimeout(Promise.resolve("done"), 50, "timed out");
+
+    expect(result).toBe("done");
+  });
+
+  it("rejects with the timeout message when the promise hangs", async () => {
+    const hang = new Promise(() => {
+      // never settles
+    });
+
+    await expect(withTimeout(hang, 10, "timed out")).rejects.toThrow(
+      "timed out",
+    );
+  });
+
+  it("propagates the original rejection when it settles before the timeout", async () => {
+    const failing = Promise.reject(new Error("boom"));
+
+    await expect(withTimeout(failing, 50, "timed out")).rejects.toThrow(
+      "boom",
+    );
+  });
+});

--- a/cli/lib/timeout.ts
+++ b/cli/lib/timeout.ts
@@ -1,0 +1,20 @@
+/** Rejects with `message` if `promise` hasn't settled within `ms`. */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -10,17 +10,21 @@ import {
   getUsersFromKeycloak,
 } from "./lib/keycloak-client.js";
 import { ConsoleLogger } from "./migration/console-logger.js";
-import { failedMigrationResult } from "./migration/migration-definition.js";
+import {
+  failedMigrationResult,
+  type MigrationOutcome,
+} from "./migration/migration-definition.js";
 import {
   computeExitCode,
   printBanner,
-  printOutcomes,
+  printOutcome,
   printSummary,
 } from "./migration/migration-output.js";
 import { migrations } from "./migration/migrations.js";
 import { TrackedMigrationContext } from "./migration/tracked-migration-context.js";
-import { OrgRunner, runForAllOrgs } from "./lib/org-runner.js";
+import { OrgRunner, runForAllOrgs, type OrgOutcome } from "./lib/org-runner.js";
 import { printConnectivity } from "./lib/org-output.js";
+import { withTimeout } from "./lib/timeout.js";
 import type { SystemCredentials } from "./lib/credentials.js";
 
 const program = new Command();
@@ -74,12 +78,18 @@ migrateCmd
   .description("Run a migration (preview first, then confirm)")
   .option("--dry-run", "Preview changes and exit without writing")
   .option("--yes", "Skip confirmation prompt")
+  .option("--timeout <seconds>", "Per-org timeout in seconds", "30")
   .action(async (id: string, cmdOpts) => {
     const opts = { ...program.opts(), ...cmdOpts };
     const migration = migrations.find((m) => m.id === id);
     if (!migration) {
       console.error(`\nUnknown migration id: "${id}"`);
       console.error(`Run "migrate list" to see available migrations.\n`);
+      return process.exit(2);
+    }
+    const timeoutSeconds = Number(cmdOpts.timeout);
+    if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+      console.error(`\nInvalid --timeout: "${cmdOpts.timeout}"\n`);
       return process.exit(2);
     }
 
@@ -99,52 +109,73 @@ migrateCmd
       return process.exit(1);
     }
 
-    const runMigration = (dryRun: boolean) =>
-      runner.runForEach(reachable, async (couchdb, org) => {
-        console.log(`\n  ${OrgRunner.orgLabel(org)}`);
-        const ctx = new TrackedMigrationContext(couchdb, org, dryRun, logger);
-        try {
-          const result = await migration.run(ctx);
-          return { result, writeStats: ctx.getWriteStats() };
-        } catch (e: unknown) {
-          const msg = e instanceof Error ? e.message : String(e);
-          const result = failedMigrationResult(msg);
-          result.details = e instanceof Error ? e.stack : undefined;
-          return { result, writeStats: ctx.getWriteStats() };
-        }
-      });
+    const runOnOrg = async (
+      couchdb: Couchdb,
+      org: SystemCredentials,
+      dryRun: boolean,
+    ): Promise<MigrationOutcome> => {
+      const ctx = new TrackedMigrationContext(couchdb, org, dryRun, logger);
+      try {
+        const result = await withTimeout(
+          migration.run(ctx),
+          timeoutSeconds * 1000,
+          `Migration timed out after ${timeoutSeconds}s`,
+        );
+        return { result, writeStats: ctx.getWriteStats() };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        const result = failedMigrationResult(msg);
+        result.details = e instanceof Error ? e.stack : undefined;
+        return { result, writeStats: ctx.getWriteStats() };
+      }
+    };
 
-    printBanner("PREVIEW", migration);
-    const preview = await runMigration(true);
-    printOutcomes(preview, false, !!opts.verbose);
-    printSummary(preview, unreachableCount);
+    // Each org is previewed, confirmed, and (if approved) applied before moving
+    // on to the next — so a rejected or problematic org never blocks review of
+    // the rest, and an early "no" can't be mistaken for a blanket abort.
+    printBanner("MIGRATE", migration);
+    const outcomes: OrgOutcome<MigrationOutcome>[] = [];
+    let skippedCount = 0;
+    for (const org of reachable) {
+      const couchdb = new Couchdb(org.url, org.password, org.username);
+      console.log();
+
+      const preview = await runOnOrg(couchdb, org, true);
+      printOutcome({ org, result: preview }, false, !!opts.verbose);
+
+      if (opts.dryRun || !preview.result.changed) {
+        outcomes.push({ org, result: preview });
+        continue;
+      }
+
+      if (!opts.yes) {
+        const confirmed = await askConfirmation(
+          `Apply ${preview.writeStats.intended} change(s) to ${OrgRunner.orgLabel(org)}? [y/N]`,
+        );
+        if (!confirmed) {
+          console.log("Skipped.");
+          // Excluded from `outcomes` on purpose: it was never applied, so
+          // counting it as "changed" (its dry-run status) would misreport
+          // what actually happened to this org.
+          skippedCount++;
+          continue;
+        }
+      }
+
+      const applied = await runOnOrg(couchdb, org, false);
+      printOutcome({ org, result: applied }, true, !!opts.verbose);
+      outcomes.push({ org, result: applied });
+    }
 
     if (opts.dryRun) {
       console.log("\n(--dry-run) No writes performed.\n");
-      return process.exit(computeExitCode(preview, unreachableCount));
+    }
+    if (skippedCount > 0) {
+      console.log(`${skippedCount} org(s) skipped (declined) — not applied.`);
     }
 
-    const wouldChange = preview.filter((o) => o.result.result.changed).length;
-    if (wouldChange === 0) {
-      console.log("\nNo changes needed — nothing to write.\n");
-      return process.exit(0);
-    }
-
-    if (!opts.yes) {
-      const confirmed = await askConfirmation(
-        `\nApply ${wouldChange} change(s) to ${reachable.length} org(s)? [y/N]`,
-      );
-      if (!confirmed) {
-        console.log("\nAborted.\n");
-        return process.exit(2);
-      }
-    }
-
-    printBanner("RUNNING", migration);
-    const real = await runMigration(false);
-    printOutcomes(real, true, !!opts.verbose);
-    printSummary(real, unreachableCount);
-    process.exit(computeExitCode(real, unreachableCount));
+    printSummary(outcomes, unreachableCount);
+    process.exit(computeExitCode(outcomes, unreachableCount));
   });
 
 // ─── couchdb ─────────────────────────────────────────────────────────────────

--- a/cli/migration/consolidate-report-definition.migration.ts
+++ b/cli/migration/consolidate-report-definition.migration.ts
@@ -1,0 +1,50 @@
+import {
+  migrateReportConfig,
+  type MigratableReportConfig,
+} from "../../src/app/features/reporting/report-config-migration.js";
+import type {
+  MigrationDefinition,
+  MigrationResult,
+} from "./migration-definition.js";
+
+/**
+ * Consolidate each ReportConfig doc's legacy definition fields into the unified `reportDefinition`:
+ * `aggregationDefinitions` (reporting/exporting) and the v1 SQL `aggregationDefinition` string.
+ *
+ * Non-destructive: the legacy fields are intentionally kept, so this can be run together with (or
+ * before) the deploy that starts reading `reportDefinition` — both coexist, so old code keeps
+ * working. A separate follow-up migration removes the legacy fields once every environment runs
+ * the new code. Idempotent — safe to re-run.
+ */
+export const consolidateReportDefinition: MigrationDefinition = {
+  id: "consolidate-report-definition",
+  description:
+    "Consolidate ReportConfig legacy definition fields (aggregationDefinitions, v1 aggregationDefinition) into reportDefinition (keeps the old fields). Safe to re-run.",
+
+  async run(ctx): Promise<MigrationResult> {
+    const docs = (await ctx.couchdb.getAll("ReportConfig")) as Array<
+      MigratableReportConfig & { _id: string }
+    >;
+
+    let intended = 0;
+    for (const doc of docs) {
+      const before = JSON.stringify(doc);
+      migrateReportConfig(doc);
+      if (JSON.stringify(doc) === before) {
+        continue;
+      }
+
+      intended++;
+      ctx.validateJson(doc);
+      ctx.log.info(`Migrating ${doc._id}`);
+      await ctx.put(`/app/${doc._id}`, doc);
+    }
+
+    if (intended === 0) {
+      ctx.log.info("No ReportConfig docs need migration");
+      return { changed: false, status: "no-change" };
+    }
+
+    return { changed: true, status: ctx.dryRun ? "dry-run" : "ok" };
+  },
+};

--- a/cli/migration/migration-output.ts
+++ b/cli/migration/migration-output.ts
@@ -14,37 +14,33 @@ export function printBanner(
   );
 }
 
-export function printOutcomes(
-  outcomes: OrgOutcome<MigrationOutcome>[],
+const STATUS_TAGS: Record<MigrationResult["status"], string> = {
+  ok: "OK       ",
+  "no-change": "NO-CHANGE",
+  "dry-run": "PREVIEW  ",
+  partial: "PARTIAL  ",
+  failed: "FAILED   ",
+};
+
+/** Prints a single org's outcome line (plus warnings/details), as each org is processed. */
+export function printOutcome(
+  { org, result: { result, writeStats } }: OrgOutcome<MigrationOutcome>,
   showWriteStats: boolean,
   verbose = false,
 ): void {
-  console.log("\n── Summary: Status per org ──");
-  for (const {
-    org,
-    result: { result, writeStats },
-  } of outcomes) {
-    process.stdout.write(`  ${OrgRunner.orgLabel(org).padEnd(50)}`);
-    const suffix =
-      showWriteStats && writeStats.intended > 0
-        ? `  (${writeStats.succeeded}/${writeStats.intended} written)`
-        : "";
-    const STATUS_TAGS: Record<MigrationResult["status"], string> = {
-      ok: "OK       ",
-      "no-change": "NO-CHANGE",
-      "dry-run": "PREVIEW  ",
-      partial: "PARTIAL  ",
-      failed: "FAILED   ",
-    };
-    console.log((STATUS_TAGS[result.status] ?? result.status) + suffix);
-    if (result.warnings?.length) {
-      result.warnings.forEach((w) => console.log(`    ! ${w}`));
-    }
-    if (verbose && result.details) {
-      String(result.details)
-        .split("\n")
-        .forEach((line) => console.log(`    ${line}`));
-    }
+  process.stdout.write(`  ${OrgRunner.orgLabel(org).padEnd(50)}`);
+  const suffix =
+    showWriteStats && writeStats.intended > 0
+      ? `  (${writeStats.succeeded}/${writeStats.intended} written)`
+      : "";
+  console.log((STATUS_TAGS[result.status] ?? result.status) + suffix);
+  if (result.warnings?.length) {
+    result.warnings.forEach((w) => console.log(`    ! ${w}`));
+  }
+  if (verbose && result.details) {
+    String(result.details)
+      .split("\n")
+      .forEach((line) => console.log(`    ${line}`));
   }
 }
 

--- a/cli/migration/migrations.ts
+++ b/cli/migration/migrations.ts
@@ -1,5 +1,6 @@
 import { codoAddEventType } from "./codo-add-event-type.migration.js";
 import { latestConfigFormats } from "./latest-config-formats.migration.js";
+import { consolidateReportDefinition } from "./consolidate-report-definition.migration.js";
 import type { MigrationDefinition } from "./migration-definition.js";
 
 export const CONFIG_DOC_PATH = "/app/Config:CONFIG_ENTITY";
@@ -11,4 +12,5 @@ export const CONFIG_DOC_PATH = "/app/Config:CONFIG_ENTITY";
 export const migrations: MigrationDefinition[] = [
   latestConfigFormats,
   codoAddEventType,
+  consolidateReportDefinition,
 ];

--- a/cli/migration/tracked-migration-context.ts
+++ b/cli/migration/tracked-migration-context.ts
@@ -59,7 +59,7 @@ export class TrackedMigrationContext implements MigrationContext {
     await this.logDiff(path, data, db);
 
     if (this.dryRun) {
-      this.log.verbose(`[PREVIEW] Would PUT ${path}`);
+      this.log.info(`[PREVIEW] Would PUT ${path}`);
       return;
     }
     try {
@@ -81,7 +81,7 @@ export class TrackedMigrationContext implements MigrationContext {
       oldData = await this.couchdb.get(path, db);
     } catch (error: unknown) {
       if (!is404Error(error)) throw error;
-      this.log.verbose(`+ ${path} (new document)`);
+      this.logChange(`+ ${path} (new document)`);
       return;
     }
 
@@ -105,22 +105,28 @@ export class TrackedMigrationContext implements MigrationContext {
       const pathStr = change.path.join(".");
       switch (change.type) {
         case "CREATE":
-          this.log.verbose(
+          this.logChange(
             `  + ${pathStr}: ${truncate(JSON.stringify(change.value))}`,
           );
           break;
         case "REMOVE":
-          this.log.verbose(
+          this.logChange(
             `  - ${pathStr}: ${truncate(JSON.stringify(change.oldValue))}`,
           );
           break;
         case "CHANGE":
-          this.log.verbose(
+          this.logChange(
             `  ~ ${pathStr}: ${truncate(JSON.stringify(change.oldValue))} → ${truncate(JSON.stringify(change.value))}`,
           );
           break;
       }
     }
+  }
+
+  /** Diff lines: always shown during preview (that's the point of a preview), only with --verbose during a real apply so multi-org runs stay quiet. */
+  private logChange(msg: string): void {
+    if (this.dryRun) this.log.info(msg);
+    else this.log.verbose(msg);
   }
 }
 

--- a/e2e/tests/reports.spec.ts
+++ b/e2e/tests/reports.spec.ts
@@ -21,7 +21,7 @@ test("Generate a configured aggregation report and download CSV", async ({
   const reportConfig = createEntityOfType("ReportConfig", "e2e-basic-report");
   reportConfig.title = "E2E Basic Report";
   reportConfig.mode = "reporting";
-  reportConfig.aggregationDefinitions = [
+  reportConfig.reportDefinition = [
     {
       query: "Child:toArray",
       label: "All children",

--- a/src/app/features/reporting/README.md
+++ b/src/app/features/reporting/README.md
@@ -117,7 +117,7 @@ In the UI, grouped SQL reports are rendered as a hierarchical report view, while
 
 #### Aggregation structure
 
-Inside the `aggregationDefinitions` an array of aggregations can be added.
+Inside the `reportDefinition` an array of aggregations can be added.
 The following example shows the structure of an aggregation.
 
 ```json

--- a/src/app/features/reporting/report-config-migration.spec.ts
+++ b/src/app/features/reporting/report-config-migration.spec.ts
@@ -1,0 +1,99 @@
+import { migrateReportConfig } from "./report-config-migration";
+
+describe("migrateReportConfig", () => {
+  it("copies aggregationDefinitions into reportDefinition for reporting/exporting reports and keeps the old field", () => {
+    const migrated = migrateReportConfig({
+      mode: "reporting",
+      aggregationDefinitions: [{ query: "Child:toArray", label: "All" }],
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([
+      { query: "Child:toArray", label: "All" },
+    ]);
+    // non-destructive: the legacy field is retained during the coexistence period
+    expect(migrated.aggregationDefinitions).toEqual([
+      { query: "Child:toArray", label: "All" },
+    ]);
+  });
+
+  it("treats an unset mode as reporting and copies aggregationDefinitions", () => {
+    const migrated = migrateReportConfig({
+      aggregationDefinitions: [{ query: "x" }],
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([{ query: "x" }]);
+  });
+
+  it("leaves an SQL report's reportDefinition untouched (and does not remove aggregationDefinitions)", () => {
+    const migrated = migrateReportConfig({
+      mode: "sql",
+      reportDefinition: [{ query: "SELECT 1" }],
+      aggregationDefinitions: [{ query: "stale" }],
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([{ query: "SELECT 1" }]);
+    expect(migrated.aggregationDefinitions).toEqual([{ query: "stale" }]);
+  });
+
+  it("folds a legacy v1 SQL aggregationDefinition into reportDefinition", () => {
+    const migrated = migrateReportConfig({
+      mode: "sql",
+      aggregationDefinition: "SELECT name FROM Child",
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([
+      { query: "SELECT name FROM Child" },
+    ]);
+    // non-destructive: legacy v1 field retained
+    expect(migrated.aggregationDefinition).toBe("SELECT name FROM Child");
+  });
+
+  it("does not overwrite a v2 SQL reportDefinition with a legacy aggregationDefinition", () => {
+    const migrated = migrateReportConfig({
+      mode: "sql",
+      reportDefinition: [{ query: "SELECT v2" }],
+      aggregationDefinition: "SELECT v1",
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([{ query: "SELECT v2" }]);
+  });
+
+  it("for a reporting report, overwrites a stale reportDefinition with aggregationDefinitions", () => {
+    // e.g. left over after switching mode sql -> reporting in the old two-field form
+    const migrated = migrateReportConfig({
+      mode: "reporting",
+      reportDefinition: [{ query: "SELECT stale" }],
+      aggregationDefinitions: [{ query: "Child:toArray", label: "real" }],
+    } as any);
+
+    expect(migrated.reportDefinition).toEqual([
+      { query: "Child:toArray", label: "real" },
+    ]);
+  });
+
+  it("does nothing for a non-array (malformed) aggregationDefinitions value", () => {
+    const migrated = migrateReportConfig({
+      mode: "reporting",
+      aggregationDefinitions: { legacy: "object" },
+    } as any);
+
+    expect(migrated.reportDefinition).toBeUndefined();
+    expect(migrated.aggregationDefinitions).toEqual({
+      legacy: "object",
+    });
+  });
+
+  it("is idempotent (second run makes no further change)", () => {
+    const once = migrateReportConfig({
+      mode: "reporting",
+      aggregationDefinitions: [{ query: "x" }],
+    } as any);
+    const twice = migrateReportConfig(JSON.parse(JSON.stringify(once)));
+
+    expect(twice).toEqual(once);
+  });
+
+  it("returns nullish input unchanged", () => {
+    expect(migrateReportConfig(undefined as any)).toBeUndefined();
+  });
+});

--- a/src/app/features/reporting/report-config-migration.ts
+++ b/src/app/features/reporting/report-config-migration.ts
@@ -1,0 +1,58 @@
+/**
+ * A minimal shape of a ReportConfig doc/entity relevant to the definition migration.
+ * Kept structural (no @angular imports) so this file can be reused by the migration CLI.
+ */
+export interface MigratableReportConfig {
+  mode?: string;
+  /** @deprecated reporting/exporting definition — consolidated into reportDefinition */
+  aggregationDefinitions?: any[];
+  /** @deprecated (sql v1) a single SQL query string — consolidated into reportDefinition */
+  aggregationDefinition?: string;
+  reportDefinition?: any[];
+}
+
+/**
+ * Consolidate a ReportConfig's legacy definition fields into the unified `reportDefinition`,
+ * so all report modes share a single definition property.
+ *
+ * Mode-aware, because the canonical definition differs per mode:
+ * - "reporting"/"exporting" (and unset, which defaults to reporting): the definition lives in
+ *   `aggregationDefinitions`; any `reportDefinition` present is stale (e.g. left over from a mode
+ *   switch in the old two-field form) → overwrite it with `aggregationDefinitions`.
+ * - "sql": `reportDefinition` (v2) is canonical when present; a legacy v1 `aggregationDefinition`
+ *   (a single SQL query string) is folded into `reportDefinition` as `[{ query }]`.
+ *
+ * **Non-destructive:** the legacy fields are intentionally kept, so this migration is safe to run
+ * before the code that reads `reportDefinition` is deployed (both coexist; old code keeps reading
+ * the old fields). A follow-up migration removes the legacy fields once every environment runs the
+ * new code. Idempotent and safe to re-run.
+ */
+export function migrateReportConfig<T extends MigratableReportConfig>(
+  report: T,
+): T {
+  if (!report || typeof report !== "object") {
+    return report;
+  }
+
+  const hasReportDefinition =
+    Array.isArray(report.reportDefinition) &&
+    report.reportDefinition.length > 0;
+
+  if (report.mode === "sql") {
+    // v1 sql: a single query string → a one-item reportDefinition
+    if (
+      !hasReportDefinition &&
+      typeof report.aggregationDefinition === "string"
+    ) {
+      report.reportDefinition = [{ query: report.aggregationDefinition }];
+    }
+  } else {
+    // reporting/exporting/unset: aggregationDefinitions is the real definition
+    const legacy = report.aggregationDefinitions;
+    if (Array.isArray(legacy) && legacy.length > 0) {
+      report.reportDefinition = legacy;
+    }
+  }
+
+  return report;
+}

--- a/src/app/features/reporting/report-config.ts
+++ b/src/app/features/reporting/report-config.ts
@@ -37,8 +37,13 @@ class ReportConfig extends Entity {
    */
   @DatabaseField() neededArgs?: string[] = [];
 
-  /** (reporting/exporting only, in browser reports) the definitions to calculate the report's aggregations */
-  @DatabaseField() aggregationDefinitions: any[];
+  /**
+   * @deprecated Consolidated into {@link reportDefinition} by the one-time CLI migration
+   * (consolidate-report-definition), which copies this into `reportDefinition` without deleting
+   * it. Kept during the coexistence period so legacy docs still load and old code keeps working;
+   * a follow-up migration removes it once every environment runs the new code.
+   */
+  @DatabaseField() aggregationDefinitions?: any[];
 
   /**
    * @deprecated (will be removed completely after server-side migration)
@@ -55,16 +60,16 @@ class ReportConfig extends Entity {
   };
 
   /**
-   *  (sql v2 only) ReportDefinitionItem, ether ReportQuery or ReportGroup
+   * The single definition of what the report calculates. Its shape depends on {@link mode}:
+   * - "sql":       {@link ReportDefinitionDto}[] — SQL queries and optional groups.
+   * - "reporting": {@link Aggregation}[] — in-browser aggregation definitions.
+   * - "exporting": {@link ExportColumnConfig}[] — export column definitions.
    *
-   *  Can be ReportQuery:
-   *  {query: "SELECT * FROM foo"}
-   *
-   *  Can be ReportGroup:
-   *  {groupTitle: "This is a group", items: [...]}
-   *
+   * Consolidated from the former `aggregationDefinitions` so all report modes share one field.
    */
-  @DatabaseField() reportDefinition: ReportDefinitionDto[];
+  @DatabaseField()
+  reportDefinition:
+    ReportDefinitionDto[] | Aggregation[] | ExportColumnConfig[];
 }
 
 export interface ReportDefinitionDto {
@@ -93,7 +98,7 @@ export const ReportEntity = ReportConfig as EntityConstructor<ReportEntity>;
  */
 export interface AggregationReport extends ReportConfig {
   mode: "reporting";
-  aggregationDefinitions: Aggregation[];
+  reportDefinition: Aggregation[];
 }
 
 /**
@@ -104,7 +109,7 @@ export interface ExportingReport extends ReportConfig {
    * If no mode is set, it will default to 'exporting'
    */
   mode?: "exporting";
-  aggregationDefinitions: ExportColumnConfig[];
+  reportDefinition: ExportColumnConfig[];
 }
 
 /**
@@ -156,7 +161,8 @@ export interface SqlReport extends ReportConfig {
 export function isHierarchicalReport(
   report: ReportEntity | undefined,
 ): boolean {
-  const reportDefinition = report?.reportDefinition;
+  const reportDefinition = report?.reportDefinition as
+    ReportDefinitionDto[] | undefined;
   if (!reportDefinition?.length) {
     return false;
   }

--- a/src/app/features/reporting/reporting/reporting.component.spec.ts
+++ b/src/app/features/reporting/reporting/reporting.component.spec.ts
@@ -162,7 +162,7 @@ describe("ReportingComponent", () => {
       expect(component.isLoading()).toBe(false);
 
       expect(mockReportingService.calculateReport).toHaveBeenCalledWith(
-        testReport.aggregationDefinitions as Aggregation[],
+        testReport.reportDefinition as Aggregation[],
         expect.any(Date),
         expect.any(Date),
       );
@@ -293,7 +293,7 @@ describe("ReportingComponent", () => {
     mockDataTransformationService.queryAndTransformData.mockResolvedValue(data);
     const report = new ReportEntity();
     report.mode = "exporting";
-    report.aggregationDefinitions = [];
+    report.reportDefinition = [];
 
     await component.calculateResults(report, new Date(), new Date());
 

--- a/src/app/features/reporting/reporting/reporting.component.ts
+++ b/src/app/features/reporting/reporting/reporting.component.ts
@@ -210,7 +210,7 @@ export class ReportingComponent {
         const dayAfterToDate = moment(to).add(1, "day").toDate();
         return {
           data: await this.dataTransformationService.queryAndTransformData(
-            report.aggregationDefinitions,
+            report.reportDefinition,
             from,
             dayAfterToDate,
           ),
@@ -231,7 +231,7 @@ export class ReportingComponent {
       default:
         return {
           data: await this.dataAggregationService.calculateReport(
-            report.aggregationDefinitions,
+            report.reportDefinition,
             from,
             to,
           ),
@@ -271,13 +271,10 @@ export class ReportingComponent {
       title: report.title,
       mode: report.mode,
     };
-    // explicitly map the relevant properties (canonical only; version is deprecated)
+    // explicitly map the relevant properties (canonical reportDefinition only;
+    // legacy aggregationDefinition(s) are consolidated into reportDefinition by migration)
     if (report.reportDefinition)
       reportDetails.reportDefinition = report.reportDefinition;
-    if (report.aggregationDefinition)
-      reportDetails.aggregationDefinition = report.aggregationDefinition;
-    if (report.aggregationDefinitions)
-      reportDetails.aggregationDefinitions = report.aggregationDefinitions;
 
     this.jsonEditorService
       .openJsonEditorDialog(reportDetails)

--- a/src/assets/base-configs/education/ReportConfig.json
+++ b/src/assets/base-configs/education/ReportConfig.json
@@ -2,7 +2,7 @@
   {
     "_id": "ReportConfig:basic-report",
     "title": "Basic Report",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Child:toArray[*isActive=true]",
         "label": "All children",
@@ -47,7 +47,7 @@
   {
     "_id": "ReportConfig:event-report",
     "title": "Event Report",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": [
@@ -70,7 +70,7 @@
     "_id": "ReportConfig:attendance-report",
     "title": "Attendance Report",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": {
@@ -124,7 +124,7 @@
     "_id": "ReportConfig:materials-distributed",
     "title": "Materials Distributed",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "EducationalMaterial:toArray[*date >= ? & date <= ?]",
         "groupBy": {

--- a/src/assets/base-configs/education/de/ReportConfig.json
+++ b/src/assets/base-configs/education/de/ReportConfig.json
@@ -2,7 +2,7 @@
   {
     "_id": "ReportConfig:basic-report",
     "title": "Basis-Bericht",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Child:toArray[*isActive=true]",
         "label": "Alle Kinder",
@@ -47,7 +47,7 @@
   {
     "_id": "ReportConfig:event-report",
     "title": "Veranstaltungsbericht",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": [
@@ -70,7 +70,7 @@
     "_id": "ReportConfig:attendance-report",
     "title": "Anwesenheitsbericht",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": {
@@ -124,7 +124,7 @@
     "_id": "ReportConfig:materials-distributed",
     "title": "Ausgegebene Materialien",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "EducationalMaterial:toArray[*date >= ? & date <= ?]",
         "groupBy": {

--- a/src/assets/base-configs/education/fr/ReportConfig.json
+++ b/src/assets/base-configs/education/fr/ReportConfig.json
@@ -2,7 +2,7 @@
   {
     "_id": "ReportConfig:basic-report",
     "title": "Rapport de base",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Child:toArray[*isActive=true]",
         "label": "Tous les enfants",
@@ -47,7 +47,7 @@
   {
     "_id": "ReportConfig:event-report",
     "title": "Rapport d'événement",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": [
@@ -70,7 +70,7 @@
     "_id": "ReportConfig:attendance-report",
     "title": "Rapport de présence",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "Event:toArray[* date >= ? & date <= ?]",
         "groupBy": {
@@ -124,7 +124,7 @@
     "_id": "ReportConfig:materials-distributed",
     "title": "Matériels distribués",
     "mode": "exporting",
-    "aggregationDefinitions": [
+    "reportDefinition": [
       {
         "query": "EducationalMaterial:toArray[*date >= ? & date <= ?]",
         "groupBy": {


### PR DESCRIPTION
- part of #4085

Consolidates the report **data model** into a single definition field, independent of the Report admin UI (per @sleidig — merged separately from #4105 / #4106, which will adapt to the consolidated field on top).

### What
- All report modes now use one **`reportDefinition`** field (mode-discriminated union) instead of a separate `aggregationDefinitions`:
  - `reporting` → `Aggregation[]`, `exporting` → `ExportColumnConfig[]`, `sql` → `ReportDefinitionDto[]`.
  - Payload shapes kept distinct (not physically merged) — `groupBy` conflicts across them and `ExportColumnConfig` is a shared export type.
- `aggregationDefinitions` and the legacy v1 `aggregationDefinition` are kept as **deprecated** fields during a coexistence period.
- Calc consumers (`reporting.component`) + `editReportConfig` read `reportDefinition`; base-config `ReportConfig.json` renamed; README updated.

### Migration
- **One-time, non-destructive CLI migration** `consolidate-report-definition` — copies the legacy fields into `reportDefinition` **without deleting** them, so it can run together with (or before) the deploy: both coexist, old code keeps working. Also folds the **v1 `aggregationDefinition`** string into `reportDefinition` (`[{ query }]`). Idempotent / safe to re-run.
- A **follow-up migration** removes the legacy fields once every environment runs the new code.

### ⚙️ Dev / deployment step (required)
Run the migration per environment, together with (or just before) the deploy:
```bash
# operator: point cli/credentials.json at the target org(s), then:
npm run cli -- migrate run consolidate-report-definition --dry-run   # preview
npm run cli -- migrate run consolidate-report-definition --yes       # apply
```
Verified on a local synced stack: reporting docs → `reportDefinition` copied from `aggregationDefinitions`; v1-SQL docs → `aggregationDefinition` string folded into `reportDefinition`; legacy fields retained; re-run = no-change.

### Testing
- Unit: `migrateReportConfig` (reporting/exporting/unset + v1-SQL + idempotency) and report/reporting specs — all green; `tsc -p .` clean.
- Live migration test on the dev-style stack (seed pre-migration doc → run migration → verify migrated, before/after + idempotent).

---

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reporting configurations now use a unified definition field, improving consistency across report types.
  * Existing report data is migrated automatically so current reports continue to work without manual updates.

* **Bug Fixes**
  * Reports and CSV exports now read from the updated configuration format more reliably.
  * Updated bundled examples, tests, and documentation to match the new report setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->