### PR TITLE
refactor: make "unsaved changes" tracking cleanly separated per form

### DIFF
--- a/e2e/tests/entity.spec.ts
+++ b/e2e/tests/entity.spec.ts
@@ -336,3 +336,66 @@ test("Dialog Cancel discards edits; Dialog Save persists changes", async ({
     page.getByRole("cell", { name: DIALOG_INITIAL_SUBJECT }),
   ).not.toBeVisible();
 });
+
+const NO_CHANGES_CHILD_NAME = "<NO CHANGES CHILD>";
+
+test("Closing an untouched new-entity dialog does not prompt discard-changes, but an edited one does", async ({
+  page,
+}) => {
+  const users = generateUsers();
+  const child = generateChild({ name: NO_CHANGES_CHILD_NAME });
+
+  await loadApp(page, [...users, child]);
+
+  await page.getByRole("navigation").getByText("Children").click();
+  await page.getByRole("cell", { name: NO_CHANGES_CHILD_NAME }).click();
+  await page.getByRole("tab", { name: "Education", exact: true }).click();
+
+  const schoolHistoryHeaderRow = page
+    .getByRole("row")
+    .filter({ hasText: "School Class" });
+  const openNewSchoolEnrollmentDialog = () =>
+    schoolHistoryHeaderRow
+      .getByRole("button", { name: /add element/i })
+      .click();
+
+  const discardDialogContainer = page
+    .getByRole("dialog")
+    .filter({ hasText: "Discard Changes?" });
+  const discardDialog = discardDialogContainer.getByRole("heading", {
+    name: "Discard Changes?",
+  });
+
+  // Case 1: open the dialog, touch no fields, and close it via the backdrop
+  // (equivalent to clicking anything behind the dialog, e.g. the page's back
+  // arrow). No discard-changes prompt should appear.
+  await openNewSchoolEnrollmentDialog();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  await page
+    .locator(".cdk-overlay-backdrop")
+    .click({ position: { x: 5, y: 5 } });
+
+  await expect(discardDialog).not.toBeVisible({ timeout: 3000 });
+  await expect(dialog).not.toBeVisible();
+
+  // Case 2: open the dialog again and actually edit a field — closing it now
+  // must still trigger the discard-changes prompt.
+  await openNewSchoolEnrollmentDialog();
+  await expect(dialog).toBeVisible();
+
+  await dialog
+    .locator("#entity-field__start")
+    .getByRole("textbox")
+    .fill("01.09.2024");
+
+  await page
+    .locator(".cdk-overlay-backdrop")
+    .click({ position: { x: 5, y: 5 } });
+
+  await expect(discardDialog).toBeVisible();
+  await discardDialogContainer.getByRole("button", { name: "No" }).click();
+  await expect(discardDialog).not.toBeVisible();
+  await expect(dialog).toBeVisible();
+});

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -61,6 +62,7 @@ export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
   private configService = inject(ConfigService);
   private entityFormService = inject(EntityFormService);
   private readonly dialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
 
   override readonly entityConstructor = computed<EntityConstructor>(() => Note);
 
@@ -136,6 +138,7 @@ export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
     const newForm = await this.entityFormService.createEntityForm(
       this.middleForm().concat(this.topForm(), this.bottomForm()),
       entity,
+      this.destroyRef,
     );
 
     if (isCancelled()) return;

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -25,6 +25,7 @@ import { ConfigService } from "../../../core/config/config.service";
 import { DynamicComponent } from "../../../core/config/dynamic-components/dynamic-component.decorator";
 import { AbstractEntityDetailsComponent } from "../../../core/entity-details/abstract-entity-details/abstract-entity-details.component";
 import { EntityArchivedInfoComponent } from "../../../core/entity-details/entity-archived-info/entity-archived-info.component";
+import { UnsavedChangesService } from "../../../core/entity-details/form/unsaved-changes.service";
 import { EntityListConfig } from "../../../core/entity-list/EntityListConfig";
 import { EntityConstructor } from "../../../core/entity/model/entity";
 import { ExportColumnConfig } from "../../../core/export/data-transformation-service/export-column-config";
@@ -61,6 +62,7 @@ import { Note } from "../model/note";
 export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
   private configService = inject(ConfigService);
   private entityFormService = inject(EntityFormService);
+  private unsavedChangesService = inject(UnsavedChangesService);
   private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -142,6 +144,12 @@ export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
     );
 
     if (isCancelled()) return;
+    // Clear the previous form's unsaved-changes registration before replacing it,
+    // to prevent stale dirty state from accumulating when the form is recreated.
+    const previousForm = this.form();
+    if (previousForm) {
+      this.unsavedChangesService.setUnsavedChanges(previousForm, false);
+    }
     this.tmpEntity.set(entity.copy());
     this.form.set(newForm); // triggers the valueChanges effect
   }

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -9,6 +9,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -76,6 +77,7 @@ export class AdminEntityFormComponent {
   private entityFormService = inject(EntityFormService);
   private matDialog = inject(MatDialog);
   private adminEntityService = inject(AdminEntityService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // migrate inputs to Angular `input()` signals
   readonly entityType = input<EntityConstructor>();
@@ -174,6 +176,7 @@ export class AdminEntityFormComponent {
     this.dummyForm = await this.entityFormService.createEntityForm(
       [...this.getUsedFields(this.fieldGroups()), ...this.availableFields()],
       this.dummyEntity,
+      this.destroyRef,
     );
     this.dummyForm.formGroup.disable();
   }

--- a/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/edit-text-with-autocomplete/edit-text-with-autocomplete.component.spec.ts
@@ -8,6 +8,7 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { ConfirmationDialogService } from "../confirmation-dialog/confirmation-dialog.service";
 import { EntityFormService } from "../entity-form/entity-form.service";
 import { EditTextWithAutocompleteComponent } from "./edit-text-with-autocomplete.component";
+import { MockDestroyRef } from "../../../utils/mock-destroy-ref";
 
 describe("EditTextWithAutocompleteComponent", () => {
   let component: EditTextWithAutocompleteComponent;
@@ -40,6 +41,7 @@ describe("EditTextWithAutocompleteComponent", () => {
     const entityForm = await entityFormService.createEntityForm(
       [{ id: "name" }, { id: "other" }, { id: "ref" }, { id: "refMixed" }],
       new TestEntity(),
+      new MockDestroyRef(),
     );
 
     const nameControl = entityForm.formGroup.get("name") as FormControl<string>;

--- a/src/app/core/common-components/entities-table/entity-inline-edit-actions/entity-inline-edit-actions.component.spec.ts
+++ b/src/app/core/common-components/entities-table/entity-inline-edit-actions/entity-inline-edit-actions.component.spec.ts
@@ -6,6 +6,7 @@ import { EntityMapperService } from "../../../entity/entity-mapper/entity-mapper
 import { UntypedFormBuilder, UntypedFormGroup } from "@angular/forms";
 import { genders } from "../../../../child-dev-project/children/model/genders";
 import { EntityFormService } from "../../entity-form/entity-form.service";
+import { MockDestroyRef } from "../../../../utils/mock-destroy-ref";
 import { AlertService } from "../../../alerts/alert.service";
 import { mockEntityMapperProvider } from "../../../entity/entity-mapper/mock-entity-mapper-service";
 import { CurrentUserSubject } from "../../../session/current-user-subject";
@@ -80,7 +81,7 @@ describe("EntityInlineEditActionsComponent", () => {
       const entityFormService = TestBed.inject(EntityFormService);
       let entityForm: any;
       entityFormService
-        .createEntityForm(["name", "gender"], child)
+        .createEntityForm(["name", "gender"], child, new MockDestroyRef())
         .then((form) => (entityForm = form));
       await vi.advanceTimersByTimeAsync(0);
 

--- a/src/app/core/common-components/entities-table/entity-inline-edit-actions/entity-inline-edit-actions.component.ts
+++ b/src/app/core/common-components/entities-table/entity-inline-edit-actions/entity-inline-edit-actions.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   inject,
   input,
   ChangeDetectionStrategy,
@@ -37,6 +38,7 @@ export class EntityInlineEditActionsComponent<T extends Entity = Entity> {
   private alertService = inject(AlertService);
   private entityRemoveService = inject(EntityActionsService);
   private unsavedChanges = inject(UnsavedChangesService);
+  private readonly destroyRef = inject(DestroyRef);
 
   row = input.required<TableRow<T>>();
 
@@ -46,6 +48,7 @@ export class EntityInlineEditActionsComponent<T extends Entity = Entity> {
     this.form = await this.entityFormService.createEntityForm(
       Array.from(this.row().record.getSchema().keys()),
       this.row().record,
+      this.destroyRef,
       true,
     );
 
@@ -80,6 +83,8 @@ export class EntityInlineEditActionsComponent<T extends Entity = Entity> {
    */
   resetChanges() {
     delete this.row().formGroup;
-    this.unsavedChanges.pending.set(false);
+    if (this.form) {
+      this.unsavedChanges.setUnsavedChanges(this.form, false);
+    }
   }
 }

--- a/src/app/core/common-components/entity-form/entity-form.service.spec.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.spec.ts
@@ -15,8 +15,7 @@ import { ChildSchoolRelation } from "../../../child-dev-project/children/model/c
 import { EntityAbility } from "../../permissions/ability/entity-ability";
 import { InvalidFormFieldError } from "./invalid-form-field.error";
 import { UnsavedChangesService } from "../../entity-details/form/unsaved-changes.service";
-import { Router } from "@angular/router";
-import { NotFoundComponent } from "../../config/dynamic-routing/not-found/not-found.component";
+import { MockDestroyRef } from "../../../utils/mock-destroy-ref";
 import {
   EntitySchemaField,
   PLACEHOLDERS,
@@ -36,12 +35,31 @@ import { EventEmitter } from "@angular/core";
 
 describe("EntityFormService", () => {
   let service: EntityFormService;
+  let destroyRef: MockDestroyRef;
+
+  /** wrapper passing a controllable DestroyRef to the service under test */
+  const createForm = <T extends Entity>(
+    formFields: Parameters<EntityFormService["createEntityForm"]>[0],
+    entity: T,
+    forTable?: boolean,
+    withPermissionCheck?: boolean,
+    withDefaultValues?: boolean,
+  ) =>
+    service.createEntityForm(
+      formFields,
+      entity,
+      destroyRef,
+      forTable,
+      withPermissionCheck,
+      withDefaultValues,
+    );
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MockedTestingModule.withState()],
     });
     service = TestBed.inject(EntityFormService);
+    destroyRef = new MockDestroyRef();
   }));
 
   it("should be created", () => {
@@ -129,7 +147,7 @@ describe("EntityFormService", () => {
     });
 
     const formFields = [{ id: "name" }, { id: "result" }];
-    const form = await service.createEntityForm(formFields, new TestEntity());
+    const form = await createForm(formFields, new TestEntity());
 
     expect(form.formGroup.valid).toBe(false);
 
@@ -160,10 +178,7 @@ describe("EntityFormService", () => {
       },
     ]);
 
-    const formGroup = await service.createEntityForm(
-      formFields,
-      new TestEntity(),
-    );
+    const formGroup = await createForm(formFields, new TestEntity());
 
     expect(formGroup.formGroup.get("name").disabled).toBe(true);
     expect(formGroup.formGroup.get("dateOfBirth").enabled).toBe(true);
@@ -183,7 +198,7 @@ describe("EntityFormService", () => {
     const child = new TestEntity();
     child._rev = "foo"; // "not new" state
 
-    const form = await service.createEntityForm(formFields, child);
+    const form = await createForm(formFields, child);
 
     expect(form.formGroup.get("name").enabled).toBe(true);
     expect(form.formGroup.get("dateOfBirth").disabled).toBe(true);
@@ -201,10 +216,7 @@ describe("EntityFormService", () => {
 
   it("should create a error if form is invalid", async () => {
     const formFields = [{ id: "schoolId" }, { id: "start" }];
-    const form = await service.createEntityForm(
-      formFields,
-      new ChildSchoolRelation(),
-    );
+    const form = await createForm(formFields, new ChildSchoolRelation());
 
     return expect(
       service.saveChanges(form, new ChildSchoolRelation()),
@@ -213,7 +225,7 @@ describe("EntityFormService", () => {
 
   it("should set pending changes once a form is edited and reset it once saved or canceled", async () => {
     const formFields = [{ id: "inactive" }];
-    const form = await service.createEntityForm(formFields, new Entity());
+    const form = await createForm(formFields, new Entity());
     const unsavedChanges = TestBed.inject(UnsavedChangesService);
 
     form.formGroup.markAsDirty();
@@ -238,15 +250,12 @@ describe("EntityFormService", () => {
 
   it("should disable fields that have readonlyAfterSet validator and have a value", async () => {
     const formFields = [{ id: "name", validators: { readonlyAfterSet: true } }];
-    const formWithNewEntity = await service.createEntityForm(
-      formFields,
-      new TestEntity(),
-    );
+    const formWithNewEntity = await createForm(formFields, new TestEntity());
     formWithNewEntity.formGroup.controls["name"].setValue("test");
     // should not disable while still editing the first time
     expect(formWithNewEntity.formGroup.get("name").disabled).toBe(false);
 
-    const formWithExistingEntity = await service.createEntityForm(
+    const formWithExistingEntity = await createForm(
       formFields,
       TestEntity.create({ name: "existing name", _rev: "1" }),
     );
@@ -275,7 +284,7 @@ describe("EntityFormService", () => {
 
     const formFields = ["simpleField", "getterField", "emptyField"];
     const mockEntity = new MockEntity();
-    const form = await service.createEntityForm(formFields, mockEntity);
+    const form = await createForm(formFields, mockEntity);
 
     form.formGroup.get("simpleField").setValue("new");
     form.formGroup.get("getterField").setValue("new value");
@@ -288,18 +297,18 @@ describe("EntityFormService", () => {
     expect(form.formGroup.get("emptyField").value).toBeUndefined();
   });
 
-  it("should reset state once navigation happens", async () => {
-    const router = TestBed.inject(Router);
-    router.resetConfig([{ path: "test", component: NotFoundComponent }]);
+  it("should clear pending changes and stop tracking once the DestroyRef is destroyed (no leak)", async () => {
     const unsavedChanged = TestBed.inject(UnsavedChangesService);
     const formFields = [{ id: "inactive" }];
-    const formGroup = await service.createEntityForm(formFields, new Entity());
+    const formGroup = await createForm(formFields, new Entity());
     formGroup.formGroup.markAsDirty();
     formGroup.formGroup.get("inactive").setValue(true);
 
     expect(unsavedChanged.pending()).toBe(true);
 
-    await router.navigate(["test"]);
+    // Simulate the hosting component/dialog being destroyed while still dirty
+    // (e.g. cancelling a dialog). The leaked-subscription bug left this pending forever.
+    destroyRef.destroy();
 
     expect(unsavedChanged.pending()).toBe(false);
 
@@ -319,10 +328,7 @@ describe("EntityFormService", () => {
     };
     TestEntity.schema.set("test", schema);
 
-    let form = await service.createEntityForm(
-      [{ id: "test" }],
-      new TestEntity(),
-    );
+    let form = await createForm([{ id: "test" }], new TestEntity());
     expect(form.formGroup.get("test").value).toEqual(1);
 
     schema.defaultValue = {
@@ -330,7 +336,7 @@ describe("EntityFormService", () => {
       config: { value: PLACEHOLDERS.NOW },
     };
 
-    form = await service.createEntityForm([{ id: "test" }], new TestEntity());
+    form = await createForm([{ id: "test" }], new TestEntity());
     expect(
       moment(form.formGroup.get("test").value).isSame(moment(), "minutes"),
     ).toBe(true);
@@ -339,14 +345,14 @@ describe("EntityFormService", () => {
       mode: "dynamic",
       config: { value: PLACEHOLDERS.CURRENT_USER },
     };
-    form = await service.createEntityForm([{ id: "test" }], new TestEntity());
+    form = await createForm([{ id: "test" }], new TestEntity());
     expect(form.formGroup.get("test").value).toEqual(
       `${TestEntity.ENTITY_TYPE}:${TEST_USER}`,
     );
 
     schema.dataType = EntityDatatype.dataType;
     schema.isArray = true;
-    form = await service.createEntityForm([{ id: "test" }], new TestEntity());
+    form = await createForm([{ id: "test" }], new TestEntity());
     expect(form.formGroup.get("test").value).toEqual([
       `${TestEntity.ENTITY_TYPE}:${TEST_USER}`,
     ]);
@@ -362,7 +368,7 @@ describe("EntityFormService", () => {
       },
     });
 
-    const form = await service.createEntityForm(
+    const form = await createForm(
       [{ id: "test" }],
       new TestEntity(),
       false,
@@ -384,16 +390,13 @@ describe("EntityFormService", () => {
         config: { value: PLACEHOLDERS.CURRENT_USER },
       },
     });
-    let form = await service.createEntityForm(
-      [{ id: "user" }],
-      new TestEntity(),
-    );
+    let form = await createForm([{ id: "user" }], new TestEntity());
     expect(form.formGroup.get("user").value).toEqual(null);
 
     // array property
     TestEntity.schema.get("user").dataType = EntityDatatype.dataType;
     TestEntity.schema.get("user").isArray = true;
-    form = await service.createEntityForm([{ id: "user" }], new TestEntity());
+    form = await createForm([{ id: "user" }], new TestEntity());
     expect(form.formGroup.get("user").value).toEqual(null);
 
     TestEntity.schema.delete("user");
@@ -409,7 +412,7 @@ describe("EntityFormService", () => {
 
     const entity = new TestEntity();
     entity._rev = "1-existing_entity";
-    const form = await service.createEntityForm([{ id: "test" }], entity);
+    const form = await createForm([{ id: "test" }], entity);
     expect(form.formGroup.get("test").value).toEqual(null);
 
     TestEntity.schema.delete("test");
@@ -425,7 +428,7 @@ describe("EntityFormService", () => {
 
     const entity = new TestEntity();
     entity["test"] = 2;
-    const form = await service.createEntityForm([{ id: "test" }], entity);
+    const form = await createForm([{ id: "test" }], entity);
     expect(form.formGroup.get("test").value).toEqual(2);
 
     TestEntity.schema.delete("test");
@@ -435,7 +438,7 @@ describe("EntityFormService", () => {
     TestEntity.schema.set("test", { dataType: "string" });
 
     const entity = new TestEntity();
-    const form = await service.createEntityForm([{ id: "test" }], entity);
+    const form = await createForm([{ id: "test" }], entity);
     form.formGroup.get("test").reset();
     expect(form.formGroup.get("test").getRawValue()).toEqual(null);
 

--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, inject, Injectable } from "@angular/core";
+import { DestroyRef, EventEmitter, inject, Injectable } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, FormControlOptions } from "@angular/forms";
 import { ColumnConfig, FormFieldConfig, toFormFieldConfig } from "./FormConfig";
 import { Entity, EntityConstructor } from "../../entity/model/entity";
@@ -8,8 +9,6 @@ import { DynamicValidatorsService } from "./dynamic-form-validators/dynamic-vali
 import { EntityAbility } from "../../permissions/ability/entity-ability";
 import { InvalidFormFieldError } from "./invalid-form-field.error";
 import { UnsavedChangesService } from "../../entity-details/form/unsaved-changes.service";
-import { ActivationStart, Router } from "@angular/router";
-import { Subscription } from "rxjs";
 import { filter } from "rxjs/operators";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
 import { DefaultValueService } from "../../default-values/default-value-service/default-value.service";
@@ -33,21 +32,6 @@ export class EntityFormService {
   private ability = inject(EntityAbility);
   private unsavedChanges = inject(UnsavedChangesService);
   private defaultValueService = inject(DefaultValueService);
-
-  private subscriptions: Subscription[] = [];
-
-  constructor() {
-    const router = inject(Router);
-
-    router.events
-      .pipe(filter((e) => e instanceof ActivationStart))
-      .subscribe(() => {
-        // Clean up everything once navigation happens
-        this.subscriptions.forEach((sub) => sub.unsubscribe());
-        this.subscriptions = [];
-        this.unsavedChanges.pending.set(false);
-      });
-  }
 
   /**
    * Uses schema information to fill missing fields in the FormFieldConfig.
@@ -113,6 +97,8 @@ export class EntityFormService {
    * Missing fields in the formFields are filled with schema information.
    * @param formFields
    * @param entity
+   * @param destroyRef the caller's DestroyRef, used to scope the form's change tracking to the
+   *   caller's lifecycle (so its unsaved-changes state is cleared when the caller is destroyed)
    * @param forTable
    * @param withPermissionCheck if true, fields without 'update' permissions will stay disabled when enabling form
    * @param withDefaultValues if true, default value strategies are initialized and applied
@@ -120,6 +106,7 @@ export class EntityFormService {
   public async createEntityForm<T extends Entity>(
     formFields: ColumnConfig[],
     entity: T,
+    destroyRef: DestroyRef,
     forTable = false,
     withPermissionCheck = true,
     withDefaultValues = true,
@@ -131,6 +118,7 @@ export class EntityFormService {
     const typedFormGroup: TypedFormGroup<Partial<T>> = this.createFormGroup(
       fields,
       entity,
+      destroyRef,
       withPermissionCheck,
     );
 
@@ -142,6 +130,22 @@ export class EntityFormService {
       inheritedParentValues: new Map(),
       watcher: new Map(),
     };
+
+    // Track unsaved changes for this form, keyed by the EntityForm itself.
+    // Both the subscription and the final cleanup are tied to the caller's lifecycle,
+    // so a closed/destroyed form never leaves stale "pending changes" behind.
+    // Note: if a caller creates several forms over its lifetime (e.g. reloading a
+    // resource), each form's state is only cleared when the shared DestroyRef is
+    // destroyed, not when a form is replaced - acceptable, as routed views guard
+    // navigation via canDeactivate and dialogs are destroyed on close.
+    typedFormGroup.valueChanges
+      .pipe(takeUntilDestroyed(destroyRef))
+      .subscribe(() =>
+        this.unsavedChanges.setUnsavedChanges(entityForm, typedFormGroup.dirty),
+      );
+    destroyRef.onDestroy(() =>
+      this.unsavedChanges.setUnsavedChanges(entityForm, false),
+    );
 
     if (withDefaultValues) {
       await this.defaultValueService.handleEntityForm(entityForm, entity);
@@ -160,6 +164,7 @@ export class EntityFormService {
   private createFormGroup<T extends Entity>(
     formFields: FormFieldConfig[],
     entity: T,
+    destroyRef: DestroyRef,
     withPermissionCheck = true,
   ): EntityFormGroup<T> {
     const formConfig = {};
@@ -174,18 +179,14 @@ export class EntityFormService {
     }
     const group = this.fb.group<Partial<T>>(formConfig);
 
-    const valueChangesSubscription = group.valueChanges.subscribe(() =>
-      this.unsavedChanges.pending.set(group.dirty),
-    );
-
-    this.subscriptions.push(valueChangesSubscription);
-
     if (withPermissionCheck) {
       this.disableReadOnlyFormControls(group, entity);
-      const statusChangesSubscription = group.statusChanges
-        .pipe(filter((status) => status !== "DISABLED"))
+      group.statusChanges
+        .pipe(
+          filter((status) => status !== "DISABLED"),
+          takeUntilDestroyed(destroyRef),
+        )
         .subscribe(() => this.disableReadOnlyFormControls(group, entity));
-      this.subscriptions.push(statusChangesSubscription);
     }
 
     return group;
@@ -259,7 +260,7 @@ export class EntityFormService {
       );
     }
 
-    this.unsavedChanges.pending.set(false);
+    this.unsavedChanges.setUnsavedChanges(entityForm, false);
     form.markAsPristine();
     form.disable();
     Object.assign(entity, updatedEntity);
@@ -324,7 +325,7 @@ export class EntityFormService {
     }
 
     form.markAsPristine();
-    this.unsavedChanges.pending.set(false);
+    this.unsavedChanges.setUnsavedChanges(entityForm, false);
     entityForm.onFormStateChange.emit("cancelled");
   }
 }

--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -132,12 +132,11 @@ export class EntityFormService {
     };
 
     // Track unsaved changes for this form, keyed by the EntityForm itself.
-    // Both the subscription and the final cleanup are tied to the caller's lifecycle,
-    // so a closed/destroyed form never leaves stale "pending changes" behind.
+    // Both the subscription and the final cleanup are tied to the caller's lifecycle.
     // Note: if a caller creates several forms over its lifetime (e.g. reloading a
-    // resource), each form's state is only cleared when the shared DestroyRef is
-    // destroyed, not when a form is replaced - acceptable, as routed views guard
-    // navigation via canDeactivate and dialogs are destroyed on close.
+    // resource), it should explicitly clear the old form's state via
+    // `setUnsavedChanges(oldForm, false)` before replacing it, to prevent stale
+    // dirty state from accumulating in UnsavedChangesService.sources.
     typedFormGroup.valueChanges
       .pipe(takeUntilDestroyed(destroyRef))
       .subscribe(() =>

--- a/src/app/core/common-components/entity-form/entity-form/entity-form.component.spec.ts
+++ b/src/app/core/common-components/entity-form/entity-form/entity-form.component.spec.ts
@@ -8,6 +8,7 @@ import { EntityFormService } from "../entity-form.service";
 import { DateWithAge } from "../../../basic-datatypes/date-with-age/dateWithAge";
 import { EntityAbility } from "../../../permissions/ability/entity-ability";
 import { TestEntity } from "../../../../utils/test-utils/TestEntity";
+import { MockDestroyRef } from "../../../../utils/mock-destroy-ref";
 
 describe("EntityFormComponent", () => {
   let component: EntityFormComponent<TestEntity>;
@@ -41,6 +42,7 @@ describe("EntityFormComponent", () => {
     const form = await TestBed.inject(EntityFormService).createEntityForm(
       columns[0],
       entity,
+      new MockDestroyRef(),
     );
     fixture.componentRef.setInput("entity", entity);
     fixture.componentRef.setInput(

--- a/src/app/core/entity-details/form/form.component.ts
+++ b/src/app/core/entity-details/form/form.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -46,6 +47,7 @@ export class FormComponent<E extends Entity> {
   private alertService = inject(AlertService);
   private viewContext = inject(ViewComponentContext, { optional: true });
   private readonly permissionService = inject(PublicFormPermissionService);
+  private readonly destroyRef = inject(DestroyRef);
   entity = input<E>();
   creatingNew = input<boolean>(false);
   fieldGroups = input<FieldGroup[]>();
@@ -57,6 +59,7 @@ export class FormComponent<E extends Entity> {
       return this.entityFormService.createEntityForm(
         [].concat(...fieldGroups.map((group) => group.fields)),
         entity,
+        this.destroyRef,
       );
     },
   });

--- a/src/app/core/entity-details/form/unsaved-changes.service.spec.ts
+++ b/src/app/core/entity-details/form/unsaved-changes.service.spec.ts
@@ -7,6 +7,10 @@ describe("UnsavedChangesService", () => {
   let service: UnsavedChangesService;
   let mockConfirmation: any;
 
+  // arbitrary stable object identities used as change "sources"
+  const sourceA = { id: "A" };
+  const sourceB = { id: "B" };
+
   beforeEach(() => {
     mockConfirmation = {
       getDiscardConfirmation: vi.fn(),
@@ -23,13 +27,30 @@ describe("UnsavedChangesService", () => {
     expect(service).toBeTruthy();
   });
 
+  it("should report pending as long as at least one source has unsaved changes", () => {
+    expect(service.pending()).toBe(false);
+
+    service.setUnsavedChanges(sourceA, true);
+    expect(service.pending()).toBe(true);
+
+    service.setUnsavedChanges(sourceB, true);
+    expect(service.pending()).toBe(true);
+
+    // clearing one source leaves the other still pending (multi-layer)
+    service.setUnsavedChanges(sourceA, false);
+    expect(service.pending()).toBe(true);
+
+    service.setUnsavedChanges(sourceB, false);
+    expect(service.pending()).toBe(false);
+  });
+
   it("should only ask for confirmation if changes are pending", async () => {
     mockConfirmation.getDiscardConfirmation.mockResolvedValue(false);
 
     await expect(service.checkUnsavedChanges()).resolves.toEqual(true);
     expect(mockConfirmation.getDiscardConfirmation).not.toHaveBeenCalled();
 
-    service.pending.set(true);
+    service.setUnsavedChanges(sourceA, true);
 
     await expect(service.checkUnsavedChanges()).resolves.toEqual(false);
     expect(mockConfirmation.getDiscardConfirmation).toHaveBeenCalled();
@@ -37,18 +58,38 @@ describe("UnsavedChangesService", () => {
     mockConfirmation.getDiscardConfirmation.mockResolvedValue(true);
 
     await expect(service.checkUnsavedChanges()).resolves.toEqual(true);
+    // confirming discards all sources
+    expect(service.pending()).toBe(false);
+  });
+
+  it("should only consider the given source when checking a single dialog (multi-layer)", async () => {
+    mockConfirmation.getDiscardConfirmation.mockResolvedValue(true);
+
+    // only the outer view (sourceB) is dirty; the dialog (sourceA) is clean
+    service.setUnsavedChanges(sourceB, true);
+
+    // closing the clean dialog must not prompt and must not discard the outer view
+    await expect(service.checkUnsavedChanges(sourceA)).resolves.toBe(true);
+    expect(mockConfirmation.getDiscardConfirmation).not.toHaveBeenCalled();
+    expect(service.pending()).toBe(true);
+
+    // now the dialog itself is dirty: confirming discards only the dialog's changes
+    service.setUnsavedChanges(sourceA, true);
+    await expect(service.checkUnsavedChanges(sourceA)).resolves.toBe(true);
+    expect(mockConfirmation.getDiscardConfirmation).toHaveBeenCalledTimes(1);
+    // the outer view remains dirty
+    expect(service.pending()).toBe(true);
   });
 
   it("should prevent closing the window if changes are pending", () => {
     const e = { preventDefault: vi.fn(), returnValue: undefined };
 
-    service.pending.set(false);
     window.onbeforeunload(e as any);
 
     expect(e.preventDefault).not.toHaveBeenCalled();
     expect(e.returnValue).toBeUndefined();
 
-    service.pending.set(true);
+    service.setUnsavedChanges(sourceA, true);
     window.onbeforeunload(e as any);
 
     expect(e.preventDefault).toHaveBeenCalled();

--- a/src/app/core/entity-details/form/unsaved-changes.service.ts
+++ b/src/app/core/entity-details/form/unsaved-changes.service.ts
@@ -1,10 +1,15 @@
-import { Injectable, inject, signal } from "@angular/core";
+import { Injectable, Signal, computed, inject, signal } from "@angular/core";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 
 /**
  * This service handles the state whether there are currently some unsaved changes in the app.
  * These pending changes might come from a form component or popup.
  * If there are pending changes, certain actions in the app should trigger a user confirmation if the changes should be discarded.
+ *
+ * Changes are tracked per "source" (e.g. an individual form or component) so that multiple layers
+ * of unsaved changes can coexist (e.g. a dirty main view with a dirty dialog form opened on top of it).
+ * Each source is responsible for registering and clearing its own state
+ * (usually tied to its lifecycle via `DestroyRef`).
  */
 @Injectable({
   providedIn: "root",
@@ -12,11 +17,13 @@ import { ConfirmationDialogService } from "../../common-components/confirmation-
 export class UnsavedChangesService {
   private confirmation = inject(ConfirmationDialogService);
 
+  /** the set of sources (forms, components, ...) that currently have unsaved changes */
+  private readonly sources = signal(new Set<object>());
+
   /**
-   * Set to true if the user has pending changes that are not yet saved.
-   * Set to false once the changes have been saved or discarded.
+   * Whether the user has any pending changes that are not yet saved.
    */
-  pending = signal(false);
+  readonly pending: Signal<boolean> = computed(() => this.sources().size > 0);
 
   constructor() {
     // prevent browser navigation if changes are pending
@@ -29,18 +36,51 @@ export class UnsavedChangesService {
   }
 
   /**
-   * Shows a user confirmation popup if there are unsaved changes which will be discarded.
+   * Register or clear the unsaved-changes state for a specific source.
+   *
+   * A source can be any stable object identity (e.g. an `EntityForm` or a component instance).
+   * Sources should clear their state when destroyed (e.g. via `DestroyRef.onDestroy`).
+   *
+   * @param source the object identifying the origin of the changes
+   * @param hasChanges whether this source currently has unsaved changes
    */
-  async checkUnsavedChanges() {
-    if (this.pending()) {
-      const confirmed = await this.confirmation.getDiscardConfirmation();
-      if (confirmed) {
-        this.pending.set(false);
-        return true;
+  setUnsavedChanges(source: object, hasChanges: boolean) {
+    const current = this.sources();
+    if (hasChanges === current.has(source)) {
+      // no change - avoid needless signal updates
+      return;
+    }
+    const next = new Set(current);
+    if (hasChanges) {
+      next.add(source);
+    } else {
+      next.delete(source);
+    }
+    this.sources.set(next);
+  }
+
+  /**
+   * Shows a user confirmation popup if there are unsaved changes which will be discarded.
+   *
+   * @param source if given, only this source's changes are considered (and discarded on confirm),
+   *   e.g. when closing a single dialog. If omitted, all sources are considered (and discarded on
+   *   confirm), e.g. when navigating away from the whole view.
+   * @returns whether it is safe to proceed (no changes, or the user confirmed discarding them)
+   */
+  async checkUnsavedChanges(source?: object): Promise<boolean> {
+    const hasChanges = source ? this.sources().has(source) : this.pending();
+    if (!hasChanges) {
+      return true;
+    }
+
+    const confirmed = !!(await this.confirmation.getDiscardConfirmation());
+    if (confirmed) {
+      if (source) {
+        this.setUnsavedChanges(source, false);
       } else {
-        return false;
+        this.sources.set(new Set());
       }
     }
-    return true;
+    return confirmed;
   }
 }

--- a/src/app/core/entity/entity-actions/entity-bulk-edit/entity-bulk-edit.component.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-bulk-edit/entity-bulk-edit.component.spec.ts
@@ -114,11 +114,7 @@ describe("EntityBulkEditComponent", () => {
     expect(mockDialogRef.close).not.toHaveBeenCalled();
   });
 
-  it("should reset unsaved changes to previous state when dialog closes without save", () => {
-    mockUnsavedChanges.pending.set(true);
-
-    beforeClosed$.next(undefined);
-
-    expect(mockUnsavedChanges.pending()).toBe(false);
-  });
+  // The bulk-edit form's unsaved-changes state is now tracked per-form and cleared
+  // automatically when the dialog's DestroyRef is destroyed (see EntityFormService),
+  // so the component no longer restores a previous global pending state on close.
 });

--- a/src/app/core/entity/entity-actions/entity-bulk-edit/entity-bulk-edit.component.ts
+++ b/src/app/core/entity/entity-actions/entity-bulk-edit/entity-bulk-edit.component.ts
@@ -2,6 +2,7 @@ import { EntityForm } from "#src/app/core/common-components/entity-form/entity-f
 import { EntityFieldEditComponent } from "#src/app/core/entity/entity-field-edit/entity-field-edit.component";
 import {
   Component,
+  DestroyRef,
   inject,
   OnInit,
   ChangeDetectionStrategy,
@@ -27,7 +28,6 @@ import { EntityFormService } from "app/core/common-components/entity-form/entity
 import { FormFieldConfig } from "app/core/common-components/entity-form/FormConfig";
 import { Entity, EntityConstructor } from "../../model/entity";
 import { EntityFieldSelectComponent } from "#src/app/core/entity/entity-field-select/entity-field-select.component";
-import { UnsavedChangesService } from "#src/app/core/entity-details/form/unsaved-changes.service";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -51,8 +51,7 @@ import { UnsavedChangesService } from "#src/app/core/entity-details/form/unsaved
 export class EntityBulkEditComponent<E extends Entity> implements OnInit {
   private dialogRef = inject<MatDialogRef<any>>(MatDialogRef);
   private entityFormService = inject(EntityFormService);
-  private readonly unsavedChanges = inject(UnsavedChangesService);
-  private readonly pendingStateBeforeDialogOpen = this.unsavedChanges.pending();
+  private readonly destroyRef = inject(DestroyRef);
 
   entityConstructor: EntityConstructor;
   entitiesToEdit: E[];
@@ -77,12 +76,8 @@ export class EntityBulkEditComponent<E extends Entity> implements OnInit {
 
   ngOnInit(): void {
     this.initForm();
-
-    this.dialogRef.beforeClosed().subscribe((result) => {
-      if (!result) {
-        this.unsavedChanges.pending.set(this.pendingStateBeforeDialogOpen);
-      }
-    });
+    // The bulk-edit form's unsaved-changes state is tracked per-form and cleared
+    // automatically when this dialog (and thus its DestroyRef) is destroyed.
   }
 
   private initForm() {
@@ -104,6 +99,7 @@ export class EntityBulkEditComponent<E extends Entity> implements OnInit {
     this.fieldValueForm = await this.entityFormService.createEntityForm(
       fieldKeys,
       this.entityData,
+      this.destroyRef,
     );
 
     const selectedField = this.selectedFieldFormControl.value;

--- a/src/app/core/form-dialog/dialog-buttons/dialog-buttons.component.spec.ts
+++ b/src/app/core/form-dialog/dialog-buttons/dialog-buttons.component.spec.ts
@@ -153,26 +153,25 @@ describe("DialogButtonsComponent", () => {
     }
   });
 
-  it("should reset pending changes when dialog is closed", () => {
+  it("should discard this form's unsaved changes on cancel", () => {
     const unsavedChanges = TestBed.inject(UnsavedChangesService);
-    unsavedChanges.pending.set(true);
+    unsavedChanges.setUnsavedChanges(component.form(), true);
+    expect(unsavedChanges.pending()).toBe(true);
 
-    closed.next();
+    component.cancel();
 
     expect(unsavedChanges.pending()).toBe(false);
+    expect(dialogRef.close).toHaveBeenCalled();
   });
 
-  it("should restore previous pending state when dialog is closed", () => {
-    fixture.destroy();
-    closed = new Subject<void>();
-    dialogRef.afterClosed.mockReturnValue(closed);
-
+  it("should not discard unsaved changes of other layers on cancel", () => {
     const unsavedChanges = TestBed.inject(UnsavedChangesService);
-    unsavedChanges.pending.set(true);
-    createComponent();
+    const outerViewChanges = {};
+    unsavedChanges.setUnsavedChanges(outerViewChanges, true);
 
-    closed.next();
+    component.cancel();
 
+    // changes of the view underneath this dialog remain untouched
     expect(unsavedChanges.pending()).toBe(true);
   });
 });

--- a/src/app/core/form-dialog/dialog-buttons/dialog-buttons.component.ts
+++ b/src/app/core/form-dialog/dialog-buttons/dialog-buttons.component.ts
@@ -6,7 +6,6 @@ import {
   output,
   computed,
   effect,
-  signal,
 } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
 import { Angulartics2Module } from "angulartics2";
@@ -47,12 +46,6 @@ export class DialogButtonsComponent<E extends Entity> {
   private router = inject(Router);
   private ability = inject(EntityAbility);
   private unsavedChanges = inject(UnsavedChangesService);
-  private readonly pendingStateBeforeDialogOpen = signal(
-    this.dialog ? this.unsavedChanges.pending() : false,
-  );
-  private readonly pendingStateAfterClose = computed(() =>
-    this.dialog ? this.pendingStateBeforeDialogOpen() : false,
-  );
 
   protected viewContext = inject(ViewComponentContext, { optional: true });
 
@@ -93,14 +86,14 @@ export class DialogButtonsComponent<E extends Entity> {
   private initDialogSettings() {
     this.dialog.disableClose = true;
     this.dialog.backdropClick().subscribe(() =>
-      this.unsavedChanges.checkUnsavedChanges().then((confirmed) => {
+      // only consider this dialog's own form, so a dirty view underneath the dialog
+      // does not trigger a discard prompt for changes unrelated to this dialog
+      this.unsavedChanges.checkUnsavedChanges(this.form()).then((confirmed) => {
         if (confirmed) {
           this.dialog.close();
         }
       }),
     );
-    // Dialog closing happens before the `canDeactivate` check, so restore the state synchronously.
-    this.dialog.afterClosed().subscribe(() => this.restorePendingChanges());
   }
 
   async save() {
@@ -120,18 +113,14 @@ export class DialogButtonsComponent<E extends Entity> {
   }
 
   cancel() {
+    // discard this form's unsaved changes
+    this.unsavedChanges.setUnsavedChanges(this.form(), false);
     this.close();
   }
 
   close(result?: any) {
     this.dialog?.close(result);
     this.closeView.emit(result);
-
-    this.restorePendingChanges();
-  }
-
-  private restorePendingChanges() {
-    this.unsavedChanges.pending.set(this.pendingStateAfterClose());
   }
 
   onAction(action: string) {

--- a/src/app/core/form-dialog/row-details/row-details.component.ts
+++ b/src/app/core/form-dialog/row-details/row-details.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   inject,
   OnInit,
 } from "@angular/core";
@@ -59,6 +60,7 @@ export class RowDetailsComponent implements OnInit {
   data = inject<DetailsComponentData>(MAT_DIALOG_DATA);
   private formService = inject(EntityFormService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   form: EntityForm<Entity>;
   fieldGroups: FieldGroup[];
@@ -76,6 +78,7 @@ export class RowDetailsComponent implements OnInit {
     this.form = await this.formService.createEntityForm(
       data.columns,
       data.entity,
+      this.destroyRef,
     );
     this.enableSaveWithoutChangesIfNew(data.entity);
 

--- a/src/app/core/form-dialog/row-details/row-details.component.ts
+++ b/src/app/core/form-dialog/row-details/row-details.component.ts
@@ -80,7 +80,6 @@ export class RowDetailsComponent implements OnInit {
       data.entity,
       this.destroyRef,
     );
-    this.enableSaveWithoutChangesIfNew(data.entity);
 
     this.fieldGroups = data.columns.map((col) => ({ fields: [col] }));
     this.tempEntity = this.data.entity;
@@ -93,12 +92,5 @@ export class RowDetailsComponent implements OnInit {
       });
     this.viewOnlyColumns = data.viewOnlyColumns;
     this.cdr.markForCheck();
-  }
-
-  private enableSaveWithoutChangesIfNew(entity: Entity) {
-    if (entity.isNew) {
-      // could check here that at least some fields hold a value but the naive heuristic to allow save of all new seems ok
-      this.form.formGroup.markAsDirty();
-    }
   }
 }

--- a/src/app/core/ui/latest-changes/update-manager.service.spec.ts
+++ b/src/app/core/ui/latest-changes/update-manager.service.spec.ts
@@ -1,5 +1,5 @@
 import { UpdateManagerService } from "./update-manager.service";
-import { ApplicationRef, signal } from "@angular/core";
+import { ApplicationRef, signal, WritableSignal } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import {
   SwUpdate,
@@ -133,7 +133,7 @@ describe("UpdateManagerService", () => {
 
   it("should reload app if no unsaved changes are detected", () => {
     service.listenToAppUpdates();
-    unsavedChanges.pending.set(true);
+    (unsavedChanges.pending as WritableSignal<boolean>).set(true);
 
     updateSubject.next(createVersionReadyEvent());
 
@@ -141,7 +141,7 @@ describe("UpdateManagerService", () => {
     expect(snackBar.open).toHaveBeenCalled();
 
     createService();
-    unsavedChanges.pending.set(false);
+    (unsavedChanges.pending as WritableSignal<boolean>).set(false);
 
     updateSubject.next(createVersionReadyEvent());
 

--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.spec.ts
@@ -115,7 +115,7 @@ describe("RollCallComponent", () => {
         },
         {
           provide: UnsavedChangesService,
-          useValue: { pending: signal(false) },
+          useValue: { pending: signal(false), setUnsavedChanges: () => {} },
         },
         {
           provide: AttendanceService,

--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   Injectable,
@@ -185,6 +186,11 @@ export class RollCallComponent {
   );
 
   constructor() {
+    // clear this component's unsaved-changes state when it is destroyed
+    inject(DestroyRef).onDestroy(() =>
+      this.unsavedChanges.setUnsavedChanges(this, false),
+    );
+
     // Initialize participants when event is loaded/resolved
     effect(() => {
       const event = this.event();
@@ -363,7 +369,7 @@ export class RollCallComponent {
       attendance.status = status;
     }
     this.isDirty.set(true);
-    this.unsavedChanges.pending.set(true);
+    this.unsavedChanges.setUnsavedChanges(this, true);
 
     this.goToParticipantWithIndex(this.currentIndex() + 1);
   }
@@ -402,7 +408,7 @@ export class RollCallComponent {
             text: $localize`:Discard changes made to a form:Discard`,
             click: (): boolean => {
               this.isDirty.set(false);
-              this.unsavedChanges.pending.set(false);
+              this.unsavedChanges.setUnsavedChanges(this, false);
               this.location.back();
               return false;
             },
@@ -421,7 +427,7 @@ export class RollCallComponent {
       try {
         await this.entityMapper.save(entity);
         this.isDirty.set(false);
-        this.unsavedChanges.pending.set(false);
+        this.unsavedChanges.setUnsavedChanges(this, false);
       } catch (e) {
         Logging.warn("Could not save attendance event", e);
         this.confirmationDialog.getConfirmation(

--- a/src/app/features/bulk-edit/entity-edit.service.ts
+++ b/src/app/features/bulk-edit/entity-edit.service.ts
@@ -1,7 +1,6 @@
 import { inject, Injectable } from "@angular/core";
 import { Entity, EntityConstructor } from "#src/app/core/entity/model/entity";
 import { CascadingEntityAction } from "#src/app/core/entity/entity-actions/cascading-entity-action";
-import { UnsavedChangesService } from "#src/app/core/entity-details/form/unsaved-changes.service";
 import { lastValueFrom } from "rxjs";
 import {
   BulkEditAction,
@@ -21,7 +20,6 @@ import { BulkOperationStateService } from "#src/app/core/entity/entity-actions/b
 export class EntityEditService extends CascadingEntityAction {
   private readonly matDialog = inject(MatDialog);
   private readonly entityActionsService = inject(EntityActionsService);
-  private readonly unsavedChanges = inject(UnsavedChangesService);
   private readonly bulkOperationState = inject(BulkOperationStateService);
 
   /**
@@ -84,7 +82,6 @@ export class EntityEditService extends CascadingEntityAction {
       // Use bulk save for performance - progress tracking happens in bulk-operation-state service
       await this.entityMapper.saveAll(newEntities);
 
-      this.unsavedChanges.pending.set(false);
       return {
         success: true,
         originalEntities,

--- a/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.ts
+++ b/src/app/features/de-duplication/bulk-merge-records/bulk-merge-records.component.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -55,6 +56,7 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
   private readonly confirmationDialog = inject(ConfirmationDialogService);
   private readonly entityFormService = inject(EntityFormService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly accountSection = viewChild(MergeAccountSectionComponent);
 
@@ -98,6 +100,7 @@ export class BulkMergeRecordsComponent<E extends Entity> implements OnInit {
     this.mergeForm = await this.entityFormService.createEntityForm(
       this.fieldsToMerge(),
       this.mergedEntity,
+      this.destroyRef,
       false,
       true,
       false,

--- a/src/app/features/de-duplication/bulk-merge-service.ts
+++ b/src/app/features/de-duplication/bulk-merge-service.ts
@@ -5,7 +5,6 @@ import { MatDialog } from "@angular/material/dialog";
 import { catchError, lastValueFrom, of } from "rxjs";
 import { BulkMergeRecordsComponent } from "app/features/de-duplication/bulk-merge-records/bulk-merge-records.component";
 import { AlertService } from "app/core/alerts/alert.service";
-import { UnsavedChangesService } from "app/core/entity-details/form/unsaved-changes.service";
 import { ConfirmationDialogService } from "app/core/common-components/confirmation-dialog/confirmation-dialog.service";
 import { OkButton } from "app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { AttendanceItem } from "../attendance/model/attendance-item";
@@ -24,7 +23,6 @@ export class BulkMergeService {
   private readonly entityRelationshipService = inject(EntityRelationsService);
   private readonly matDialog = inject(MatDialog);
   private readonly alert = inject(AlertService);
-  private readonly unsavedChangesService = inject(UnsavedChangesService);
   private readonly confirmationDialog = inject(ConfirmationDialogService);
   private readonly userAdminService = inject(UserAdminService);
 
@@ -85,7 +83,8 @@ export class BulkMergeService {
       dialogResult.deleteSecondaryAccount,
       dialogResult.accountUpdate,
     );
-    this.unsavedChangesService.pending.set(false);
+    // the merge dialog's form is already destroyed (and thus its unsaved-changes state cleared)
+    // by the time we reach here, since we awaited its `afterClosed()` above.
     this.alert.addInfo($localize`Records merged successfully.`);
     return true;
   }

--- a/src/app/features/inherited-field/automated-field-update/automated-field-update-config.service.ts
+++ b/src/app/features/inherited-field/automated-field-update/automated-field-update-config.service.ts
@@ -8,7 +8,6 @@ import {
   AutomatedFieldUpdateComponent,
 } from "./automated-field-update.component";
 import { lastValueFrom } from "rxjs";
-import { UnsavedChangesService } from "#src/app/core/entity-details/form/unsaved-changes.service";
 import { DefaultValueConfigInheritedField } from "../inherited-field-config";
 import { Logging } from "#src/app/core/logging/logging.service";
 import { EntitySchemaService } from "#src/app/core/entity/schema/entity-schema.service";
@@ -31,7 +30,6 @@ export class AutomatedFieldUpdateConfigService {
   private readonly entityRegistry = inject(EntityRegistry);
   private readonly entityMapper = inject(EntityMapperService);
   private readonly dialog = inject(MatDialog);
-  private readonly unsavedChangesService = inject(UnsavedChangesService);
   private readonly entitySchemaService = inject(EntitySchemaService);
 
   /**
@@ -416,7 +414,6 @@ export class AutomatedFieldUpdateConfigService {
     });
 
     await Promise.all(savePromises);
-    this.unsavedChangesService.pending.set(false);
   }
 
   /**

--- a/src/app/features/inherited-field/automated-field-update/automated-field-update.component.ts
+++ b/src/app/features/inherited-field/automated-field-update/automated-field-update.component.ts
@@ -3,6 +3,7 @@ import { EntityFieldEditComponent } from "#src/app/core/entity/entity-field-edit
 import { EntitySchemaService } from "#src/app/core/entity/schema/entity-schema.service";
 import {
   Component,
+  DestroyRef,
   inject,
   OnInit,
   ChangeDetectionStrategy,
@@ -83,6 +84,7 @@ export class AutomatedFieldUpdateComponent implements OnInit {
   private readonly entityFormService = inject(EntityFormService);
   private readonly entitySchemaService = inject(EntitySchemaService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   entityConstructor: EntityConstructor;
 
@@ -99,6 +101,7 @@ export class AutomatedFieldUpdateComponent implements OnInit {
       const entityForm = await this.entityFormService.createEntityForm(
         [fieldId],
         entity.affectedEntity,
+        this.destroyRef,
       );
 
       entity.form = entityForm;

--- a/src/app/features/notification/notification-settings/notification-settings.component.spec.ts
+++ b/src/app/features/notification/notification-settings/notification-settings.component.spec.ts
@@ -208,7 +208,7 @@ describe("NotificationSettingComponent", () => {
     component.addNewNotificationRule();
     vi.spyOn(entityMapper, "save").mockReturnValue(Promise.resolve());
     const unsavedChanges = TestBed.inject(UnsavedChangesService);
-    unsavedChanges.pending.set(true);
+    expect(unsavedChanges.pending()).toBe(true);
 
     await component.saveSettings();
 

--- a/src/app/features/notification/notification-settings/notification-settings.component.ts
+++ b/src/app/features/notification/notification-settings/notification-settings.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   inject,
   linkedSignal,
   resource,
@@ -66,6 +67,13 @@ export class NotificationSettingsComponent {
   protected readonly notificationService = inject(NotificationService);
   private readonly alertService = inject(AlertService);
   protected readonly unsavedChanges = inject(UnsavedChangesService);
+
+  constructor() {
+    // clear this component's unsaved-changes state when it is destroyed
+    inject(DestroyRef).onDestroy(() =>
+      this.unsavedChanges.setUnsavedChanges(this, false),
+    );
+  }
 
   readonly accountEmail = toSignal(this.sessionInfo.pipe(map((s) => s?.email)));
 
@@ -163,7 +171,7 @@ export class NotificationSettingsComponent {
       clone.channels = { ...config.channels, email: event.checked };
       return clone;
     });
-    this.unsavedChanges.pending.set(true);
+    this.unsavedChanges.setUnsavedChanges(this, true);
   }
 
   async togglePushNotifications(event: MatSlideToggleChange) {
@@ -207,7 +215,7 @@ export class NotificationSettingsComponent {
       clone.notificationRules = [...(config.notificationRules ?? []), newRule];
       return clone;
     });
-    this.unsavedChanges.pending.set(true);
+    this.unsavedChanges.setUnsavedChanges(this, true);
   }
 
   updateNotificationRule(
@@ -224,13 +232,13 @@ export class NotificationSettingsComponent {
       );
       return clone;
     });
-    this.unsavedChanges.pending.set(true);
+    this.unsavedChanges.setUnsavedChanges(this, true);
   }
 
   async saveSettings() {
     const saved = await this.saveNotificationConfig(this.notificationConfig());
     if (!saved) return;
-    this.unsavedChanges.pending.set(false);
+    this.unsavedChanges.setUnsavedChanges(this, false);
     this.alertService.addInfo($localize`Notification settings saved.`);
   }
 
@@ -254,7 +262,7 @@ export class NotificationSettingsComponent {
         this.notificationConfig(),
       );
       if (!saved) return false;
-      this.unsavedChanges.pending.set(false);
+      this.unsavedChanges.setUnsavedChanges(this, false);
       return true;
     }
     return false;

--- a/src/app/features/public-form/public-form.component.ts
+++ b/src/app/features/public-form/public-form.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   inject,
   OnInit,
   ChangeDetectionStrategy,
@@ -63,6 +64,7 @@ export class PublicFormComponent<E extends Entity> implements OnInit {
 
   private ability = inject(EntityAbility);
   private router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   formConfig = signal<PublicFormConfig | undefined>(undefined);
   entityFormEntries = signal<
@@ -283,6 +285,7 @@ export class PublicFormComponent<E extends Entity> implements OnInit {
       entry.form = await this.entityFormService.createEntityForm(
         [].concat(...entry.fieldGroups.map((group) => group.fields)),
         entry.entity,
+        this.destroyRef,
       );
 
       entry.form.formGroup.valueChanges

--- a/src/app/features/public-form/public-forms.service.ts
+++ b/src/app/features/public-form/public-forms.service.ts
@@ -12,7 +12,6 @@ import { asArray } from "#src/app/utils/asArray";
 import { AdminEntityService } from "app/core/admin/admin-entity.service";
 import { EntityRegistry } from "app/core/entity/database-entity.decorator";
 import { EntityConfigService } from "app/core/entity/entity-config.service";
-import { UnsavedChangesService } from "#src/app/core/entity-details/form/unsaved-changes.service";
 
 @Injectable({
   providedIn: "root",
@@ -24,7 +23,6 @@ export class PublicFormsService {
   private readonly adminEntityService = inject(AdminEntityService);
   private readonly entities = inject(EntityRegistry);
   private readonly entityConfigService = inject(EntityConfigService);
-  private readonly unsavedChangesService = inject(UnsavedChangesService);
 
   /**
    * Initializes and registers custom form actions for entities.
@@ -243,7 +241,6 @@ export class PublicFormsService {
 
     if (hasNewFields) {
       await this.adminEntityService.setAndSaveEntityConfig(entityConstructor);
-      this.unsavedChangesService.pending.set(false);
     }
   }
 }

--- a/src/app/utils/mock-destroy-ref.ts
+++ b/src/app/utils/mock-destroy-ref.ts
@@ -1,0 +1,30 @@
+import { DestroyRef } from "@angular/core";
+
+/**
+ * A controllable {@link DestroyRef} for use in unit tests.
+ *
+ * Collects registered `onDestroy` callbacks and lets the test trigger them
+ * manually via {@link destroy}, so that DestroyRef-scoped cleanup logic
+ * (e.g. `takeUntilDestroyed` or explicit `onDestroy` handlers) can be verified
+ * deterministically without a real component lifecycle.
+ */
+export class MockDestroyRef extends DestroyRef {
+  private readonly callbacks = new Set<() => void>();
+  private _destroyed = false;
+
+  get destroyed(): boolean {
+    return this._destroyed;
+  }
+
+  onDestroy(callback: () => void): () => void {
+    this.callbacks.add(callback);
+    return () => this.callbacks.delete(callback);
+  }
+
+  /** Trigger all registered onDestroy callbacks, simulating destruction. */
+  destroy(): void {
+    this._destroyed = true;
+    this.callbacks.forEach((cb) => cb());
+    this.callbacks.clear();
+  }
+}


### PR DESCRIPTION
closes #4113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unsaved changes are now tracked per form/dialog layer for more accurate discard prompts and safer navigation.
  * Forms now automatically clear draft/unsaved state when their lifecycle ends (such as closing dialogs or removing components).

* **Bug Fixes**
  * Improved cancel/backdrop behavior so discarding affects only the current form layer, not underlying dialogs.
  * Fixed stale unsaved-change warnings after save/reset and during form re-initialization.
  * Updated inline edit, bulk edit, notification settings, attendance, and other form flows to reliably clear unsaved state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->