### PR TITLE
fix: downgrade expected auth/permission log noise from warning to debug

### DIFF
--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -13,6 +13,17 @@ import { AlertService } from "../../alerts/alert.service";
 import { isVersionNewer } from "./version-comparison.utils";
 
 /**
+ * 4XX statuses that occur during normal operation
+ * (and are handled by callers or the auth layer),
+ * so they are not reported to remote logging.
+ */
+const EXPECTED_4XX_STATUSES: number[] = [
+  HttpStatusCode.Unauthorized,
+  HttpStatusCode.Forbidden,
+  HttpStatusCode.NotFound,
+];
+
+/**
  * An alternative implementation of PouchDatabase that directly makes HTTP requests to a remote CouchDB.
  */
 export class RemotePouchDatabase extends PouchDatabase {
@@ -168,6 +179,10 @@ export class RemotePouchDatabase extends PouchDatabase {
         Logging.debug(
           "Notifications database not found (404) - may be expected",
         );
+      } else if (EXPECTED_4XX_STATUSES.includes(result.status)) {
+        // expired session (401), permission-filtered doc (403) and missing doc (404)
+        // are part of normal operation and handled by callers
+        Logging.debug("Failed to fetch from DB with 40X error", result);
       } else {
         Logging.warn("Failed to fetch from DB with 40X error", result);
       }

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -219,6 +219,9 @@ export class SyncedPouchDatabase extends PouchDatabase {
           );
         } else if (this.isSyncConnectivityError(err)) {
           Logging.debug(`sync failed (connectivity)`, { db: this.dbName }, err);
+        } else if (err?.status === 401 || err?.statusCode === 401) {
+          // expired session; the fetch layer already triggers re-login
+          Logging.debug(`sync failed (unauthorized)`, { db: this.dbName }, err);
         } else {
           Logging.warn(`sync failed`, { db: this.dbName }, err);
         }

--- a/src/app/core/entity/entity-mapper/entity-mapper.service.ts
+++ b/src/app/core/entity/entity-mapper/entity-mapper.service.ts
@@ -247,7 +247,8 @@ export class EntityMapperService {
       return;
     }
     if (!this.ability.initialized) {
-      Logging.warn(
+      // known race during app startup; the server still enforces permissions
+      Logging.debug(
         "Permission check skipped: ability not yet initialized",
         entity.getId(),
       );

--- a/src/app/features/inherited-field/inherited-value.service.ts
+++ b/src/app/features/inherited-field/inherited-value.service.ts
@@ -346,11 +346,21 @@ export class InheritedValueService extends DefaultValueStrategy {
         entityId,
       );
     } catch (error) {
-      Logging.warn(
-        "InheritedValueService could not load source entity for inherited field",
-        { entityId },
-        error,
-      );
+      const status = error?.["status"] ?? error?.["statusCode"];
+      if (status === 401 || status === 403) {
+        // the user simply has no read access to the linked entity - expected for some roles
+        Logging.debug(
+          "InheritedValueService could not load source entity for inherited field (no permission)",
+          { entityId },
+          error,
+        );
+      } else {
+        Logging.warn(
+          "InheritedValueService could not load source entity for inherited field",
+          { entityId },
+          error,
+        );
+      }
       return undefined;
     }
   }


### PR DESCRIPTION
Part of the Sentry noise reduction effort (see analysis in #4117 context): these four log sites produced **~8,500 Sentry events in the last 30 days** for conditions that are part of normal operation. `Logging.debug` is not forwarded to Sentry, so everything stays visible in the browser console for diagnosis.

## Changes

- **RemotePouchDatabase**: 401/403/404 responses are logged as debug instead of warning — expired sessions trigger re-login in the fetch layer, 403s occur for permission-filtered docs, 404s for missing docs; all handled by callers. Other unexpected 4XX statuses (e.g. 400, 409, 412) still warn. ([AAM-DIGITAL-6HX](https://aam-digital.sentry.io/issues/AAM-DIGITAL-6HX): 7,604 events/30d — archived in Sentry, but archived issues still consume quota)
- **InheritedValueService**: when loading the source entity of an inherited field fails with 401/403, log as debug — restricted roles legitimately cannot read some linked entities, and this fired on every page view of such records ([AAM-DIGITAL-6MQ](https://aam-digital.sentry.io/issues/AAM-DIGITAL-6MQ): 800 events/30d)
- **SyncedPouchDatabase**: "sync failed" with status 401 (expired session) is logged as debug, analogous to the existing connectivity-error branch; the fetch layer already triggers re-login ([AAM-DIGITAL-6Y8](https://aam-digital.sentry.io/issues/AAM-DIGITAL-6Y8))
- **EntityMapperService**: "Permission check skipped: ability not yet initialized" is a known startup race and the server still enforces permissions; downgraded to debug ([AAM-DIGITAL-6ZN](https://aam-digital.sentry.io/issues/AAM-DIGITAL-6ZN): 94 events/30d)

Genuinely unexpected failures (5XX, unknown sync errors, document write errors, non-auth load failures) keep reporting exactly as before.

## PR Checklist

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)