### PR TITLE
fix: cap repeated identical Sentry events per session

### DIFF
--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -1,5 +1,9 @@
 import { LogLevel } from "./log-level";
-import { LoggingService } from "./logging.service";
+import {
+  LoggingService,
+  MAX_REPEATED_SENTRY_EVENTS,
+  processSentryEvent,
+} from "./logging.service";
 
 describe("LoggingService", () => {
   const testMessage = "FANCY_TEST_MESSAGE";
@@ -73,5 +77,48 @@ describe("LoggingService", () => {
       testMessage,
       LogLevel.WARN,
     );
+  });
+
+  describe("processSentryEvent (beforeSend)", () => {
+    it("should drop an identical event after MAX_REPEATED_SENTRY_EVENTS occurrences", () => {
+      const event = () =>
+        ({
+          exception: {
+            values: [{ type: "Error", value: "repeated failure A" }],
+          },
+        }) as any;
+
+      for (let i = 0; i < MAX_REPEATED_SENTRY_EVENTS; i++) {
+        expect(processSentryEvent(event(), {})).not.toBeNull();
+      }
+      expect(processSentryEvent(event(), {})).toBeNull();
+      expect(processSentryEvent(event(), {})).toBeNull();
+    });
+
+    it("should not drop a different event after another event was capped", () => {
+      const repeated = () =>
+        ({
+          exception: {
+            values: [{ type: "Error", value: "repeated failure B" }],
+          },
+        }) as any;
+      for (let i = 0; i < MAX_REPEATED_SENTRY_EVENTS + 2; i++) {
+        processSentryEvent(repeated(), {});
+      }
+
+      const other = {
+        exception: { values: [{ type: "Error", value: "different failure" }] },
+      } as any;
+      expect(processSentryEvent(other, {})).not.toBeNull();
+    });
+
+    it("should count message-only events (captureMessage) separately by message", () => {
+      const messageEvent = () => ({ message: "repeated warning C" }) as any;
+
+      for (let i = 0; i < MAX_REPEATED_SENTRY_EVENTS; i++) {
+        expect(processSentryEvent(messageEvent(), {})).not.toBeNull();
+      }
+      expect(processSentryEvent(messageEvent(), {})).toBeNull();
+    });
   });
 });

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -40,7 +40,7 @@ export class LoggingService {
       release: "ndb-core@" + environment.appVersion,
       transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport),
       beforeBreadcrumb: enhanceSentryBreadcrumb,
-      beforeSend: enrichSentryEvent,
+      beforeSend: processSentryEvent,
     };
     Sentry.init(Object.assign(defaultOptions, options));
   }
@@ -285,7 +285,42 @@ interface SentryBreadcrumbHint {
 export const Logging = new LoggingService();
 
 /**
- * Sentry `beforeSend` hook that enriches events with structured extra data
+ * Maximum number of times an identical event is sent to remote logging
+ * within one app session (page load).
+ * Guards against error loops (e.g. an error thrown on every change detection
+ * cycle) flooding remote monitoring with thousands of duplicate events.
+ */
+export const MAX_REPEATED_SENTRY_EVENTS = 5;
+
+const sentryEventCounts = new Map<string, number>();
+
+/**
+ * Sentry `beforeSend` hook: drops excessive repeats of an identical event
+ * and enriches the remaining events with structured extra data.
+ */
+export function processSentryEvent(
+  event: Sentry.ErrorEvent,
+  hint: Sentry.EventHint,
+): Sentry.ErrorEvent | null {
+  if (isExcessiveRepeat(event)) {
+    return null;
+  }
+  return enrichSentryEvent(event, hint);
+}
+
+function isExcessiveRepeat(event: Sentry.ErrorEvent): boolean {
+  const exception = event.exception?.values?.[0];
+  const key = exception
+    ? `${exception.type}: ${exception.value}`
+    : String(event.message ?? "unknown");
+
+  const count = (sentryEventCounts.get(key) ?? 0) + 1;
+  sentryEventCounts.set(key, count);
+  return count > MAX_REPEATED_SENTRY_EVENTS;
+}
+
+/**
+ * Enrich events with structured extra data
  * from custom Error properties (e.g. DatabaseException's entityId, status, reason).
  */
 function enrichSentryEvent(

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -316,7 +316,15 @@ function isExcessiveRepeat(event: Sentry.ErrorEvent): boolean {
 
   const count = (sentryEventCounts.get(key) ?? 0) + 1;
   sentryEventCounts.set(key, count);
-  return count > MAX_REPEATED_SENTRY_EVENTS;
+
+  if (count > MAX_REPEATED_SENTRY_EVENTS) {
+    Logging.debug("Skipping repeated event for remote logging", {
+      event: key,
+      occurrence: count,
+    });
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -308,6 +308,21 @@ export function processSentryEvent(
   return enrichSentryEvent(event, hint);
 }
 
+/**
+ * Count occurrences of an event and check whether it exceeded the session cap.
+ *
+ * The key is deliberately coarse: error class + message of the root cause
+ * (`values[0]` is the deepest `cause` in the chain; the originally thrown,
+ * outermost error is last), without any stack information.
+ * Consequences:
+ * - Same-message errors from different code paths share one budget,
+ *   and all wrappers of a cascading failure are capped via their common
+ *   root cause. This is a flood guard, not a grouping mechanism -
+ *   Sentry's server-side, stack-based grouping remains authoritative
+ *   for separating issues, and the first occurrences always get through.
+ * - Errors that interpolate data (e.g. entity IDs) into their message
+ *   get a separate budget per variant, so the cap is weaker for those.
+ */
 function isExcessiveRepeat(event: Sentry.ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
   const key = exception


### PR DESCRIPTION
Part of the Sentry noise reduction effort: an error thrown repeatedly — e.g. on every change detection cycle — previously flooded remote monitoring without any client-side limit. The recent `NG0600` incident produced **20,797 events from essentially a single broken page** ([AAM-DIGITAL-720](https://aam-digital.sentry.io/issues/AAM-DIGITAL-720)), the largest noise source of the month.

## Changes

- The Sentry `beforeSend` hook now counts events by exception `type: message` (or plain message for `captureMessage` events) and **drops further occurrences after 5 per app session** (page load).
- Console logging is unaffected — only remote reporting is capped.
- The first 5 occurrences still reach Sentry, so issues are still created, alerted on, and carry representative context; only the flood is suppressed.
- Covered by unit tests (pure function, no mocks needed).

## PR Checklist

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate error reports so repeated identical issues are grouped more cleanly.
  * Kept different error types and message-based events tracked separately, improving alert accuracy.
  * Preserved useful error details in reports while avoiding unnecessary noise.

* **Tests**
  * Added coverage for repeated error handling and message-based event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->