### PR TITLE
fix: don't report network fetch failures to Sentry while device is offline

### DIFF
--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -120,5 +120,41 @@ describe("LoggingService", () => {
       }
       expect(processSentryEvent(messageEvent(), {})).toBeNull();
     });
+
+    describe("offline network errors", () => {
+      afterEach(() => vi.unstubAllGlobals());
+
+      const networkErrorEvent = () =>
+        ({
+          exception: {
+            values: [
+              { type: "DatabaseException", value: "Failed to fetch from DB" },
+            ],
+          },
+        }) as any;
+
+      it("should drop network fetch failures while offline", () => {
+        vi.stubGlobal("navigator", { onLine: false });
+
+        expect(processSentryEvent(networkErrorEvent(), {})).toBeNull();
+      });
+
+      it("should keep network fetch failures while online", () => {
+        vi.stubGlobal("navigator", { onLine: true });
+
+        expect(processSentryEvent(networkErrorEvent(), {})).not.toBeNull();
+      });
+
+      it("should keep non-network errors while offline", () => {
+        vi.stubGlobal("navigator", { onLine: false });
+
+        const otherEvent = {
+          exception: {
+            values: [{ type: "Error", value: "some application bug" }],
+          },
+        } as any;
+        expect(processSentryEvent(otherEvent, {})).not.toBeNull();
+      });
+    });
   });
 });

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -295,17 +295,47 @@ export const MAX_REPEATED_SENTRY_EVENTS = 5;
 const sentryEventCounts = new Map<string, number>();
 
 /**
- * Sentry `beforeSend` hook: drops excessive repeats of an identical event
+ * Error message fragments produced by browsers (and our fetch wrapper)
+ * when a request fails at the network layer.
+ */
+const NETWORK_ERROR_PATTERNS = [
+  "Failed to fetch", // Chrome (also matches DatabaseException "Failed to fetch from DB")
+  "NetworkError when attempting to fetch resource", // Firefox
+  "Load failed", // Safari
+];
+
+/**
+ * Sentry `beforeSend` hook: drops network failures of offline devices
+ * and excessive repeats of an identical event,
  * and enriches the remaining events with structured extra data.
  */
 export function processSentryEvent(
   event: Sentry.ErrorEvent,
   hint: Sentry.EventHint,
 ): Sentry.ErrorEvent | null {
-  if (isExcessiveRepeat(event)) {
+  if (isOfflineNetworkError(event) || isExcessiveRepeat(event)) {
     return null;
   }
   return enrichSentryEvent(event, hint);
+}
+
+/**
+ * Whether the event is a network-layer fetch failure that occurred while the
+ * device was offline. In an offline-first app this is a normal state without
+ * diagnostic value (server outages still surface through online users).
+ */
+function isOfflineNetworkError(event: Sentry.ErrorEvent): boolean {
+  if (navigator.onLine) {
+    return false;
+  }
+
+  const messages = [
+    event.message,
+    ...(event.exception?.values?.map((v) => v.value) ?? []),
+  ];
+  return messages.some(
+    (msg) => msg && NETWORK_ERROR_PATTERNS.some((p) => msg.includes(p)),
+  );
 }
 
 /**


### PR DESCRIPTION
~~Stacked on #4119~~ — #4119 has been merged; this branch is now rebased directly onto `master`.

Part of the Sentry noise reduction effort: in an offline-first app, failed network requests while the device has no connectivity are a normal state without diagnostic value. They still produced **~2,300 Sentry events in the last 30 days** (e.g. [AAM-DIGITAL-71T](https://aam-digital.sentry.io/issues/AAM-DIGITAL-71T), [AAM-DIGITAL-607](https://aam-digital.sentry.io/issues/AAM-DIGITAL-607)) — amplified by `makeBrowserOfflineTransport`, which queues events while offline and faithfully delivers the backlog after reconnecting.

## Changes

- The Sentry `beforeSend` hook drops events whose error message matches a known browser network-failure pattern (`Failed to fetch` / Firefox `NetworkError…` / Safari `Load failed`, which also covers our `DatabaseException: Failed to fetch from DB` wrapper) **while `navigator.onLine` is false**.
- Genuine server outages still surface through online users (`navigator.onLine === true` → events are kept).
- Console logging is unaffected.
- Covered by unit tests.

## PR Checklist

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
