### PR TITLE
fix: avoid NG0911 error when form is aborted before completely loading

### DIFF
--- a/src/app/core/common-components/entity-form/entity-form.service.spec.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.spec.ts
@@ -319,6 +319,16 @@ describe("EntityFormService", () => {
     expect(unsavedChanged.pending()).toBe(false);
   });
 
+  it("should not throw (NG0911) and should clear unsaved-changes state if the DestroyRef is already destroyed when the form finishes creating (async race, e.g. navigated away while the form was still loading)", async () => {
+    const unsavedChanged = TestBed.inject(UnsavedChangesService);
+    const formFields = [{ id: "inactive" }];
+
+    destroyRef.destroy();
+
+    await expect(createForm(formFields, new Entity())).resolves.toBeDefined();
+    expect(unsavedChanged.pending()).toBe(false);
+  });
+
   it("should assign default values", async () => {
     const schema: EntitySchemaField = {
       defaultValue: {

--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -142,9 +142,17 @@ export class EntityFormService {
       .subscribe(() =>
         this.unsavedChanges.setUnsavedChanges(entityForm, typedFormGroup.dirty),
       );
-    destroyRef.onDestroy(() =>
-      this.unsavedChanges.setUnsavedChanges(entityForm, false),
-    );
+    // The caller's view may already be destroyed by the time this async form
+    // finishes being created (e.g. navigated away while the form was still loading).
+    // `onDestroy` throws NG0911 in that case, so check `destroyed` first, the same
+    // way `takeUntilDestroyed` (used above) guards against it internally.
+    if (destroyRef.destroyed) {
+      this.unsavedChanges.setUnsavedChanges(entityForm, false);
+    } else {
+      destroyRef.onDestroy(() =>
+        this.unsavedChanges.setUnsavedChanges(entityForm, false),
+      );
+    }
 
     if (withDefaultValues) {
       await this.defaultValueService.handleEntityForm(entityForm, entity);

--- a/src/app/utils/mock-destroy-ref.ts
+++ b/src/app/utils/mock-destroy-ref.ts
@@ -17,6 +17,10 @@ export class MockDestroyRef extends DestroyRef {
   }
 
   onDestroy(callback: () => void): () => void {
+    if (this._destroyed) {
+      // mirrors Angular's NG0911 "View has already been destroyed" behavior
+      throw new Error("NG0911: View has already been destroyed.");
+    }
     this.callbacks.add(callback);
     return () => this.callbacks.delete(callback);
   }


### PR DESCRIPTION
## Summary

`EntityFormService.createEntityForm` is `async`, but registered its unsaved-changes cleanup via `destroyRef.onDestroy(...)` unconditionally, without checking whether the caller's view had already been destroyed by the time the async work finished. Since `onDestroy` throws Angular's `NG0911` ("View has already been destroyed") when called on an already-destroyed `DestroyRef`, this surfaced in production as an unhandled error whenever a component using `createEntityForm` was torn down (e.g. user navigated away) before the form finished loading.

### Root cause analysis (Sentry)

Found while triaging new Sentry issues (aam-digital org, issues first seen since 2026-07-02):

- **AAM-DIGITAL-737** (~50 events) — `/public-form/form/:id/`, mostly slow/low-end Android devices filling out a baseline survey where the form takes long enough to load that users navigate away first.
- **AAM-DIGITAL-73G** — `/c/recurring-activity/:id/`. Its stack trace confirmed this isn't page-specific: the caller was `automated-field-update.component.ts` (inherited-field feature), a completely different code path hitting the same `entity-form.service.ts:145` line.
- **AAM-DIGITAL-73F** — same call site (minified frame matches the same `unsavedChanges.setUnsavedChanges` callback registered via `onDestroy`).

All three trace back to the same line, introduced by #4115 (merged 2026-07-02, the day the issue count started climbing), which added the `destroyRef.onDestroy(...)` cleanup registration but didn't account for the async gap between when a component starts creating a form and when that creation actually completes.

## Fix

Guard with `if (destroyRef.destroyed)` before calling `onDestroy` — the same pattern Angular's own `takeUntilDestroyed` operator uses internally (verified in `@angular/core/rxjs-interop`), using the public `DestroyRef.destroyed` API. If the ref is already destroyed, clear the unsaved-changes state immediately instead of registering a callback that would throw and never fire.

Also updated `MockDestroyRef` (test utility) so `onDestroy` throws when called on an already-destroyed ref, matching real Angular `NodeInjectorDestroyRef` behavior — previously it silently accepted this, which would have masked the bug in tests. Added a regression test that destroys the ref before the async form finishes creating and asserts no throw + state is cleared correctly.

## Test plan

- [x] `entity-form.service.spec.ts` — new regression test passes, plus all 15 existing tests
- [x] Full spec suite for the 3 other `MockDestroyRef` consumers (`edit-text-with-autocomplete`, `entity-inline-edit-actions`, `entity-form.component`) — 45 tests total, all passing
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form cleanup when a screen is already closed before form setup finishes, preventing unsaved-change indicators from getting stuck.
  * Aligned destroyed-state handling with expected app behavior to avoid late callback registration issues.

* **Tests**
  * Added coverage for the async race case where a destroy event happens before form creation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->