### PR TITLE
Remove redundant exportConfig option

### DIFF
--- a/src/app/child-dev-project/notes/note-details/note-details.component.html
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.html
@@ -35,18 +35,9 @@
   </div>
 
   <app-view-actions>
-    <app-dialog-buttons [form]="$any(form())" [entity]="entity()">
-      <button mat-menu-item (click)="openExportDialog()">
-        <fa-icon
-          class="color-accent standard-icon-with-text"
-          aria-label="download csv"
-          icon="download"
-          angulartics2On="click"
-          angularticsCategory="Note"
-          angularticsAction="single_note_csv_export"
-        ></fa-icon>
-        <span i18n="Download note details as CSV">Download details</span>
-      </button>
-    </app-dialog-buttons>
+    <app-dialog-buttons
+      [form]="$any(form())"
+      [entity]="entity()"
+    ></app-dialog-buttons>
   </app-view-actions>
 }

--- a/src/app/child-dev-project/notes/note-details/note-details.component.ts
+++ b/src/app/child-dev-project/notes/note-details/note-details.component.ts
@@ -10,26 +10,18 @@ import {
   signal,
   ViewEncapsulation,
 } from "@angular/core";
-import { MatDialog, MatDialogModule } from "@angular/material/dialog";
-import { MatMenuModule } from "@angular/material/menu";
 import { MatProgressBar } from "@angular/material/progress-bar";
-import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { Angulartics2Module } from "angulartics2";
 import { CustomDatePipe } from "../../../core/basic-datatypes/date/custom-date.pipe";
 import { EntityFormService } from "../../../core/common-components/entity-form/entity-form.service";
 import { EntityFormComponent } from "../../../core/common-components/entity-form/entity-form/entity-form.component";
 import { ViewActionsComponent } from "../../../core/common-components/view-actions/view-actions.component";
 import { ViewTitleComponent } from "../../../core/common-components/view-title/view-title.component";
-import { ConfigService } from "../../../core/config/config.service";
 import { DynamicComponent } from "../../../core/config/dynamic-components/dynamic-component.decorator";
 import { AbstractEntityDetailsComponent } from "../../../core/entity-details/abstract-entity-details/abstract-entity-details.component";
 import { EntityArchivedInfoComponent } from "../../../core/entity-details/entity-archived-info/entity-archived-info.component";
 import { UnsavedChangesService } from "../../../core/entity-details/form/unsaved-changes.service";
-import { EntityListConfig } from "../../../core/entity-list/EntityListConfig";
 import { EntityConstructor } from "../../../core/entity/model/entity";
-import { ExportColumnConfig } from "../../../core/export/data-transformation-service/export-column-config";
-import { ExportDialogComponent } from "../../../core/export/export-dialog/export-dialog.component";
 import { DialogButtonsComponent } from "../../../core/form-dialog/dialog-buttons/dialog-buttons.component";
 import { getDefaultNoteDetailsConfig } from "../add-default-note-views";
 import { Note } from "../model/note";
@@ -45,13 +37,9 @@ import { Note } from "../model/note";
   templateUrl: "./note-details.component.html",
   styleUrls: ["./note-details.component.scss"],
   imports: [
-    MatDialogModule,
     CustomDatePipe,
-    FontAwesomeModule,
-    Angulartics2Module,
     EntityFormComponent,
     DialogButtonsComponent,
-    MatMenuModule,
     EntityArchivedInfoComponent,
     ViewTitleComponent,
     MatProgressBar,
@@ -60,20 +48,11 @@ import { Note } from "../model/note";
   encapsulation: ViewEncapsulation.None,
 })
 export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
-  private configService = inject(ConfigService);
   private entityFormService = inject(EntityFormService);
   private unsavedChangesService = inject(UnsavedChangesService);
-  private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
   override readonly entityConstructor = computed<EntityConstructor>(() => Note);
-
-  /** export format for notes to be used for downloading the individual details */
-  readonly exportConfig = computed<ExportColumnConfig[]>(
-    () =>
-      this.configService.getConfig<{ config: EntityListConfig }>("view:note")
-        ?.config.exportConfig,
-  );
 
   private readonly defaultFormConfig = getDefaultNoteDetailsConfig();
   topForm = input(this.defaultFormConfig.topForm);
@@ -115,19 +94,6 @@ export class NoteDetailsComponent extends AbstractEntityDetailsComponent {
           this.tmpEntity.set(Object.assign(entity.copy(), value));
         });
       onCleanup(() => sub.unsubscribe());
-    });
-  }
-
-  openExportDialog() {
-    const entity = this.entity() as Note;
-    const dateStr = entity?.date ? entity.date.toISOString().split("T")[0] : "";
-    const filename = `event_${entity?.toString()?.replaceAll(" ", "-")}_${dateStr}`;
-    this.dialog.open(ExportDialogComponent, {
-      data: {
-        allEntities: entity ? [entity] : [],
-        exportConfig: this.exportConfig(),
-        filename,
-      },
     });
   }
 

--- a/src/app/core/config/config-migrations.spec.ts
+++ b/src/app/core/config/config-migrations.spec.ts
@@ -7,6 +7,25 @@ describe("applyConfigMigrations", () => {
     expect(applyConfigMigrations(doc)).toEqual(doc);
   });
 
+  it("removes the deprecated exportConfig from view configs", () => {
+    const old = {
+      "view:note": {
+        component: "EntityList",
+        config: {
+          entityType: "Note",
+          columns: ["subject"],
+          exportConfig: [{ query: "subject", label: "Subject" }],
+        },
+      },
+    };
+    expect(applyConfigMigrations(old)).toEqual({
+      "view:note": {
+        component: "EntityList",
+        config: { entityType: "Note", columns: ["subject"] },
+      },
+    });
+  });
+
   describe("migrateChildrenListConfig", () => {
     it("migrates ChildrenList component to EntityList", () => {
       const old = { "view:X": { component: "ChildrenList", config: {} } };

--- a/src/app/core/config/config-migrations.ts
+++ b/src/app/core/config/config-migrations.ts
@@ -490,6 +490,19 @@ const migrateNotesManagerComponent: ConfigMigration = (key, configPart) => {
   return configPart;
 };
 
+const removeExportConfig: ConfigMigration = (key, configPart) => {
+  if (
+    configPart &&
+    typeof configPart === "object" &&
+    !Array.isArray(configPart) &&
+    "exportConfig" in configPart
+  ) {
+    delete configPart.exportConfig;
+  }
+
+  return configPart;
+};
+
 /**
  * All temporary config migrations that fix legacy data formats.
  * Applied by both ConfigService (Angular app) and the admin CLI.
@@ -517,6 +530,7 @@ export const configMigrations: ConfigMigration[] = [
   migrateNotesManagerComponent,
   removeConfigRoutesMigratedToFixedFeatures,
   migrateAttendanceRecurringActivityRoute,
+  removeExportConfig,
 ];
 
 /**

--- a/src/app/core/entity-list/EntityListConfig.ts
+++ b/src/app/core/entity-list/EntityListConfig.ts
@@ -43,7 +43,10 @@ export interface EntityListConfig {
   defaultSort?: Sort;
 
   /**
-   * Optional config defining what fields are included in exports.
+   * Export column definitions consumed by the entity-details export path
+   * (e.g. the note details export dialog), which supports advanced features
+   * such as subQueries. The entity list view no longer uses this — its export
+   * columns are derived from the visible columns and entity schema.
    */
   exportConfig?: ExportColumnConfig[];
 }

--- a/src/app/core/entity-list/EntityListConfig.ts
+++ b/src/app/core/entity-list/EntityListConfig.ts
@@ -1,6 +1,5 @@
 import { FilterSelectionOption } from "../filter/filters/filters";
 import { FormFieldConfig } from "../common-components/entity-form/FormConfig";
-import { ExportColumnConfig } from "../export/data-transformation-service/export-column-config";
 import { Sort } from "@angular/material/sort";
 import { unitOfTime } from "moment";
 
@@ -41,14 +40,6 @@ export interface EntityListConfig {
    * Default is to sort by the first column.
    */
   defaultSort?: Sort;
-
-  /**
-   * Export column definitions consumed by the entity-details export path
-   * (e.g. the note details export dialog), which supports advanced features
-   * such as subQueries. The entity list view no longer uses this — its export
-   * columns are derived from the visible columns and entity schema.
-   */
-  exportConfig?: ExportColumnConfig[];
 }
 
 export interface ColumnGroupsConfig {

--- a/src/app/core/entity-list/entity-list/entity-list.component.spec.ts
+++ b/src/app/core/entity-list/entity-list/entity-list.component.spec.ts
@@ -321,32 +321,4 @@ describe("EntityListComponent", () => {
       vi.useRealTimers();
     }
   });
-
-  it("should apply admin-configured export labels to matching columns", async () => {
-    vi.useFakeTimers();
-    try {
-      createComponent();
-      fixture.componentRef.setInput("exportConfig", [
-        { query: ".name", label: "Custom Name Label" },
-      ]);
-      fixture.detectChanges();
-      await vi.advanceTimersByTimeAsync(0);
-
-      component.columnsToDisplay = ["name"];
-
-      const matDialog = TestBed.inject(MatDialog);
-      const openSpy = vi
-        .spyOn(matDialog, "open")
-        .mockImplementation(() => makeMatDialogRef());
-
-      component.openExportDialog();
-
-      const callArgs = openSpy.mock.calls[0][1] as any;
-      const available = callArgs.data.exportConfig as any[];
-      const nameColumn = available.find((c) => c.query === ".name");
-      expect(nameColumn.label).toBe("Custom Name Label");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });

--- a/src/app/core/entity-list/entity-list/entity-list.component.ts
+++ b/src/app/core/entity-list/entity-list/entity-list.component.ts
@@ -41,7 +41,6 @@ import { DisableEntityOperationDirective } from "../../permissions/permission-di
 import { DuplicateRecordService } from "../duplicate-records/duplicate-records.service";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { Sort } from "@angular/material/sort";
-import { ExportColumnConfig } from "../../export/data-transformation-service/export-column-config";
 import { ExportColumnsService } from "../../export/export-columns.service";
 import { RouteTarget } from "../../../route-target";
 import { EntitiesTableComponent } from "../../common-components/entities-table/entities-table.component";
@@ -128,7 +127,6 @@ export class EntityListComponent<T extends Entity> implements OnInit {
   entityType = input<string>();
   entityConstructor = model<EntityConstructor<T>>();
   defaultSort = input<Sort>();
-  exportConfig = input<ExportColumnConfig[]>();
 
   /**
    * The special service or method to load data via an index or other special method.
@@ -438,7 +436,6 @@ export class EntityListComponent<T extends Entity> implements OnInit {
         schema,
         visibleColIds: cols,
         availableColumns,
-        exportConfig: this.exportConfig(),
       });
 
     this.dialog.open(ExportDialogComponent, {

--- a/src/app/core/export/export-columns.service.ts
+++ b/src/app/core/export/export-columns.service.ts
@@ -11,7 +11,6 @@ export interface BuildExportColumnsOptions {
   schema: Map<string, any> | undefined;
   visibleColIds: string[];
   availableColumns: Array<string | ExportColumnConfig | FormFieldConfig>;
-  exportConfig?: ExportColumnConfig[];
 }
 
 export interface BuildExportColumnsResult {
@@ -29,7 +28,7 @@ export class ExportColumnsService {
   buildExportColumns(
     opts: BuildExportColumnsOptions,
   ): BuildExportColumnsResult {
-    const { schema, visibleColIds, availableColumns, exportConfig } = opts;
+    const { schema, visibleColIds, availableColumns } = opts;
 
     const allAvailableColumns: ExportColumnConfig[] = [];
     // export column config objects keyed by their column id (for label overrides)
@@ -126,17 +125,6 @@ export class ExportColumnsService {
       );
       const col = primary && columnById.get(primary.columnId);
       if (visibleLabel && col) col.label = visibleLabel;
-    }
-
-    // Admin-configured custom labels take precedence over the list view labels
-    // (see EntityListConfig.exportConfig).
-    for (const configured of exportConfig ?? []) {
-      if (!configured.label) continue;
-      const key = normalizeQueryKey(configured.query);
-      const match = allAvailableColumns.find(
-        (c) => normalizeQueryKey(c.query) === key,
-      );
-      if (match) match.label = configured.label;
     }
 
     const preselectedExportConfig = allAvailableColumns.filter((c) =>

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -778,28 +778,6 @@
             "label": "School"
           }
         ],
-        "exportConfig": [
-          {
-            "label": "Name",
-            "query": "name"
-          },
-          {
-            "label": "Gender",
-            "query": "gender"
-          },
-          {
-            "label": "Date of Birth",
-            "query": "dateOfBirth"
-          },
-          {
-            "label": "School",
-            "query": ".schoolId:toEntities(School).name"
-          },
-          {
-            "label": "more fields can be configured - or all data exported",
-            "query": "projectNumber"
-          }
-        ],
         "loaderMethod": "ChildrenService"
       },
       "_id": "view:child"
@@ -1223,20 +1201,6 @@
           "type",
           "status",
           "assignedTo"
-        ],
-        "exportConfig": [
-          {
-            "label": "Title",
-            "query": "title"
-          },
-          {
-            "label": "Type",
-            "query": "type"
-          },
-          {
-            "label": "Assigned users",
-            "query": "assignedTo"
-          }
         ]
       },
       "_id": "view:attendance/recurring-activity"

--- a/src/assets/base-configs/education/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/education/Config_CONFIG_ENTITY.json
@@ -717,20 +717,6 @@
           "type",
           "status",
           "assignedTo"
-        ],
-        "exportConfig": [
-          {
-            "label": "Title",
-            "query": "title"
-          },
-          {
-            "label": "Type",
-            "query": "type"
-          },
-          {
-            "label": "Assigned users",
-            "query": "assignedTo"
-          }
         ]
       },
       "_id": "view:attendance/recurring-activity"

--- a/src/assets/base-configs/education/de/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/education/de/Config_CONFIG_ENTITY.json
@@ -717,20 +717,6 @@
           "type",
           "status",
           "assignedTo"
-        ],
-        "exportConfig": [
-          {
-            "label": "Title",
-            "query": "title"
-          },
-          {
-            "label": "Type",
-            "query": "type"
-          },
-          {
-            "label": "Assigned users",
-            "query": "assignedTo"
-          }
         ]
       },
       "_id": "view:attendance/recurring-activity"

--- a/src/assets/base-configs/education/fr/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/education/fr/Config_CONFIG_ENTITY.json
@@ -717,20 +717,6 @@
           "type",
           "status",
           "assignedTo"
-        ],
-        "exportConfig": [
-          {
-            "label": "Title",
-            "query": "title"
-          },
-          {
-            "label": "Type",
-            "query": "type"
-          },
-          {
-            "label": "Assigned users",
-            "query": "assignedTo"
-          }
         ]
       },
       "_id": "view:attendance/recurring-activity"


### PR DESCRIPTION
Removes the redundant `exportConfig` option completely.

Since the new download dialog landed, `exportConfig` on list views only overrode column labels (column selection, `subQueries` and `groupBy` were silently ignored), and note details used it for a custom attendance export. Both cases are now covered without it:

- List and record exports pick columns through the download dialog (derived from the visible columns and entity schema).
- Note attendance export uses the generic "Download attendance list" action (available on any entity with an attendance field), and fully custom column sets are handled by Reports (same query engine, incl. `subQueries`).

Changes:
- Remove the `exportConfig` field from `EntityListConfig`.
- Remove the entity-list `exportConfig` input and the label-override logic in `ExportColumnsService`.
- Remove note details `exportConfig` usage and its "Download details" button.
- Strip `exportConfig` from the base configs and add a config migration that removes it from existing deployments.

The export engine (`subQueries` / `getAttendanceArray`) is unchanged; it still backs Reports and the generic attendance export.

- closes #4074

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

1. Open an entity list (e.g. Children), click Export, and confirm the CSV/XLSX has the expected columns and headers.
2. Open a Note, open the actions menu, and confirm there is no "Download details" option anymore. The "Download attendance list" action is still available and exports one row per participant.
3. For a fully custom column export, confirm Reports still produces it (e.g. an attendance report with participant and school columns).
4. Load an existing config that still has `exportConfig` and confirm the app works normally (the migration removes the field on load).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified note detail dialogs by removing the dedicated export button.
  * Removed custom export-column configuration from list views and export processing.
  * Export columns and selections are now derived from the available view and schema fields.
  * Updated recurring activity and child-related configurations to reflect the streamlined export behavior.
  * Added migration support to automatically remove deprecated export settings from existing configurations.
* **Tests**
  * Added coverage for migrating configurations with deprecated export settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->