### PR TITLE
fix: retry transient network aborts on idempotent DB reads (AAM-DIGITAL-73M)

### DIFF
--- a/src/app/core/database/pouchdb/database-exception.ts
+++ b/src/app/core/database/pouchdb/database-exception.ts
@@ -1,0 +1,33 @@
+/**
+ * This overwrites PouchDB's error class which only logs limited information
+ */
+export class DatabaseException extends Error {
+  entityId?: string;
+
+  /**
+   * The `name` of the underlying error that was wrapped (e.g. "AbortError",
+   * "TimeoutError", "not_found"). Preserved separately because {@link name} is
+   * deliberately kept as "DatabaseException" for stable Sentry grouping — which
+   * would otherwise erase the original name and hide that a failure is actually
+   * a transient network abort. Read by {@link isConnectivityError} so wrapped
+   * transient errors stay classifiable.
+   */
+  originalName?: string;
+
+  constructor(
+    error: PouchDB.Core.Error | { message: string; [key: string]: any },
+    entityId?: string,
+  ) {
+    super(error?.message || "Database error");
+
+    this.entityId = entityId;
+    // Capture the wrapped error's name before Object.assign / `this.name` erase it.
+    const originalName = (error as { name?: string })?.name;
+    Object.assign(this, error);
+    // Restore class name after Object.assign overwrites it with PouchDB's name (e.g. "not_found")
+    this.name = "DatabaseException";
+    if (originalName && originalName !== "DatabaseException") {
+      this.originalName = originalName;
+    }
+  }
+}

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -15,7 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { PouchDatabase } from "./pouch-database";
+import { DatabaseException, PouchDatabase } from "./pouch-database";
 import { MemoryPouchDatabase } from "./memory-pouch-database";
 import { SyncStateSubject } from "app/core/session/session-type";
 
@@ -375,5 +375,40 @@ describe("PouchDatabase tests", () => {
         "1-conflict",
       ]);
     });
+  });
+});
+
+describe("DatabaseException", () => {
+  it("keeps name as 'DatabaseException' for stable Sentry grouping", () => {
+    const ex = new DatabaseException(
+      { status: 404, name: "not_found", message: "missing" },
+      "Entity:1",
+    );
+
+    expect(ex.name).toBe("DatabaseException");
+    expect(ex.entityId).toBe("Entity:1");
+    expect(ex.message).toBe("missing");
+  });
+
+  it("preserves the wrapped error's name in originalName", () => {
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError",
+    );
+
+    const ex = new DatabaseException(abortError, "Config:CONFIG_ENTITY");
+
+    // name stays stable for grouping, but the underlying name is retained
+    expect(ex.name).toBe("DatabaseException");
+    expect(ex.originalName).toBe("AbortError");
+    expect(ex.message).toBe("The operation was aborted.");
+  });
+
+  it("does not set originalName when wrapping another DatabaseException", () => {
+    const inner = new DatabaseException({ message: "Failed to fetch from DB" });
+
+    const outer = new DatabaseException(inner, "Entity:1");
+
+    expect(outer.originalName).toBeUndefined();
   });
 });

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -526,6 +526,16 @@ export class PouchDatabase extends Database {
 export class DatabaseException extends Error {
   entityId?: string;
 
+  /**
+   * The `name` of the underlying error that was wrapped (e.g. "AbortError",
+   * "TimeoutError", "not_found"). Preserved separately because {@link name} is
+   * deliberately kept as "DatabaseException" for stable Sentry grouping — which
+   * would otherwise erase the original name and hide that a failure is actually
+   * a transient network abort. Read by {@link isConnectivityError} so wrapped
+   * transient errors stay classifiable.
+   */
+  originalName?: string;
+
   constructor(
     error: PouchDB.Core.Error | { message: string; [key: string]: any },
     entityId?: string,
@@ -533,8 +543,13 @@ export class DatabaseException extends Error {
     super(error?.message || "Database error");
 
     this.entityId = entityId;
+    // Capture the wrapped error's name before Object.assign / `this.name` erase it.
+    const originalName = (error as { name?: string })?.name;
     Object.assign(this, error);
     // Restore class name after Object.assign overwrites it with PouchDB's name (e.g. "not_found")
     this.name = "DatabaseException";
+    if (originalName && originalName !== "DatabaseException") {
+      this.originalName = originalName;
+    }
   }
 }

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -103,6 +103,20 @@ export class PouchDatabase extends Database {
   }
 
   /**
+   * Hook wrapping an idempotent read (`get`/`allDocs`/`query`) so subclasses
+   * can transparently retry transient failures.
+   *
+   * The base implementation runs the operation exactly once (no retry).
+   * {@link RemotePouchDatabase} overrides this to re-issue reads that fail with
+   * a transient network abort/timeout, which recovers e.g. a connection gone
+   * stale after the tab was suspended. Only reads use this hook — writes must
+   * run exactly once and are never routed through it.
+   */
+  protected async withReadRetry<T>(operation: () => Promise<T>): Promise<T> {
+    return operation();
+  }
+
+  /**
    * Load a single document by id from the database.
    * (see {@link Database})
    * @param id The primary key of the document to be loaded
@@ -115,7 +129,9 @@ export class PouchDatabase extends Database {
     returnUndefined?: boolean,
   ): Promise<any> {
     try {
-      return await (await this.getPouchDBOnceReady()).get(id, options);
+      return await this.withReadRetry(async () =>
+        (await this.getPouchDBOnceReady()).get(id, options),
+      );
     } catch (err) {
       if (err.status === 404) {
         Logging.debug("Doc not found in database: " + id);
@@ -140,7 +156,9 @@ export class PouchDatabase extends Database {
    */
   async allDocs(options?: GetAllOptions) {
     try {
-      const result = await (await this.getPouchDBOnceReady()).allDocs(options);
+      const result = await this.withReadRetry(async () =>
+        (await this.getPouchDBOnceReady()).allDocs(options),
+      );
       return result.rows.map((row) => row.doc);
     } catch (err) {
       throw new DatabaseException(
@@ -380,14 +398,14 @@ export class PouchDatabase extends Database {
     fun: string | ((doc: any, emit: any) => void),
     options: QueryOptions,
   ): Promise<any> {
-    return this.getPouchDBOnceReady()
-      .then((pouchDB) => pouchDB.query(fun, options))
-      .catch((err) => {
-        throw new DatabaseException(
-          err,
-          typeof fun === "string" ? fun : undefined,
-        );
-      });
+    return this.withReadRetry(() =>
+      this.getPouchDBOnceReady().then((pouchDB) => pouchDB.query(fun, options)),
+    ).catch((err) => {
+      throw new DatabaseException(
+        err,
+        typeof fun === "string" ? fun : undefined,
+      );
+    });
   }
 
   /**

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -1,5 +1,6 @@
 import { Database, GetAllOptions, GetOptions, QueryOptions } from "../database";
 import { Logging } from "../../logging/logging.service";
+import { DatabaseException } from "./database-exception";
 import PouchDB from "pouchdb-browser";
 import indexeddbAdapter from "pouchdb-adapter-indexeddb";
 import { NgZone } from "@angular/core";
@@ -520,36 +521,4 @@ export class PouchDatabase extends Database {
   }
 }
 
-/**
- * This overwrites PouchDB's error class which only logs limited information
- */
-export class DatabaseException extends Error {
-  entityId?: string;
-
-  /**
-   * The `name` of the underlying error that was wrapped (e.g. "AbortError",
-   * "TimeoutError", "not_found"). Preserved separately because {@link name} is
-   * deliberately kept as "DatabaseException" for stable Sentry grouping — which
-   * would otherwise erase the original name and hide that a failure is actually
-   * a transient network abort. Read by {@link isConnectivityError} so wrapped
-   * transient errors stay classifiable.
-   */
-  originalName?: string;
-
-  constructor(
-    error: PouchDB.Core.Error | { message: string; [key: string]: any },
-    entityId?: string,
-  ) {
-    super(error?.message || "Database error");
-
-    this.entityId = entityId;
-    // Capture the wrapped error's name before Object.assign / `this.name` erase it.
-    const originalName = (error as { name?: string })?.name;
-    Object.assign(this, error);
-    // Restore class name after Object.assign overwrites it with PouchDB's name (e.g. "not_found")
-    this.name = "DatabaseException";
-    if (originalName && originalName !== "DatabaseException") {
-      this.originalName = originalName;
-    }
-  }
-}
+export { DatabaseException } from "./database-exception";

--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -1,5 +1,5 @@
 import type { Mock } from "vitest";
-import { PouchDatabase } from "./pouch-database";
+import { DatabaseException, PouchDatabase } from "./pouch-database";
 import PouchDB from "pouchdb-browser";
 import { HttpStatusCode } from "@angular/common/http";
 import { RemotePouchDatabase } from "./remote-pouch-database";
@@ -77,142 +77,139 @@ describe("RemotePouchDatabase tests", () => {
     expect(headers.get("ngsw-bypass")).toBe("true");
   });
 
-  it("should retry on transient network errors", async () => {
-    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
-    (database as any).FETCH_TIMEOUT_MS = 60000;
+  const READ_URL = `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`;
 
-    let callCount = 0;
-    (PouchDB.fetch as Mock).mockImplementation(async () => {
-      callCount++;
-      if (callCount < 3) {
-        throw new TypeError("Failed to fetch");
-      }
-      return new Response("{}", { status: HttpStatusCode.Ok });
+  describe("withReadRetry (operation-level retry for idempotent reads)", () => {
+    it("should retry a transient (connectivity) failure then resolve", async () => {
+      (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
+
+      let calls = 0;
+      const operation = vi.fn(async () => {
+        calls++;
+        if (calls < 3) {
+          throw new TypeError("Failed to fetch");
+        }
+        return "ok";
+      });
+
+      const result = await (database as any).withReadRetry(operation);
+
+      // 1 initial + 2 retries
+      expect(calls).toBe(3);
+      expect(result).toBe("ok");
     });
 
-    const result = await (database as any).fetchWithTransientRetry(
-      `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-      { headers: new Headers() },
-    );
+    it("should throw after exhausting retries on a persistent transient error", async () => {
+      (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
 
-    expect(callCount).toBe(3);
-    expect(result.status).toBe(HttpStatusCode.Ok);
+      let calls = 0;
+      const operation = vi.fn(async () => {
+        calls++;
+        throw new DOMException("The operation was aborted.", "AbortError");
+      });
+
+      await expect((database as any).withReadRetry(operation)).rejects.toThrow(
+        "operation was aborted",
+      );
+      // 1 initial + 2 retries = 3 total
+      expect(calls).toBe(3);
+    });
+
+    it("should not retry non-connectivity errors (e.g. a code bug or 404)", async () => {
+      let calls = 0;
+      const operation = vi.fn(async () => {
+        calls++;
+        throw new Error("x is not a function");
+      });
+
+      await expect((database as any).withReadRetry(operation)).rejects.toThrow(
+        "x is not a function",
+      );
+      expect(calls).toBe(1);
+    });
   });
 
-  it("should throw after exhausting transient retries", async () => {
+  it("should retry a transient read at the operation level via get() and recover", async () => {
+    // Reproduces AAM-DIGITAL-73M: an abort surfacing during the read (e.g.
+    // response-body streaming on a stale connection) is retried transparently.
     (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
-    (database as any).FETCH_TIMEOUT_MS = 60000;
+    database.init("");
+    const pouchDB = (database as any).pouchDB;
 
-    let callCount = 0;
-    (PouchDB.fetch as Mock).mockImplementation(async () => {
-      callCount++;
+    let calls = 0;
+    vi.spyOn(pouchDB, "get").mockImplementation(async () => {
+      calls++;
+      if (calls < 2) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+      return { _id: "Entity:ABC" };
+    });
+
+    const result = await database.get("Entity:ABC");
+
+    expect(calls).toBe(2);
+    expect(result._id).toBe("Entity:ABC");
+  });
+
+  it("should surface a persistent transient read failure as a DatabaseException after exhausting retries", async () => {
+    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
+    database.init("");
+    const pouchDB = (database as any).pouchDB;
+
+    let calls = 0;
+    vi.spyOn(pouchDB, "get").mockImplementation(async () => {
+      calls++;
+      throw new DOMException("The operation was aborted.", "AbortError");
+    });
+
+    await expect(database.get("Entity:ABC")).rejects.toThrow(DatabaseException);
+    // 1 initial + 2 retries = 3 total
+    expect(calls).toBe(3);
+  });
+
+  it("fetchWithTimeout attaches an abort signal to reads but no longer retries them", async () => {
+    // retry now lives at the operation level (withReadRetry), not the fetch layer
+    let calls = 0;
+    let capturedOpts: any;
+    (PouchDB.fetch as Mock).mockImplementation(async (_url, opts) => {
+      calls++;
+      capturedOpts = opts;
       throw new TypeError("Failed to fetch");
     });
 
     await expect(
-      (database as any).fetchWithTransientRetry(
-        `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-        { headers: new Headers() },
-      ),
+      (database as any).fetchWithTimeout(READ_URL, {
+        method: "GET",
+        headers: new Headers(),
+      }),
     ).rejects.toThrow(TypeError);
 
-    // 1 initial + 2 retries = 3 total
-    expect(callCount).toBe(3);
+    // read gets the abort timeout signal, but only a single attempt
+    expect(capturedOpts?.signal).toBeInstanceOf(AbortSignal);
+    expect(calls).toBe(1);
   });
 
-  it("should not retry on non-TypeError errors", async () => {
-    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
-    (database as any).FETCH_TIMEOUT_MS = 60000;
-
-    let callCount = 0;
-    (PouchDB.fetch as Mock).mockImplementation(async () => {
-      callCount++;
-      throw new Error("Some other error");
-    });
-
-    await expect(
-      (database as any).fetchWithTransientRetry(
-        `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-        { headers: new Headers() },
-      ),
-    ).rejects.toThrow(Error);
-
-    // no retries for non-TypeError
-    expect(callCount).toBe(1);
-  });
-
-  it("should retry AbortError for GET requests", async () => {
-    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
-    (database as any).FETCH_TIMEOUT_MS = 60000;
-
-    const abortError = new DOMException("Fetch is aborted", "AbortError");
-
-    let callCount = 0;
-    (PouchDB.fetch as Mock).mockImplementation(async () => {
-      callCount++;
-      if (callCount < 2) {
-        throw abortError;
-      }
-      return new Response("{}", { status: HttpStatusCode.Ok });
-    });
-
-    const result = await (database as any).fetchWithTransientRetry(
-      `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-      { method: "GET", headers: new Headers() },
-    );
-
-    expect(callCount).toBe(2);
-    expect(result.status).toBe(HttpStatusCode.Ok);
-  });
-
-  it("should not retry write operations on any transient error (avoids create-then-unauthorized-update)", async () => {
-    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
-    (database as any).FETCH_TIMEOUT_MS = 60000;
-
-    const transientErrors = [
-      new DOMException("Fetch is aborted", "AbortError"),
-      new TypeError("Failed to fetch"), // e.g. ERR_NETWORK_CHANGED
-    ];
-
-    for (const method of ["PUT", "POST", "DELETE"]) {
-      for (const err of transientErrors) {
-        let callCount = 0;
-        (PouchDB.fetch as Mock).mockImplementation(async () => {
-          callCount++;
-          throw err;
-        });
-
-        await expect(
-          (database as any).fetchWithTransientRetry(
-            `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-            { method, headers: new Headers() },
-          ),
-        ).rejects.toBe(err);
-
-        // writes are never auto-retried — the server may have already committed
-        expect(callCount).toBe(1);
-      }
-    }
-  });
-
-  it("should not impose the abort timeout on write operations", async () => {
+  it("should run writes exactly once with no abort timeout signal", async () => {
     // a tiny timeout would abort almost immediately if it were applied to writes
     (database as any).FETCH_TIMEOUT_MS = 0;
 
+    let calls = 0;
     let capturedOpts: any;
     (PouchDB.fetch as Mock).mockImplementation(async (_url, opts) => {
+      calls++;
       capturedOpts = opts;
       return new Response("{}", { status: HttpStatusCode.Ok });
     });
 
-    const result = await (database as any).fetchWithTransientRetry(
-      `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-      { method: "PUT", headers: new Headers() },
-    );
+    const result = await (database as any).fetchWithTimeout(READ_URL, {
+      method: "PUT",
+      headers: new Headers(),
+    });
 
     expect(result.status).toBe(HttpStatusCode.Ok);
     // no AbortController signal is attached to writes, so a slow write is not aborted
     expect(capturedOpts?.signal).toBeUndefined();
+    expect(calls).toBe(1);
   });
 
   it("should use periodic polling for changes feed instead of live long-polling", async () => {
@@ -276,10 +273,9 @@ describe("RemotePouchDatabase tests", () => {
     }
   });
 
-  it("should show alert when fetch fails after retries", async () => {
+  it("should show alert when a fetch fails", async () => {
     const mockAlertService = { addWarning: vi.fn() };
     (database as any).alertService = mockAlertService;
-    (database as any).TRANSIENT_ERROR_DELAY_MS = 0;
     (database as any).FETCH_TIMEOUT_MS = 60000;
 
     (PouchDB.fetch as Mock).mockImplementation(async () => {

--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -11,6 +11,7 @@ import { timer } from "rxjs";
 import { exhaustMap, takeUntil } from "rxjs/operators";
 import { AlertService } from "../../alerts/alert.service";
 import { isVersionNewer } from "./version-comparison.utils";
+import { isConnectivityError } from "#src/app/utils/connectivity-error";
 
 /**
  * 4XX statuses that occur during normal operation
@@ -112,10 +113,11 @@ export class RemotePouchDatabase extends PouchDatabase {
 
   /**
    * Per-request timeout in ms for READ requests only. If the server sends no
-   * response within this window, the read fetch is aborted (and retried). This
-   * prevents long-idle connections from being killed unpredictably by Chrome
-   * (ERR_NETWORK_CHANGED) or proxies. Writes are never aborted or retried — see
-   * fetchWithTransientRetry.
+   * response within this window, the read fetch is aborted (and retried at the
+   * operation level by {@link withReadRetry}). This prevents long-idle
+   * connections from being killed unpredictably by Chrome (ERR_NETWORK_CHANGED)
+   * or proxies. Writes are never aborted or retried — see
+   * {@link fetchWithTimeout}.
    */
   private readonly FETCH_TIMEOUT_MS = 15000;
 
@@ -138,7 +140,7 @@ export class RemotePouchDatabase extends PouchDatabase {
 
     let result: Response;
     try {
-      result = await this.fetchWithTransientRetry(remoteUrl, opts);
+      result = await this.fetchWithTimeout(remoteUrl, opts);
     } catch (err) {
       Logging.debug("Failed initial fetch from DB", err);
       Logging.debug("navigator.onLine", navigator.onLine);
@@ -200,20 +202,57 @@ export class RemotePouchDatabase extends PouchDatabase {
   };
 
   /**
-   * Fetch with automatic retry for transient network errors (e.g. ERR_NETWORK_CHANGED)
-   * and a per-request timeout to abort long-idle connections cleanly.
-   * Network errors manifest as TypeErrors from the Fetch API.
+   * Retry idempotent reads that fail with a transient network error
+   * (e.g. an abort/timeout on a connection gone stale after the tab was
+   * suspended, or ERR_NETWORK_CHANGED).
    *
-   * Only safe/idempotent read methods (GET, HEAD) get the abort timeout and the
-   * transient-error retry. Non-idempotent writes (PUT, POST, DELETE) are run
-   * exactly once with no client-side timeout: a write may have already committed
-   * on the server even when the client never sees the response, so aborting or
-   * retrying it can turn a "create" into a forbidden "update" (the public role is
-   * create-only) or create a duplicate — surfacing as spurious "unauthorized"
-   * errors. Letting the write run to completion ensures the client reliably
-   * learns the new `_rev`.
+   * Retrying lives here, at the operation level, rather than in the fetch
+   * wrapper: {@link fetchWithTimeout} can only abort while acquiring the
+   * response headers, but an abort during response-body streaming surfaces
+   * after the fetch has returned — outside the wrapper's reach. Re-issuing the
+   * whole read (fresh fetch and body) recovers both cases transparently.
+   * Only reads route through this hook; writes must run exactly once
+   * (see {@link fetchWithTimeout}).
    */
-  private async fetchWithTransientRetry(
+  protected override async withReadRetry<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await operation();
+      } catch (err) {
+        if (
+          !isConnectivityError(err) ||
+          attempt >= this.TRANSIENT_ERROR_RETRIES
+        ) {
+          throw err;
+        }
+        Logging.debug(
+          `Transient DB read error (attempt ${attempt + 1}/${this.TRANSIENT_ERROR_RETRIES}), retrying...`,
+          err,
+        );
+        await new Promise((resolve) =>
+          setTimeout(resolve, this.TRANSIENT_ERROR_DELAY_MS),
+        );
+      }
+    }
+  }
+
+  /**
+   * Fetch a request with a per-request timeout so a hung/stale connection is
+   * aborted cleanly instead of hanging indefinitely (e.g. after the tab was
+   * suspended, or ERR_NETWORK_CHANGED). The abort surfaces as a transient
+   * error that {@link withReadRetry} retries at the operation level.
+   *
+   * Only safe/idempotent read methods (GET, HEAD) get the abort timeout.
+   * Non-idempotent writes (PUT, POST, DELETE) are run exactly once with no
+   * client-side timeout: a write may have already committed on the server even
+   * when the client never sees the response, so aborting it can turn a "create"
+   * into a forbidden "update" (the public role is create-only) or create a
+   * duplicate — surfacing as spurious "unauthorized" errors. Letting the write
+   * run to completion ensures the client reliably learns the new `_rev`.
+   */
+  private async fetchWithTimeout(
     url: string,
     opts: RequestInit,
   ): Promise<Response> {
@@ -221,35 +260,19 @@ export class RemotePouchDatabase extends PouchDatabase {
     const isSafeMethod = method === "GET" || method === "HEAD";
 
     if (!isSafeMethod) {
-      // Write: run once, to completion, without abort timeout or retry.
+      // Write: run once, to completion, without abort timeout.
       return PouchDB.fetch(url, opts);
     }
 
-    for (let attempt = 0; ; attempt++) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        this.FETCH_TIMEOUT_MS,
-      );
-      try {
-        const fetchOpts = { ...opts, signal: controller.signal };
-        return await PouchDB.fetch(url, fetchOpts);
-      } catch (err) {
-        const isTransient =
-          err instanceof TypeError || err?.name === "AbortError";
-        if (!isTransient || attempt >= this.TRANSIENT_ERROR_RETRIES) {
-          throw err;
-        }
-        Logging.debug(
-          `Transient network error (attempt ${attempt + 1}/${this.TRANSIENT_ERROR_RETRIES}), retrying...`,
-          err,
-        );
-        await new Promise((resolve) =>
-          setTimeout(resolve, this.TRANSIENT_ERROR_DELAY_MS),
-        );
-      } finally {
-        clearTimeout(timeoutId);
-      }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      this.FETCH_TIMEOUT_MS,
+    );
+    try {
+      return await PouchDB.fetch(url, { ...opts, signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/src/app/utils/connectivity-error.spec.ts
+++ b/src/app/utils/connectivity-error.spec.ts
@@ -1,0 +1,55 @@
+import { isConnectivityError } from "./connectivity-error";
+import { DatabaseException } from "../core/database/pouchdb/pouch-database";
+
+describe("isConnectivityError", () => {
+  it("returns false for nullish or unrelated errors", () => {
+    expect(isConnectivityError(undefined)).toBe(false);
+    expect(isConnectivityError(null)).toBe(false);
+    expect(isConnectivityError(new Error("x is not a function"))).toBe(false);
+    expect(isConnectivityError({ status: 404 })).toBe(false);
+  });
+
+  it("detects raw AbortError / TimeoutError by name", () => {
+    expect(isConnectivityError(new DOMException("aborted", "AbortError"))).toBe(
+      true,
+    );
+    expect(
+      isConnectivityError(new DOMException("timed out", "TimeoutError")),
+    ).toBe(true);
+  });
+
+  it("detects transient gateway/offline status codes", () => {
+    for (const status of [0, 502, 503, 504]) {
+      expect(isConnectivityError({ status })).toBe(true);
+    }
+  });
+
+  it("detects browser fetch failures by message", () => {
+    expect(isConnectivityError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(
+      isConnectivityError(
+        new TypeError("NetworkError when attempting to fetch resource"),
+      ),
+    ).toBe(true);
+    expect(isConnectivityError(new TypeError("Load failed"))).toBe(true);
+  });
+
+  it("classifies a DatabaseException that wraps an AbortError (via originalName)", () => {
+    // the abort's name would otherwise be clobbered to "DatabaseException"
+    const wrapped = new DatabaseException(
+      new DOMException("The operation was aborted.", "AbortError"),
+      "Config:CONFIG_ENTITY",
+    );
+
+    expect(wrapped.name).toBe("DatabaseException");
+    expect(isConnectivityError(wrapped)).toBe(true);
+  });
+
+  it("classifies a DatabaseException whose message is a network failure", () => {
+    const wrapped = new DatabaseException({
+      message: "Failed to fetch from DB",
+    });
+
+    expect(isConnectivityError(wrapped)).toBe(true);
+  });
+});

--- a/src/app/utils/connectivity-error.ts
+++ b/src/app/utils/connectivity-error.ts
@@ -19,7 +19,13 @@ const CONNECTIVITY_ERROR_PATTERNS = [
  */
 export function isConnectivityError(err: any): boolean {
   if (!err) return false;
-  if (err?.name === "TimeoutError" || err?.name === "AbortError") return true;
+  // Check both `name` and `originalName`: a DatabaseException keeps its `name`
+  // as "DatabaseException" for Sentry grouping but preserves the wrapped error's
+  // name (e.g. "AbortError") in `originalName`.
+  const names = [err?.name, err?.originalName];
+  if (names.includes("TimeoutError") || names.includes("AbortError")) {
+    return true;
+  }
   if ([0, 502, 503, 504].includes(err?.status)) return true;
 
   const message = `${err?.message ?? ""} ${err?.reason ?? ""} ${err?.toString?.() ?? ""}`;


### PR DESCRIPTION
Closes #4135 · Sentry: `AAM-DIGITAL-73M`

## Problem

Online-mode reads (`get` / `query` / `allDocs` over HTTP) could surface a **transient network abort** as an error-level `DatabaseException` reaching Sentry, even though the failure is benign and recovers on retry — e.g. when a response-body read is aborted on a connection gone stale after the browser tab was suspended (laptop sleep / long idle).

The existing retry lived in the fetch wrapper, which only covers **acquiring the response headers**. An abort during **response-body streaming** happens *after* the fetch returns — outside the wrapper's reach — and also bypasses the `"Failed to fetch from DB"` normalization, so the raw abort became a terminal error on its first occurrence. Full analysis in #4135.

## Change

### 1. Recover — move retry to the operation layer

Retry now lives at the **operation layer** — the only layer that sees a read's final outcome (headers *and* body):

- **`PouchDatabase`**: new `withReadRetry` hook (base implementation runs the read once, no retry); `get` / `allDocs` / `query` route their DB call through it. Behaviour for local/synced DBs is unchanged.
- **`RemotePouchDatabase`**: overrides `withReadRetry` to re-issue idempotent reads on `isConnectivityError` (aborts / timeouts / network errors), up to the existing retry budget. The predicate runs on the raw error, so it catches both the bare `AbortError` and the normalized `"Failed to fetch from DB"`.
- **`fetchWithTransientRetry` → `fetchWithTimeout`**: keeps only the per-request abort timeout, no retry. Writes still run exactly once with no timeout (a network failure gives no signal whether the server already committed, so retrying could duplicate a create or turn a create-only write into a forbidden update).

### 2. Classify — preserve the wrapped error name on `DatabaseException`

`DatabaseException` keeps its `name` as `"DatabaseException"` for stable Sentry grouping, which erased the wrapped error's own name (e.g. `"AbortError"`). It now also preserves that name in a new `originalName` field, and `isConnectivityError` checks both `name` and `originalName`. This is the residual safety net: a persistent transient failure that still throws terminally after retries are exhausted stays classifiable as a connectivity error downstream.

Net result: retry lives in exactly **one** place; the abort-during-body-read failure mode is recovered transparently on a fresh connection; and any residual terminal transient error remains recognizable instead of masquerading as a generic DB error.

## Note on sync / replication

The operation-layer retry only wraps `get` / `allDocs` / `query`, so it does **not** apply to sync — `SyncedPouchDatabase` runs PouchDB replication (`localDb.sync(remote, …)`), whose HTTP calls go straight through the remote's `fetch`, bypassing the operation layer.

A side effect of dropping the fetch-layer retry: GET-based replication requests (`_changes`, checkpoint reads, …) previously got a per-request retry via `fetchWithTransientRetry` and no longer do. Writes are unaffected (only GET/HEAD were ever retried). Sync now relies on the retry it already had — `liveSync()` re-runs the whole sync every 30s and on any local change, and treats connectivity errors as expected (debug-level, not Sentry noise). This is a minor, deliberate trade-off to keep retry in a single place and avoid double-retrying online-mode reads (which would otherwise retry at both the fetch and operation layers). If per-request sync resilience is wanted back, it can be restored on the sync-only remote instance without re-introducing double-retry.

## Testing

- `pouch-database.spec.ts`: `DatabaseException` unit tests (name stays `"DatabaseException"`, `originalName` preserved, not set when wrapping another `DatabaseException`).
- `connectivity-error.spec.ts` (new): `isConnectivityError` incl. a `DatabaseException` wrapping an `AbortError` classified via `originalName`.
- `remote-pouch-database.spec.ts`: operation-level `withReadRetry` tests, an end-to-end `get()` retry/recover test reproducing the Sentry issue, and timeout-only `fetchWithTimeout` tests.
- `synced-pouch-database.spec.ts`, `logging.service.spec.ts`, `keycloak-auth.service.spec.ts` (consumers): all green.
- Full run: 107 passing across the affected specs; `tsc --noEmit`: clean.

## Follow-up (separate)

The last piece of the safety net: extend the Sentry `beforeSend` filter to drop abort/transient events regardless of `navigator.onLine` (a tab that just reconnected reports `onLine: true` while requests still time out). Noted in #4135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
