### PR TITLE
fix(login): show offline demo users in mock mode and render picker without delay

### DIFF
--- a/src/app/core/session/auth/local/local-auth.service.spec.ts
+++ b/src/app/core/session/auth/local/local-auth.service.spec.ts
@@ -8,17 +8,20 @@ describe("LocalAuthService", () => {
   let service: LocalAuthService;
   let testUser: SessionInfo;
   let mockDatabases: ReturnType<typeof vi.fn>;
+  const originalSessionType = environment.session_type;
 
   beforeEach(() => {
     service = new LocalAuthService();
     localStorage.clear();
     mockDatabases = vi.fn().mockResolvedValue([]);
     vi.stubGlobal("indexedDB", { databases: mockDatabases });
+    environment.session_type = SessionType.local;
   });
 
   afterEach(() => {
     localStorage.clear();
     vi.unstubAllGlobals();
+    environment.session_type = originalSessionType;
   });
 
   it("should be created", () => {

--- a/src/app/core/session/auth/local/local-auth.service.ts
+++ b/src/app/core/session/auth/local/local-auth.service.ts
@@ -25,6 +25,12 @@ export class LocalAuthService {
       return [];
     }
 
+    // Mock (demo) mode uses the in-memory PouchDB adapter, so no IndexedDB
+    // database exists to check against. Return all stored users directly.
+    if (environment.session_type === SessionType.mock) {
+      return users;
+    }
+
     const existingDbNames = await this.listIndexedDbNames();
     return users.filter((user) => this.hasLocalDatabase(user, existingDbNames));
   }

--- a/src/app/core/session/login/login.component.html
+++ b/src/app/core/session/login/login.component.html
@@ -65,7 +65,7 @@
       </div>
 
       <!-- OFFLINE -->
-      @if (showOfflineSection() && offlineUsers.length > 0) {
+      @if (showOfflineSection() && offlineUsers().length > 0) {
         <mat-card class="margin-top-large" appearance="outlined">
           <mat-card-header
             matTooltip="You can use the application completely offline. However, your changes cannot be synchronized with other team members in this mode. When available, you should always use the online login."
@@ -84,7 +84,7 @@
           </mat-card-header>
           <mat-card-content>
             <mat-action-list>
-              @for (user of offlineUsers; track user.id) {
+              @for (user of offlineUsers(); track user.id) {
                 <button
                   mat-list-item
                   (click)="sessionManager.offlineLogin(user)"

--- a/src/app/core/session/login/login.component.spec.ts
+++ b/src/app/core/session/login/login.component.spec.ts
@@ -100,7 +100,7 @@ describe("LoginComponent", () => {
     // so enableOfflineLogin is already true.
     expect(component.enableOfflineLogin()).toBe(true);
     expect(component.showOfflineSection()).toBe(true);
-    expect(component.offlineUsers).toEqual(mockUsers);
+    expect(component.offlineUsers()).toEqual(mockUsers);
   });
 
   it("should show offline login after 10 seconds", async () => {
@@ -124,7 +124,7 @@ describe("LoginComponent", () => {
       await vi.advanceTimersByTimeAsync(10000);
       expect(component.enableOfflineLogin()).toBe(true);
       expect(component.showOfflineSection()).toBe(true);
-      expect(component.offlineUsers).toEqual(mockUsers);
+      expect(component.offlineUsers()).toEqual(mockUsers);
     } finally {
       vi.useRealTimers();
     }

--- a/src/app/core/session/login/login.component.ts
+++ b/src/app/core/session/login/login.component.ts
@@ -70,7 +70,7 @@ export class LoginComponent implements OnInit {
   loginState = inject(LoginStateSubject);
   siteSettingsService = inject(SiteSettingsService);
 
-  offlineUsers: SessionInfo[] = [];
+  offlineUsers = signal<SessionInfo[]>([]);
   /**
    * Whether offline-login buttons are clickable.
    * Becomes true once the remote login has failed or after a hard timeout,
@@ -167,7 +167,7 @@ export class LoginComponent implements OnInit {
     });
 
     this.sessionManager.getOfflineUsers().then((users) => {
-      this.offlineUsers = users;
+      this.offlineUsers.set(users);
     });
   }
 


### PR DESCRIPTION
- closes #4138

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing and CodeRabbit AI review
- [x] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

Test on the PR demo deployment (mock demo mode) in a **clean browser profile / Incognito window** (a normal profile may have a leftover local database from earlier runs that masks the bug):

1. Open the PR demo deployment.
2. Wait for the demo to load (auto-logs-in `demo-admin`).
3. Sign out.
4. On the login page, check the "Offline Login" section.

Expected:
- `demo` and `demo-admin` are listed and selectable.
- The list appears together with the "Log in" button, not 10-20 seconds later.
- Selecting `demo` or `demo-admin` logs you back in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline and demo-mode login so available local users are displayed and can be selected reliably.
  - Corrected offline user list updates after session checks and delayed loading.
  - Preserved offline login behavior across different session configurations.
- **Tests**
  - Added coverage to verify offline users are restored and displayed consistently during login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->