### PR TITLE
fix(import): link every value of a multi-value entity reference cell

### DIFF
--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -257,8 +257,16 @@ test("Import a multi-value entity reference from a single comma-separated column
     .getByRole("button", { name: "Confirm & Run Import" })
     .click();
 
-  // import runs to completion (the note is created with both linked schools)
+  // import runs to completion
   await expect(page.getByText("Import completed")).toBeVisible({
     timeout: 15_000,
   });
+
+  // open the created note and confirm both schools are linked on the saved record
+  await page.getByRole("navigation").getByText("Notes").click();
+  await page.getByText("Joint school meeting").click();
+  const noteDetails = page.getByRole("dialog");
+  await expect(noteDetails).toBeVisible();
+  await expect(noteDetails.getByText("Springfield Elementary")).toBeVisible();
+  await expect(noteDetails.getByText("Shelbyville Academy")).toBeVisible();
 });

--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -173,3 +173,78 @@ test("Import children with entity reference, date and enum column mappings", asy
   await expect(page.getByText("Bob Smith")).toBeVisible();
   await expect(page.getByText("Charlie Lee")).toBeVisible();
 });
+
+test("Import a multi-value entity reference from a single comma-separated column", async ({
+  page,
+}) => {
+  const users = generateUsers();
+
+  // Two schools to be referenced by name from one comma-separated cell
+  const school1 = createEntityOfType("School", "school-1");
+  school1["name"] = "Springfield Elementary";
+  const school2 = createEntityOfType("School", "school-2");
+  school2["name"] = "Shelbyville Academy";
+
+  await loadApp(page, [...users, school1, school2]);
+
+  await page.getByRole("navigation").getByText("Import").click();
+  await expect(page.getByText("Select a .xlsx or .csv file")).toBeVisible();
+
+  // a single "Groups" cell holds several comma-separated school names
+  const csvContent = [
+    "Subject,Groups",
+    'Joint school meeting,"Springfield Elementary, Shelbyville Academy"',
+  ].join("\n");
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles({
+    name: "multi-value-note.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(csvContent),
+  });
+
+  await expect(page.getByText("1 rows detected")).toBeVisible();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  // Step 2: import as Note (its "Groups" field is a multi-value entity reference)
+  await expect(page.getByText("Select the import target type")).toBeVisible();
+  await page.getByRole("textbox", { name: "Import as" }).fill("Note");
+  await page.getByRole("option", { name: "Note", exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  // Step 3: "Subject" and "Groups" auto-map by label; match the groups by school name
+  await expect(
+    page.getByText("Define which columns / fields will be imported"),
+  ).toBeVisible();
+
+  const groupsRow = page
+    .locator("app-edit-import-column-mapping")
+    .filter({ hasText: "Groups" });
+  await groupsRow.locator("mat-select").click();
+  await page.getByRole("option", { name: "Name", exact: true }).click();
+
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  // Step 4: both comma-separated names resolve to their records (the bug: was empty)
+  await expect(
+    page.getByText("Review your mapped data to be imported"),
+  ).toBeVisible();
+  await expect(page.getByText("Springfield Elementary")).toBeVisible();
+  await expect(page.getByText("Shelbyville Academy")).toBeVisible();
+
+  await argosScreenshot(page, "import-multi-value-review-both-references");
+
+  await page.getByRole("button", { name: "Start Import" }).click();
+  const confirmDialog = page.getByRole("dialog");
+  await expect(
+    confirmDialog.getByText("1 records will be imported"),
+  ).toBeVisible();
+  await confirmDialog
+    .getByRole("button", { name: "Confirm & Run Import" })
+    .click();
+
+  // import runs to completion (the note is created with both linked schools)
+  await expect(page.getByText("Import completed")).toBeVisible({
+    timeout: 15_000,
+  });
+});

--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -190,10 +190,11 @@ test("Import a multi-value entity reference from a single comma-separated column
   await page.getByRole("navigation").getByText("Import").click();
   await expect(page.getByText("Select a .xlsx or .csv file")).toBeVisible();
 
-  // a single "Groups" cell holds several comma-separated school names
+  // "Groups" holds comma-separated school names; "GroupIds" a second condition
+  // mapped to the same field (multi-column matching) holding the internal ids
   const csvContent = [
-    "Subject,Groups",
-    'Joint school meeting,"Springfield Elementary, Shelbyville Academy"',
+    "Subject,Groups,GroupIds",
+    'Joint school meeting,"Springfield Elementary, Shelbyville Academy","School:school-1, School:school-2"',
   ].join("\n");
 
   const fileInput = page.locator('input[type="file"]');
@@ -212,20 +213,33 @@ test("Import a multi-value entity reference from a single comma-separated column
   await page.getByRole("option", { name: "Note", exact: true }).click();
   await page.getByRole("button", { name: "Continue" }).click();
 
-  // Step 3: "Subject" and "Groups" auto-map by label; match the groups by school name
+  // Step 3: "Subject" and "Groups" auto-map by label; match the groups by school
+  // name, and map a second "GroupIds" column onto the same field matched by id
+  // (multi-column matching)
   await expect(
     page.getByText("Define which columns / fields will be imported"),
   ).toBeVisible();
 
   const groupsRow = page
     .locator("app-edit-import-column-mapping")
-    .filter({ hasText: "Groups" });
+    .filter({ hasText: /^Groups/ });
   await groupsRow.locator("mat-select").click();
   await page.getByRole("option", { name: "Name", exact: true }).click();
 
+  const groupIdsRow = page
+    .locator("app-edit-import-column-mapping")
+    .filter({ hasText: "GroupIds" });
+  await groupIdsRow.getByRole("textbox", { name: "GroupIds" }).fill("Groups");
+  await page.getByRole("option", { name: "Groups", exact: true }).click();
+  await groupIdsRow.locator("mat-select").click();
+  await page.getByRole("option", { name: /internal unique/i }).click();
+
+  // multi-column matching indicator is shown on the mapping step
+  await argosScreenshot(page, "import-multi-column-matching-mapping");
+
   await page.getByRole("button", { name: "Continue" }).click();
 
-  // Step 4: both comma-separated names resolve to their records (the bug: was empty)
+  // Step 4: both comma-separated names resolve to their records
   await expect(
     page.getByText("Review your mapped data to be imported"),
   ).toBeVisible();

--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -262,9 +262,11 @@ test("Import a multi-value entity reference from a single comma-separated column
     timeout: 15_000,
   });
 
-  // open the created note and confirm both schools are linked on the saved record
+  // open the created note and confirm both schools are linked on the saved record.
+  // the imported note has no date, so clear the list's default date-range filter first.
   await page.getByRole("navigation").getByText("Notes").click();
-  await page.getByText("Joint school meeting").click();
+  await page.getByRole("button", { name: "Reset date filter" }).click();
+  await page.getByRole("cell", { name: "Joint school meeting" }).click();
   const noteDetails = page.getByRole("dialog");
   await expect(noteDetails).toBeVisible();
   await expect(noteDetails.getByText("Springfield Elementary")).toBeVisible();

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
@@ -20,7 +20,7 @@ import { MatFormFieldModule } from "@angular/material/form-field";
 import { ConfirmationDialogService } from "../../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { EntitySchemaService } from "../../../entity/schema/entity-schema.service";
 import { MappingDialogData } from "app/core/import/import-column-mapping/mapping-dialog-data";
-import { splitArrayValue } from "app/core/import/import.service";
+import { splitArrayValue } from "app/core/import/split-array-value";
 import { EntitySchemaField } from "../../../entity/schema/entity-schema-field";
 import { KeyValuePipe } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -74,9 +74,28 @@ export class EntityDatatype extends StringDatatype {
   /**
    * Maps a value from an import to an actual entity in the database.
    *
-   * Finds all column mappings targeting this field, resolves each column's comparison value
-   * (applying any configured value mapping), and progressively filters candidate entities
-   * until a unique match is found.
+   * This gets called once for each (multi-value) value in a column mapped to the entity field,
+   * for each column (if multiple columns are mapped to the same field to filter it further).
+   *
+   * Case target field isArray===false:
+   * simple:
+   *  IMPORT: { x: "x1", y: "y1" }
+   *  --> matches { x: "x1", y: "y1" } (if there is a single unique match)
+   *
+   * complex, multi-value import:
+   *  IMPORT: { x: "x1,x2", y: "y1,y2" }
+   *  --> matches { x1, y1 } OR { x2, y2 } OR { x1, y2 } OR { x2, y1 } (if there is a single combination that matches)
+   *
+   *
+   * Case target field isArray===true:
+   * simple:
+   *  IMPORT: { x: "x1", y: "y1" }
+   *  --> matches { x: "x1", y: "y1", z: "z1" }, { x: "x1", y: "y1", z: "z2" } (if there are multiple matches)
+   *
+   * complex, multi-value import:
+   *  IMPORT: { x: "x1,x2", y: "y1,y2" }
+   *  --> matches { x: "x1", y: "y1" }, { x: "x2", y: "y2" }, { x: "x1", y: "y2" }, { x: "x2", y: "y1" } (any combinations that match)
+   *
    *
    * @param val The value from an import that should be mapped to an entity reference.
    * @param schemaField The config defining details of the field that will hold the entity reference after mapping.
@@ -320,6 +339,29 @@ function normalizeValue(val: any): string {
  * Manage cache access to the current import processing context.
  */
 class EntityFieldImportContext {
+  // SUGGESTED IMPLEMENTATION:
+  // keep a very clear class instance holding all details of the import for the current row for this field
+  // (also keep a (static?) cache of the full entity list to be reused across rows?)
+  // goal --> make this class very intuitive to understand (and hold all details for matching, without needing to read other methods outside)
+
+  /**
+   * The schema field of the entity, into which the value(s) will be imported.
+   */
+  targetField: EntitySchemaField;
+
+  /**
+   * Column(s) of the imported file that are mapped to the target field
+   * and used to filter the candidate entities for matching.
+   *
+   * This is populated gradually with every call to importMapFunction for each column mapped to the same field.
+   */
+  sourceColumns: any[]; // TODO: type? more than just the column ID maybe, if we have details?
+
+  // TODO: cache of full entity list to be searched
+  // TODO: cache of currently filtered down entity list? (if that's possible to cache for the various combinations)
+
+  // TODO: function to return entity object(s) currently matching the mapping
+
   constructor(
     private globalContext: ImportProcessingContext,
     private schemaField: EntitySchemaField,

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -22,7 +22,7 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { Logging } from "app/core/logging/logging.service";
 import { ImportProcessingContext } from "../../import/import-processing-context";
-import { splitArrayValue } from "../../import/import.service";
+import { splitArrayValue } from "../../import/split-array-value";
 import { ColumnMapping } from "../../import/column-mapping";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { Entity, EntityConstructor } from "../../entity/model/entity";

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -108,9 +108,20 @@ export class EntityDatatype extends StringDatatype {
       importProcessingContext,
     );
 
+    // Filter fresh from the full candidate list on every call so each value
+    // of a multi-value cell is matched independently (import.service splits
+    // the cell and calls this function once per value).
+    let candidates = context.entities ?? [];
+
     for (const mapping of columnMappings) {
       const mappingConfig = normalizeEntityAdditional(mapping.additional);
-      const rawValue = importProcessingContext.row[mapping.column];
+      // Use the passed value for the column currently being mapped; other
+      // columns targeting this field contribute extra match criteria read
+      // from the row.
+      const isCurrentColumn = mappingConfig?.refField === fieldConfig.refField;
+      const rawValue = isCurrentColumn
+        ? val
+        : importProcessingContext.row[mapping.column];
 
       const expectedValue = await this.resolveColumnValue(
         rawValue,
@@ -120,13 +131,13 @@ export class EntityDatatype extends StringDatatype {
         importProcessingContext,
       );
 
-      context.filteredEntities = context.filteredEntities.filter(
+      candidates = candidates.filter(
         (entity) =>
           normalizeValue(entity[mappingConfig?.refField]) === expectedValue,
       );
     }
 
-    return this.pickSingleMatch(context.filteredEntities);
+    return this.pickSingleMatch(candidates);
   }
 
   /**
@@ -309,18 +320,10 @@ function normalizeValue(val: any): string {
  * Manage cache access to the current import processing context.
  */
 class EntityFieldImportContext {
-  private contextKey: string;
-
   constructor(
     private globalContext: ImportProcessingContext,
     private schemaField: EntitySchemaField,
-  ) {
-    this.contextKey = `${schemaField.id}_${globalContext.rowIndex}`;
-
-    if (!globalContext[this.contextKey]) {
-      globalContext[this.contextKey] = {};
-    }
-  }
+  ) {}
 
   /**
    * Entities (in database format for easier comparison!)
@@ -342,21 +345,5 @@ class EntityFieldImportContext {
 
   set refEntityCtor(value: EntityConstructor) {
     this.globalContext[`ctor_${this.schemaField.additional}`] = value;
-  }
-
-  /**
-   * Entities already filter by any other column conditions
-   * (in database format for easier comparison!)
-   */
-  get filteredEntities(): any[] {
-    return (
-      this.globalContext[this.contextKey].filteredEntities ??
-      this.entities ??
-      []
-    );
-  }
-
-  set filteredEntities(value: any[]) {
-    this.globalContext[this.contextKey].filteredEntities = value;
   }
 }

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -26,7 +26,10 @@ import { splitArrayValue } from "../../import/split-array-value";
 import { ColumnMapping } from "../../import/column-mapping";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { Entity, EntityConstructor } from "../../entity/model/entity";
-import { ExportColumnMapping } from "../../entity/default-datatype/default.datatype";
+import {
+  ColumnImportInput,
+  ExportColumnMapping,
+} from "../../entity/default-datatype/default.datatype";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
 
 /**
@@ -105,7 +108,7 @@ export class EntityDatatype extends StringDatatype {
    */
   override async importMatchField(
     schemaField: EntitySchemaField,
-    columns: { mapping: ColumnMapping; rawCell: any }[],
+    columns: ColumnImportInput[],
     importProcessingContext: ImportProcessingContext,
   ): Promise<string | string[] | undefined> {
     const context = new EntityFieldImportContext(
@@ -115,12 +118,57 @@ export class EntityDatatype extends StringDatatype {
     await this.loadImportMapEntities(schemaField.additional, context);
     const candidates = context.entities ?? [];
 
+    const criteria = await this.buildMatchCriteria(
+      columns,
+      context,
+      importProcessingContext,
+    );
+    if (criteria.length === 0) {
+      return schemaField.isArray ? [] : undefined;
+    }
+
+    // A candidate matches when, for every mapped column, its referenced field
+    // value is one of that column's (possibly multiple) values. A mapped column
+    // with no value yields an empty list that matches nothing, so an incomplete
+    // row cannot match.
+    const matchedIds = candidates
+      .filter((entity) =>
+        criteria.every((criterion) =>
+          criterion.values.includes(normalizeValue(entity[criterion.refField])),
+        ),
+      )
+      .map((entity) => entity._id);
+    const uniqueIds = [...new Set(matchedIds)];
+
+    if (schemaField.isArray) {
+      return uniqueIds;
+    }
+    if (uniqueIds.length === 1) {
+      return uniqueIds[0];
+    }
+    if (uniqueIds.length > 1) {
+      Logging.debug(
+        "No unique match found in EntityDatatype importMatchField",
+        uniqueIds.length,
+      );
+    }
+    return undefined;
+  }
+
+  /**
+   * Build one match criterion per mapped column: the referenced field to
+   * compare and the acceptable (normalized) values parsed from the column cell.
+   */
+  private async buildMatchCriteria(
+    columns: ColumnImportInput[],
+    context: EntityFieldImportContext,
+    importProcessingContext: ImportProcessingContext,
+  ): Promise<EntityMatchCriterion[]> {
     const separator =
       importProcessingContext.importSettings.additionalSettings
         ?.multiValueSeparator ?? ",";
 
-    // one list of comparison values per mapped column
-    const columnValueLists: { refField: string; values: string[] }[] = [];
+    const criteria: EntityMatchCriterion[] = [];
     for (const { mapping, rawCell } of columns) {
       const config = normalizeEntityAdditional(mapping.additional);
       if (!config?.refField) {
@@ -128,16 +176,12 @@ export class EntityDatatype extends StringDatatype {
         continue;
       }
 
-      const enableSplitting = mapping.additional?.enableSplitting ?? true;
-      const rawValues =
-        rawCell == null
-          ? []
-          : enableSplitting
-            ? splitArrayValue(rawCell, separator)
-            : [rawCell];
-
       const values: string[] = [];
-      for (const rawValue of rawValues) {
+      for (const rawValue of this.splitCellValues(
+        rawCell,
+        mapping,
+        separator,
+      )) {
         values.push(
           await this.resolveColumnValue(
             rawValue,
@@ -148,64 +192,25 @@ export class EntityDatatype extends StringDatatype {
           ),
         );
       }
-      // a mapped identifier column with no value can never match, so keep it as
-      // an (empty) criterion rather than dropping it (blocks incomplete rows)
-      columnValueLists.push({
-        refField: config.refField,
-        values: values.length ? values : [""],
-      });
+      criteria.push({ refField: config.refField, values });
     }
-
-    if (columnValueLists.length === 0) {
-      return schemaField.isArray ? [] : undefined;
-    }
-
-    const matches = this.findMatchingEntities(candidates, columnValueLists);
-
-    if (schemaField.isArray) {
-      return matches.map((entity) => entity._id);
-    }
-    if (matches.length === 1) {
-      return matches[0]._id;
-    }
-    if (matches.length > 1) {
-      Logging.debug(
-        "No unique match found in EntityDatatype importMatchField",
-        matches.length,
-      );
-    }
-    return undefined;
+    return criteria;
   }
 
   /**
-   * Returns the distinct entities matched by any combination of one comparison
-   * value per column (cartesian product of the columns' value lists).
+   * Split a raw cell into the individual values to match, honoring the column's
+   * enableSplitting flag.
    */
-  private findMatchingEntities(
-    candidates: any[],
-    columnValueLists: { refField: string; values: string[] }[],
-  ): any[] {
-    let combinations: Record<string, string>[] = [{}];
-    for (const { refField, values } of columnValueLists) {
-      combinations = combinations.flatMap((combination) =>
-        values.map((value) => ({ ...combination, [refField]: value })),
-      );
+  private splitCellValues(
+    rawCell: unknown,
+    mapping: ColumnMapping,
+    separator: string,
+  ): unknown[] {
+    if (rawCell === undefined || rawCell === null) {
+      return [];
     }
-
-    const matched: any[] = [];
-    const seen = new Set<string>();
-    for (const combination of combinations) {
-      for (const entity of candidates) {
-        const isMatch = Object.entries(combination).every(
-          ([refField, value]) => normalizeValue(entity[refField]) === value,
-        );
-        if (isMatch && !seen.has(entity._id)) {
-          seen.add(entity._id);
-          matched.push(entity);
-        }
-      }
-    }
-    return matched;
+    const enableSplitting = mapping.additional?.enableSplitting ?? true;
+    return enableSplitting ? splitArrayValue(rawCell, separator) : [rawCell];
   }
 
   /**
@@ -313,6 +318,15 @@ export class EntityDatatype extends StringDatatype {
 
     return relatedEntitiesToStrings;
   }
+}
+
+/**
+ * One matching condition derived from a mapped import column: candidates must
+ * have `refField` equal to one of the (normalized) `values`.
+ */
+interface EntityMatchCriterion {
+  refField: string;
+  values: string[];
 }
 
 /**

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -22,6 +22,8 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { Logging } from "app/core/logging/logging.service";
 import { ImportProcessingContext } from "../../import/import-processing-context";
+import { splitArrayValue } from "../../import/import.service";
+import { ColumnMapping } from "../../import/column-mapping";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
 import { Entity, EntityConstructor } from "../../entity/model/entity";
 import { ExportColumnMapping } from "../../entity/default-datatype/default.datatype";
@@ -72,103 +74,138 @@ export class EntityDatatype extends StringDatatype {
   }
 
   /**
-   * Maps a value from an import to an actual entity in the database.
+   * Matches an import row to actual entities in the database
+   * (per-field entry point, see DefaultDatatype.importMatchField).
    *
-   * This gets called once for each (multi-value) value in a column mapped to the entity field,
-   * for each column (if multiple columns are mapped to the same field to filter it further).
+   * Splits every mapped column's cell into individual values, resolves any
+   * per-column value mapping, then searches candidate entities for each
+   * combination of one value per column:
    *
    * Case target field isArray===false:
    * simple:
    *  IMPORT: { x: "x1", y: "y1" }
    *  --> matches { x: "x1", y: "y1" } (if there is a single unique match)
-   *
    * complex, multi-value import:
    *  IMPORT: { x: "x1,x2", y: "y1,y2" }
    *  --> matches { x1, y1 } OR { x2, y2 } OR { x1, y2 } OR { x2, y1 } (if there is a single combination that matches)
    *
-   *
    * Case target field isArray===true:
    * simple:
    *  IMPORT: { x: "x1", y: "y1" }
-   *  --> matches { x: "x1", y: "y1", z: "z1" }, { x: "x1", y: "y1", z: "z2" } (if there are multiple matches)
-   *
+   *  --> matches every record with { x: "x1", y: "y1" }
    * complex, multi-value import:
    *  IMPORT: { x: "x1,x2", y: "y1,y2" }
-   *  --> matches { x: "x1", y: "y1" }, { x: "x2", y: "y2" }, { x: "x1", y: "y2" }, { x: "x2", y: "y1" } (any combinations that match)
+   *  --> matches every record for any combination { x1, y1 }, { x2, y2 }, { x1, y2 }, { x2, y1 }
    *
-   *
-   * @param val The value from an import that should be mapped to an entity reference.
-   * @param schemaField The config defining details of the field that will hold the entity reference after mapping.
-   * @param additional The field of the referenced entity that should be compared with the val.
-   *   Can be a plain string (legacy) or an object `{ refField: string, valueMapping?: any }`.
-   * @param importProcessingContext context to share information across calls for multiple columns and rows.
-   * @returns Promise resolving to the ID of the matched entity or undefined if no match is found.
+   * @param schemaField the target field the value(s) are imported into
+   * @param columns every column mapped to this field, with its raw cell value
+   * @param importProcessingContext context shared across columns and rows
+   * @returns the id of the single match (isArray=false) or the deduped ids of
+   *   all matches (isArray=true), or undefined / [] if nothing matched
    */
-  override async importMapFunction(
-    val: any,
+  override async importMatchField(
     schemaField: EntitySchemaField,
-    additional: string | EntityAdditional,
+    columns: { mapping: ColumnMapping; rawCell: any }[],
     importProcessingContext: ImportProcessingContext,
-  ): Promise<string | undefined> {
-    const fieldConfig = normalizeEntityAdditional(additional);
-    if (!fieldConfig?.refField || val == null) {
-      return undefined;
-    }
-
+  ): Promise<string | string[] | undefined> {
     const context = new EntityFieldImportContext(
       importProcessingContext,
       schemaField,
     );
-
     await this.loadImportMapEntities(schemaField.additional, context);
+    const candidates = context.entities ?? [];
 
-    const columnMappings = this.getColumnMappingsForField(
-      schemaField.id,
-      importProcessingContext,
-    );
+    const separator =
+      importProcessingContext.importSettings.additionalSettings
+        ?.multiValueSeparator ?? ",";
 
-    // Filter fresh from the full candidate list on every call so each value
-    // of a multi-value cell is matched independently (import.service splits
-    // the cell and calls this function once per value).
-    let candidates = context.entities ?? [];
+    // one list of comparison values per mapped column
+    const columnValueLists: { refField: string; values: string[] }[] = [];
+    for (const { mapping, rawCell } of columns) {
+      const config = normalizeEntityAdditional(mapping.additional);
+      if (!config?.refField) {
+        // column not usable as an identifier for this field
+        continue;
+      }
 
-    for (const mapping of columnMappings) {
-      const mappingConfig = normalizeEntityAdditional(mapping.additional);
-      // Use the passed value for the column currently being mapped; other
-      // columns targeting this field contribute extra match criteria read
-      // from the row.
-      const isCurrentColumn = mappingConfig?.refField === fieldConfig.refField;
-      const rawValue = isCurrentColumn
-        ? val
-        : importProcessingContext.row[mapping.column];
+      const enableSplitting = mapping.additional?.enableSplitting ?? true;
+      const rawValues =
+        rawCell == null
+          ? []
+          : enableSplitting
+            ? splitArrayValue(rawCell, separator)
+            : [rawCell];
 
-      const expectedValue = await this.resolveColumnValue(
-        rawValue,
-        mappingConfig?.refField,
-        mappingConfig?.valueMapping,
-        context,
-        importProcessingContext,
-      );
-
-      candidates = candidates.filter(
-        (entity) =>
-          normalizeValue(entity[mappingConfig?.refField]) === expectedValue,
-      );
+      const values: string[] = [];
+      for (const rawValue of rawValues) {
+        values.push(
+          await this.resolveColumnValue(
+            rawValue,
+            config.refField,
+            config.valueMapping,
+            context,
+            importProcessingContext,
+          ),
+        );
+      }
+      // a mapped identifier column with no value can never match, so keep it as
+      // an (empty) criterion rather than dropping it (blocks incomplete rows)
+      columnValueLists.push({
+        refField: config.refField,
+        values: values.length ? values : [""],
+      });
     }
 
-    return this.pickSingleMatch(candidates);
+    if (columnValueLists.length === 0) {
+      return schemaField.isArray ? [] : undefined;
+    }
+
+    const matches = this.findMatchingEntities(candidates, columnValueLists);
+
+    if (schemaField.isArray) {
+      return matches.map((entity) => entity._id);
+    }
+    if (matches.length === 1) {
+      return matches[0]._id;
+    }
+    if (matches.length > 1) {
+      Logging.debug(
+        "No unique match found in EntityDatatype importMatchField",
+        matches.length,
+      );
+    }
+    return undefined;
   }
 
   /**
-   * Returns all column mappings that target the given field.
+   * Returns the distinct entities matched by any combination of one comparison
+   * value per column (cartesian product of the columns' value lists).
    */
-  private getColumnMappingsForField(
-    fieldId: string,
-    importProcessingContext: ImportProcessingContext,
-  ) {
-    return importProcessingContext.importSettings.columnMapping.filter(
-      (m) => m.propertyName === fieldId,
-    );
+  private findMatchingEntities(
+    candidates: any[],
+    columnValueLists: { refField: string; values: string[] }[],
+  ): any[] {
+    let combinations: Record<string, string>[] = [{}];
+    for (const { refField, values } of columnValueLists) {
+      combinations = combinations.flatMap((combination) =>
+        values.map((value) => ({ ...combination, [refField]: value })),
+      );
+    }
+
+    const matched: any[] = [];
+    const seen = new Set<string>();
+    for (const combination of combinations) {
+      for (const entity of candidates) {
+        const isMatch = Object.entries(combination).every(
+          ([refField, value]) => normalizeValue(entity[refField]) === value,
+        );
+        if (isMatch && !seen.has(entity._id)) {
+          seen.add(entity._id);
+          matched.push(entity);
+        }
+      }
+    }
+    return matched;
   }
 
   /**
@@ -206,22 +243,6 @@ export class EntityDatatype extends StringDatatype {
       refFieldSchema,
     );
     return normalizeValue(dbFormat);
-  }
-
-  /**
-   * Returns the entity ID if exactly one candidate remains, otherwise undefined.
-   */
-  private pickSingleMatch(candidates: any[]): string | undefined {
-    if (candidates.length === 1) {
-      return candidates[0]._id;
-    }
-    if (candidates.length > 1) {
-      Logging.debug(
-        "No unique match found in EntityDatatype importMapFunction",
-        candidates.length,
-      );
-    }
-    return undefined;
   }
 
   /**
@@ -339,29 +360,6 @@ function normalizeValue(val: any): string {
  * Manage cache access to the current import processing context.
  */
 class EntityFieldImportContext {
-  // SUGGESTED IMPLEMENTATION:
-  // keep a very clear class instance holding all details of the import for the current row for this field
-  // (also keep a (static?) cache of the full entity list to be reused across rows?)
-  // goal --> make this class very intuitive to understand (and hold all details for matching, without needing to read other methods outside)
-
-  /**
-   * The schema field of the entity, into which the value(s) will be imported.
-   */
-  targetField: EntitySchemaField;
-
-  /**
-   * Column(s) of the imported file that are mapped to the target field
-   * and used to filter the candidate entities for matching.
-   *
-   * This is populated gradually with every call to importMapFunction for each column mapped to the same field.
-   */
-  sourceColumns: any[]; // TODO: type? more than just the column ID maybe, if we have details?
-
-  // TODO: cache of full entity list to be searched
-  // TODO: cache of currently filtered down entity list? (if that's possible to cache for the various combinations)
-
-  // TODO: function to return entity object(s) currently matching the mapping
-
   constructor(
     private globalContext: ImportProcessingContext,
     private schemaField: EntitySchemaField,

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -139,6 +139,31 @@ describe("Schema data type: entity (advanced functionality)", () => {
     expect(result).toBe(undefined);
   });
 
+  it("should importMap each split value of a multi-value cell", async () => {
+    const joe = new TestEntity();
+    joe.name = "Joe";
+    const max = new TestEntity();
+    max.name = "Max";
+    await entityMapper.saveAll([joe, max]);
+
+    // single column mapping into an array field: the cell holds comma-separated
+    // names, so import.service splits it and calls importMapFunction per value
+    const importContext = new ImportProcessingContext({
+      entityType: TestEntity.ENTITY_TYPE,
+      columnMapping: [
+        { column: "iRef", propertyName: schema.id, additional: "name" },
+      ],
+    });
+    importContext.row = { iRef: "Joe, Max" };
+
+    await expect(
+      dataType.importMapFunction("Joe", schema, "name", importContext),
+    ).resolves.toEqual(joe.getId());
+    await expect(
+      dataType.importMapFunction("Max", schema, "name", importContext),
+    ).resolves.toEqual(max.getId());
+  });
+
   it("should anonymize entity recursively", async () => {
     const referencedEntity = new TestEntity("ref-1");
     referencedEntity.name = "test";

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -10,6 +10,11 @@ import { ImportProcessingContext } from "../../import/import-processing-context"
 import { TestBed } from "@angular/core/testing";
 import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.service";
 import { CoreTestingModule } from "../../../utils/core-testing.module";
+import { ImportService } from "../../import/import.service";
+import { ColumnMapping } from "../../import/column-mapping";
+import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { DatabaseField } from "../../entity/database-field.decorator";
+import { Entity } from "../../entity/model/entity";
 
 // separate test file for custom functionality of the EntityDatatype
 // because there were conflicts with the standard tests in entity.datatype.spec.ts
@@ -41,19 +46,16 @@ describe("Schema data type: entity (advanced functionality)", () => {
     schema = TestEntity.schema.get("ref") as EntitySchemaField;
   });
 
-  it("should importMap by matching string correctly", async () => {
-    const c1 = new TestEntity();
-    c1.other = "456"; // Ensure "other" is a string
-    await entityMapper.saveAll([c1]);
+  // NOTE ON SCOPE: the happy-path matching cases (basic string match, multi-column
+  // narrowing, isArray/multi-value behavior) are covered end-to-end through
+  // ImportService in the separate describe block at the bottom of this file. The
+  // direct-call tests kept here cover orthogonal dimensions of importMapFunction
+  // that the end-to-end suite does not exercise: value-type coercion, the object
+  // `additional` format, valueMapping, per-value array splitting, and the
+  // "no unique match -> undefined" contract.
 
-    const importContext = createImportContext("456", schema.id, "other");
-
-    // "simple" case: imported value is string already
-    await expect(
-      dataType.importMapFunction("456", schema, "other", importContext),
-    ).resolves.toEqual(c1.getId());
-  });
-
+  // Orthogonal: value-type coercion — a numeric import value must still match a
+  // string-stored field (normalizeValue coerces both sides to string).
   it("should importMap by matching numeric value correctly", async () => {
     const c2 = new TestEntity();
     c2.other = "456"; // Ensure "other" is a string
@@ -67,78 +69,38 @@ describe("Schema data type: entity (advanced functionality)", () => {
     ).resolves.toEqual(c2.getId());
   });
 
-  it("should importMap by matching multiple fields", async () => {
-    const c1 = new TestEntity();
-    c1.name = "Joe";
-    c1.other = "1";
+  // Orthogonal: the "no unique match -> undefined" contract. When multiple mapped
+  // columns impose criteria that no single entity satisfies together, the result
+  // must be undefined (the positive multi-column narrowing path is covered by the
+  // end-to-end "single unique match" case).
+  it("should importMap to undefined when mapped columns have no common match", async () => {
+    const joe = new TestEntity();
+    joe.name = "Joe";
+    joe.other = "1";
+    const max = new TestEntity();
+    max.name = "Max";
+    max.other = "2";
+    await entityMapper.saveAll([joe, max]);
 
-    const c2 = new TestEntity();
-    c2.name = "Max";
-    c2.other = "2";
-
-    const c3 = new TestEntity();
-    c3.name = "Joe";
-    c3.other = "2";
-
-    await entityMapper.saveAll([c1, c2, c3]);
-
-    let importContext = new ImportProcessingContext({
+    const importContext = new ImportProcessingContext({
       entityType: TestEntity.ENTITY_TYPE,
       columnMapping: [
-        {
-          column: "iName",
-          propertyName: schema.id,
-          additional: "name",
-        },
-        {
-          column: "iOther",
-          propertyName: schema.id,
-          additional: "other",
-        },
+        { column: "iName", propertyName: schema.id, additional: "name" },
+        { column: "iOther", propertyName: schema.id, additional: "other" },
       ],
     });
-    importContext.row = { iName: "Joe", iOther: "2", iRef: "x" };
-    let result = await dataType.importMapFunction(
-      "Joe",
-      schema,
-      "name",
-      importContext,
-    );
+    // "Joe" exists and "2" exists, but no single entity has both -> no match
+    importContext.row = { iName: "Joe", iOther: "2" };
 
-    // expect to filter all column conditions and update result upon second column's criteria
-    expect(result).toBe(c3.getId());
-
-    let importContext2 = new ImportProcessingContext({
-      entityType: TestEntity.ENTITY_TYPE,
-      columnMapping: [
-        {
-          column: "iName",
-          propertyName: schema.id,
-          additional: "name",
-        },
-        {
-          column: "iOther",
-          propertyName: schema.id,
-          additional: "other",
-        },
-        {
-          column: "iRef",
-          propertyName: schema.id,
-          additional: "ref",
-        },
-      ],
-    });
-    importContext2.row = { iName: "Joe", iOther: "2", iRef: "x" };
-    result = await dataType.importMapFunction(
-      "x",
-      schema,
-      "ref",
-      importContext2,
-    );
-    // expect reset to undefined if further criteria does not match anymore
-    expect(result).toBe(undefined);
+    await expect(
+      dataType.importMapFunction("Joe", schema, "name", importContext),
+    ).resolves.toBe(undefined);
   });
 
+  // Orthogonal: per-value splitting of a single-column multi-value cell. Distinct
+  // from the (still-red) multi-column array cases in the end-to-end block below —
+  // this single-column path already works: ImportService splits the cell and calls
+  // importMapFunction once per value.
   it("should importMap each split value of a multi-value cell", async () => {
     const joe = new TestEntity();
     joe.name = "Joe";
@@ -188,38 +150,35 @@ describe("Schema data type: entity (advanced functionality)", () => {
     expect(removeService.anonymize).toHaveBeenCalledWith(referencedEntity);
   });
 
-  it("should importMap with new object additional format { refField }", async () => {
-    const c1 = new TestEntity();
-    c1.other = "456";
-    await entityMapper.saveAll([c1]);
-
-    const importContext = createImportContext("456", schema.id, {
-      refField: "other",
-    });
+  // Orthogonal: the `additional` config accepts both the legacy plain-string form
+  // and the object `{ refField }` form. (Legacy string is also implicitly exercised
+  // by the end-to-end suite; kept here as an explicit guard for both forms.)
+  it("should importMap with both legacy-string and object { refField } additional", async () => {
+    const legacy = TestEntity.create({ other: "legacyValue" });
+    const object = TestEntity.create({ other: "objectValue" });
+    await entityMapper.saveAll([legacy, object]);
 
     await expect(
       dataType.importMapFunction(
-        "456",
+        "legacyValue",
+        schema,
+        "other",
+        createImportContext("legacyValue", schema.id, "other"),
+      ),
+    ).resolves.toEqual(legacy.getId());
+
+    await expect(
+      dataType.importMapFunction(
+        "objectValue",
         schema,
         { refField: "other" },
-        importContext,
+        createImportContext("objectValue", schema.id, { refField: "other" }),
       ),
-    ).resolves.toEqual(c1.getId());
+    ).resolves.toEqual(object.getId());
   });
 
-  it("should importMap with legacy string additional (backward compat)", async () => {
-    const c1 = new TestEntity();
-    c1.other = "testValue";
-    await entityMapper.saveAll([c1]);
-
-    const importContext = createImportContext("testValue", schema.id, "other");
-
-    // Legacy format (plain string) should still work
-    await expect(
-      dataType.importMapFunction("testValue", schema, "other", importContext),
-    ).resolves.toEqual(c1.getId());
-  });
-
+  // Orthogonal: valueMapping runs the raw import value through the referenced
+  // field's own datatype (here a date) before comparing.
   it("should importMap entity ref with date valueMapping", async () => {
     const entity = new TestEntity();
     // Store the date as it would be in DB format (YYYY-MM-DD)
@@ -236,28 +195,6 @@ describe("Schema data type: entity (advanced functionality)", () => {
     await expect(
       dataType.importMapFunction(
         "01.05.1990",
-        schema,
-        additional,
-        importContext,
-      ),
-    ).resolves.toEqual(entity.getId());
-  });
-
-  it("should importMap entity ref using object additional format with refField", async () => {
-    const entity = new TestEntity();
-    entity.other = "some value";
-    await entityMapper.saveAll([entity]);
-
-    const additional = { refField: "other" };
-    const importContext = createImportContext(
-      "some value",
-      schema.id,
-      additional,
-    );
-
-    await expect(
-      dataType.importMapFunction(
-        "some value",
         schema,
         additional,
         importContext,
@@ -284,4 +221,160 @@ describe("Schema data type: entity (advanced functionality)", () => {
 
     return importContext;
   }
+});
+
+/**
+ * End-to-end coverage of the entity-reference matching cases documented on
+ * EntityDatatype.importMapFunction, exercised through the real ImportService so
+ * that column splitting and multi-value aggregation (which live in ImportService,
+ * not the datatype) are part of the assertion.
+ *
+ * Target entity has both a single-value (`singleRef`) and an array (`arrayRef`)
+ * entity-reference field pointing at TestEntity, so each documented isArray case
+ * can be triggered by mapping columns onto the matching field.
+ *
+ * CURRENT STATUS (TDD) — only the isArray===false / simple case passes today.
+ * The other three tests are intentionally RED: they pin the intended behavior
+ * documented on importMapFunction that is NOT yet implemented. Root causes:
+ *  - Multiple matches for an array field: `pickSingleMatch` returns `undefined`
+ *    whenever >1 candidate remains, so a value that matches several records links
+ *    none instead of all of them.
+ *  - Cross-column value combinations: array cells are split, but only for the
+ *    *current* mapped column — every other mapped column is read whole from the
+ *    row (importMapFunction, `row[mapping.column]`) and compared by equality, so
+ *    combinations across columns never form.
+ *  - Non-array multi-value cells are never split at all (ImportService only splits
+ *    when `schema.isArray`), so a "x1,x2" cell can't resolve to a single combo.
+ * Implementing these requires changing importMapFunction's single-id return
+ * contract (to yield multiple ids for array targets) and the split/aggregate
+ * logic in ImportService.
+ */
+describe("Schema data type: entity (import matching, end-to-end via ImportService)", () => {
+  class ImportTarget extends Entity {
+    @DatabaseField({
+      dataType: EntityDatatype.dataType,
+      additional: TestEntity.ENTITY_TYPE,
+    })
+    singleRef: string;
+
+    @DatabaseField({
+      dataType: EntityDatatype.dataType,
+      isArray: true,
+      additional: TestEntity.ENTITY_TYPE,
+    })
+    arrayRef: string[];
+  }
+
+  let service: ImportService;
+  let entityMapper: MockEntityMapperService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CoreTestingModule],
+      providers: [ImportService, ...mockEntityMapperProvider([])],
+    });
+    service = TestBed.inject(ImportService);
+    entityMapper = TestBed.inject(
+      EntityMapperService,
+    ) as MockEntityMapperService;
+
+    // resolve the "ImportTarget" type used only in this spec, while keeping the
+    // real registry for the referenced TestEntity type
+    const registry = TestBed.inject(EntityRegistry);
+    const realGet = registry.get.bind(registry);
+    vi.spyOn(registry, "get").mockImplementation((type: string) =>
+      type === "ImportTarget" ? (ImportTarget as any) : realGet(type),
+    );
+  });
+
+  async function runImport(row: any, columnMapping: ColumnMapping[]) {
+    const { entities } = await service.transformRawDataToEntities([row], {
+      entityType: "ImportTarget",
+      columnMapping,
+    });
+    return entities[0] as ImportTarget | undefined;
+  }
+
+  // Case target field isArray===false, simple:
+  //  { name: "John", other: "m" } --> the single unique match
+  // GREEN. Also the canonical happy-path: subsumes the former direct-call tests
+  // for basic string matching, multi-column narrowing, and legacy-string
+  // `additional` format (`additional: "name"` is the legacy string form).
+  it("links the single unique match (isArray=false, simple)", async () => {
+    const john = TestEntity.create({ name: "John", other: "m" });
+    const jane = TestEntity.create({ name: "Jane", other: "m" });
+    await entityMapper.saveAll([john, jane]);
+
+    const result = await runImport({ name: "John", other: "m" }, [
+      { column: "name", propertyName: "singleRef", additional: "name" },
+      { column: "other", propertyName: "singleRef", additional: "other" },
+    ]);
+
+    expect(result?.singleRef).toEqual(john.getId());
+  });
+
+  // Case target field isArray===false, complex multi-value:
+  //  { name: "John,Jane", other: "x,y" } --> the single combination that matches
+  // RED / not implemented: a non-array cell is never split, so "John,Jane" is
+  // compared whole and matches nothing. Needs cell-splitting + combination search
+  // that resolves to a single unique match for non-array targets.
+  it("links the single matching combination of multi-value cells (isArray=false)", async () => {
+    const john = TestEntity.create({ name: "John", other: "x" });
+    await entityMapper.saveAll([john]);
+
+    const result = await runImport({ name: "John,Jane", other: "x,y" }, [
+      { column: "name", propertyName: "singleRef", additional: "name" },
+      { column: "other", propertyName: "singleRef", additional: "other" },
+    ]);
+
+    // only (John,x) matches an existing entity
+    expect(result?.singleRef).toEqual(john.getId());
+  });
+
+  // Case target field isArray===true, simple:
+  //  { name: "John", other: "m" } --> ALL records that match
+  // RED / not implemented: `pickSingleMatch` returns undefined for >1 candidate,
+  // so two equally-matching records currently link nothing. An array target should
+  // instead collect every match.
+  it("links all matching records for an array field (isArray=true, simple)", async () => {
+    const john1 = TestEntity.create({ name: "John", other: "m" });
+    const john2 = TestEntity.create({ name: "John", other: "m" });
+    await entityMapper.saveAll([john1, john2]);
+
+    const result = await runImport({ name: "John", other: "m" }, [
+      { column: "name", propertyName: "arrayRef", additional: "name" },
+      { column: "other", propertyName: "arrayRef", additional: "other" },
+    ]);
+
+    expect(result?.arrayRef).toEqual(
+      expect.arrayContaining([john1.getId(), john2.getId()]),
+    );
+    expect(result?.arrayRef).toHaveLength(2);
+  });
+
+  // Case target field isArray===true, complex multi-value:
+  //  { name: "John,Jane", other: "1,2" } --> every combination that matches
+  // RED / not implemented: only the current column is split; the other column is
+  // read whole from the row, so no cross-column combination is formed.
+  // NOTE: this data (John/1, Jane/2) does not yet distinguish a true cross-product
+  // from a positional zip of the two columns — both yield {John, Jane}. Pinning the
+  // cross-product semantics precisely needs an extra record (e.g. John/2) that only
+  // the cross-product would touch. Whether unrelated cross-pairs *should* be linked
+  // is an open design question for the import UX, so it is deliberately left loose.
+  it("links all matching combinations of multi-value cells (isArray=true)", async () => {
+    const john = TestEntity.create({ name: "John", other: "1" });
+    const jane = TestEntity.create({ name: "Jane", other: "2" });
+    await entityMapper.saveAll([john, jane]);
+
+    const result = await runImport({ name: "John,Jane", other: "1,2" }, [
+      { column: "name", propertyName: "arrayRef", additional: "name" },
+      { column: "other", propertyName: "arrayRef", additional: "other" },
+    ]);
+
+    // (John,1) and (Jane,2) match; (John,2) and (Jane,1) do not
+    expect(result?.arrayRef).toEqual(
+      expect.arrayContaining([john.getId(), jane.getId()]),
+    );
+    expect(result?.arrayRef).toHaveLength(2);
+  });
 });

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -49,23 +49,20 @@ describe("Schema data type: entity (advanced functionality)", () => {
   // NOTE ON SCOPE: the happy-path matching cases (basic string match, multi-column
   // narrowing, isArray/multi-value behavior) are covered end-to-end through
   // ImportService in the separate describe block at the bottom of this file. The
-  // direct-call tests kept here cover orthogonal dimensions of importMapFunction
+  // direct-call tests kept here cover orthogonal dimensions of importMatchField
   // that the end-to-end suite does not exercise: value-type coercion, the object
-  // `additional` format, valueMapping, per-value array splitting, and the
-  // "no unique match -> undefined" contract.
+  // `additional` format, valueMapping, and the "no unique match -> undefined"
+  // contract for a single-value target field.
 
   // Orthogonal: value-type coercion — a numeric import value must still match a
   // string-stored field (normalizeValue coerces both sides to string).
-  it("should importMap by matching numeric value correctly", async () => {
+  it("should match a numeric import value against a string field", async () => {
     const c2 = new TestEntity();
     c2.other = "456"; // Ensure "other" is a string
     await entityMapper.saveAll([c2]);
 
-    const importContext = createImportContext(456, schema.id, "other");
-
-    // "advanced" case: imported value is number but should match also
     await expect(
-      dataType.importMapFunction(456, schema, "other", importContext),
+      matchField([{ additional: "other", rawCell: 456 }]),
     ).resolves.toEqual(c2.getId());
   });
 
@@ -73,7 +70,7 @@ describe("Schema data type: entity (advanced functionality)", () => {
   // columns impose criteria that no single entity satisfies together, the result
   // must be undefined (the positive multi-column narrowing path is covered by the
   // end-to-end "single unique match" case).
-  it("should importMap to undefined when mapped columns have no common match", async () => {
+  it("should match to undefined when mapped columns have no common match", async () => {
     const joe = new TestEntity();
     joe.name = "Joe";
     joe.other = "1";
@@ -82,48 +79,13 @@ describe("Schema data type: entity (advanced functionality)", () => {
     max.other = "2";
     await entityMapper.saveAll([joe, max]);
 
-    const importContext = new ImportProcessingContext({
-      entityType: TestEntity.ENTITY_TYPE,
-      columnMapping: [
-        { column: "iName", propertyName: schema.id, additional: "name" },
-        { column: "iOther", propertyName: schema.id, additional: "other" },
-      ],
-    });
     // "Joe" exists and "2" exists, but no single entity has both -> no match
-    importContext.row = { iName: "Joe", iOther: "2" };
-
     await expect(
-      dataType.importMapFunction("Joe", schema, "name", importContext),
+      matchField([
+        { additional: "name", rawCell: "Joe" },
+        { additional: "other", rawCell: "2" },
+      ]),
     ).resolves.toBe(undefined);
-  });
-
-  // Orthogonal: per-value splitting of a single-column multi-value cell. Distinct
-  // from the (still-red) multi-column array cases in the end-to-end block below —
-  // this single-column path already works: ImportService splits the cell and calls
-  // importMapFunction once per value.
-  it("should importMap each split value of a multi-value cell", async () => {
-    const joe = new TestEntity();
-    joe.name = "Joe";
-    const max = new TestEntity();
-    max.name = "Max";
-    await entityMapper.saveAll([joe, max]);
-
-    // single column mapping into an array field: the cell holds comma-separated
-    // names, so import.service splits it and calls importMapFunction per value
-    const importContext = new ImportProcessingContext({
-      entityType: TestEntity.ENTITY_TYPE,
-      columnMapping: [
-        { column: "iRef", propertyName: schema.id, additional: "name" },
-      ],
-    });
-    importContext.row = { iRef: "Joe, Max" };
-
-    await expect(
-      dataType.importMapFunction("Joe", schema, "name", importContext),
-    ).resolves.toEqual(joe.getId());
-    await expect(
-      dataType.importMapFunction("Max", schema, "name", importContext),
-    ).resolves.toEqual(max.getId());
   });
 
   it("should anonymize entity recursively", async () => {
@@ -153,101 +115,78 @@ describe("Schema data type: entity (advanced functionality)", () => {
   // Orthogonal: the `additional` config accepts both the legacy plain-string form
   // and the object `{ refField }` form. (Legacy string is also implicitly exercised
   // by the end-to-end suite; kept here as an explicit guard for both forms.)
-  it("should importMap with both legacy-string and object { refField } additional", async () => {
+  it("should match with both legacy-string and object { refField } additional", async () => {
     const legacy = TestEntity.create({ other: "legacyValue" });
     const object = TestEntity.create({ other: "objectValue" });
     await entityMapper.saveAll([legacy, object]);
 
     await expect(
-      dataType.importMapFunction(
-        "legacyValue",
-        schema,
-        "other",
-        createImportContext("legacyValue", schema.id, "other"),
-      ),
+      matchField([{ additional: "other", rawCell: "legacyValue" }]),
     ).resolves.toEqual(legacy.getId());
 
     await expect(
-      dataType.importMapFunction(
-        "objectValue",
-        schema,
-        { refField: "other" },
-        createImportContext("objectValue", schema.id, { refField: "other" }),
-      ),
+      matchField([
+        { additional: { refField: "other" }, rawCell: "objectValue" },
+      ]),
     ).resolves.toEqual(object.getId());
   });
 
   // Orthogonal: valueMapping runs the raw import value through the referenced
   // field's own datatype (here a date) before comparing.
-  it("should importMap entity ref with date valueMapping", async () => {
+  it("should match an entity ref with a date valueMapping", async () => {
     const entity = new TestEntity();
     // Store the date as it would be in DB format (YYYY-MM-DD)
     entity.dateOfBirth = new Date(1990, 4, 1) as any; // May 1, 1990
     await entityMapper.saveAll([entity]);
 
-    const additional = { refField: "dateOfBirth", valueMapping: "DD.MM.YYYY" };
-    const importContext = createImportContext(
-      "01.05.1990",
-      schema.id,
-      additional,
-    );
-
     await expect(
-      dataType.importMapFunction(
-        "01.05.1990",
-        schema,
-        additional,
-        importContext,
-      ),
+      matchField([
+        {
+          additional: { refField: "dateOfBirth", valueMapping: "DD.MM.YYYY" },
+          rawCell: "01.05.1990",
+        },
+      ]),
     ).resolves.toEqual(entity.getId());
   });
 
-  function createImportContext(
-    value: any,
-    fieldId: string,
-    additional: any,
-  ): ImportProcessingContext {
+  /**
+   * Call importMatchField directly with the given columns mapped to `schema`
+   * (a single-value entity-reference field on TestEntity).
+   */
+  function matchField(
+    columns: { additional: any; rawCell: any }[],
+  ): Promise<string | string[] | undefined> {
     const importContext = new ImportProcessingContext({
       entityType: TestEntity.ENTITY_TYPE,
-      columnMapping: [
-        {
-          column: "x",
-          propertyName: fieldId,
-          additional: additional,
-        },
-      ],
+      columnMapping: columns.map((c, i) => ({
+        column: `col${i}`,
+        propertyName: schema.id,
+        additional: c.additional,
+      })),
     });
-    importContext.row = { x: value };
-
-    return importContext;
+    return dataType.importMatchField(
+      schema,
+      columns.map((c, i) => ({
+        mapping: {
+          column: `col${i}`,
+          propertyName: schema.id,
+          additional: c.additional,
+        },
+        rawCell: c.rawCell,
+      })),
+      importContext,
+    );
   }
 });
 
 /**
  * End-to-end coverage of the entity-reference matching cases documented on
- * EntityDatatype.importMapFunction, exercised through the real ImportService so
- * that column splitting and multi-value aggregation (which live in ImportService,
- * not the datatype) are part of the assertion.
+ * EntityDatatype.importMatchField, exercised through the real ImportService so
+ * that column grouping per field is part of the assertion.
  *
  * Target entity has both a single-value (`singleRef`) and an array (`arrayRef`)
  * entity-reference field pointing at TestEntity, so each documented isArray case
  * can be triggered by mapping columns onto the matching field.
- *
- * CURRENT STATUS (TDD) — only the isArray===false / simple case passes today.
- * The other three tests are intentionally RED: they pin the intended behavior
- * documented on importMapFunction that is NOT yet implemented. Root causes:
- *  - Multiple matches for an array field: `pickSingleMatch` returns `undefined`
- *    whenever >1 candidate remains, so a value that matches several records links
- *    none instead of all of them.
- *  - Cross-column value combinations: array cells are split, but only for the
- *    *current* mapped column — every other mapped column is read whole from the
- *    row (importMapFunction, `row[mapping.column]`) and compared by equality, so
- *    combinations across columns never form.
- *  - Non-array multi-value cells are never split at all (ImportService only splits
- *    when `schema.isArray`), so a "x1,x2" cell can't resolve to a single combo.
- * Implementing these requires changing importMapFunction's single-id return
- * contract (to yield multiple ids for array targets) and the split/aggregate
- * logic in ImportService.
  */
 describe("Schema data type: entity (import matching, end-to-end via ImportService)", () => {
   class ImportTarget extends Entity {
@@ -278,13 +217,12 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
       EntityMapperService,
     ) as MockEntityMapperService;
 
-    // resolve the "ImportTarget" type used only in this spec, while keeping the
-    // real registry for the referenced TestEntity type
+    // register the "ImportTarget" type used only in this spec, alongside the
+    // real registry entries (e.g. the referenced TestEntity type)
     const registry = TestBed.inject(EntityRegistry);
-    const realGet = registry.get.bind(registry);
-    vi.spyOn(registry, "get").mockImplementation((type: string) =>
-      type === "ImportTarget" ? (ImportTarget as any) : realGet(type),
-    );
+    if (!registry.has("ImportTarget")) {
+      registry.add("ImportTarget", ImportTarget as any);
+    }
   });
 
   async function runImport(row: any, columnMapping: ColumnMapping[]) {
@@ -297,9 +235,8 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
 
   // Case target field isArray===false, simple:
   //  { name: "John", other: "m" } --> the single unique match
-  // GREEN. Also the canonical happy-path: subsumes the former direct-call tests
-  // for basic string matching, multi-column narrowing, and legacy-string
-  // `additional` format (`additional: "name"` is the legacy string form).
+  // Canonical happy-path: also covers basic string matching, multi-column
+  // narrowing, and the legacy-string `additional` format ("name").
   it("links the single unique match (isArray=false, simple)", async () => {
     const john = TestEntity.create({ name: "John", other: "m" });
     const jane = TestEntity.create({ name: "Jane", other: "m" });
@@ -315,9 +252,8 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
 
   // Case target field isArray===false, complex multi-value:
   //  { name: "John,Jane", other: "x,y" } --> the single combination that matches
-  // RED / not implemented: a non-array cell is never split, so "John,Jane" is
-  // compared whole and matches nothing. Needs cell-splitting + combination search
-  // that resolves to a single unique match for non-array targets.
+  // The cells are split and searched for every combination; exactly one
+  // combination (John,x) matches an existing entity, so it resolves uniquely.
   it("links the single matching combination of multi-value cells (isArray=false)", async () => {
     const john = TestEntity.create({ name: "John", other: "x" });
     await entityMapper.saveAll([john]);
@@ -333,9 +269,7 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
 
   // Case target field isArray===true, simple:
   //  { name: "John", other: "m" } --> ALL records that match
-  // RED / not implemented: `pickSingleMatch` returns undefined for >1 candidate,
-  // so two equally-matching records currently link nothing. An array target should
-  // instead collect every match.
+  // An array target collects every matching record (not just a unique one).
   it("links all matching records for an array field (isArray=true, simple)", async () => {
     const john1 = TestEntity.create({ name: "John", other: "m" });
     const john2 = TestEntity.create({ name: "John", other: "m" });
@@ -354,8 +288,6 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
 
   // Case target field isArray===true, complex multi-value:
   //  { name: "John,Jane", other: "1,2" } --> every combination that matches
-  // RED / not implemented: only the current column is split; the other column is
-  // read whole from the row, so no cross-column combination is formed.
   // NOTE: this data (John/1, Jane/2) does not yet distinguish a true cross-product
   // from a positional zip of the two columns — both yield {John, Jane}. Pinning the
   // cross-product semantics precisely needs an extra record (e.g. John/2) that only

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -20,6 +20,17 @@ import { EntitySchemaField } from "../schema/entity-schema-field";
 import { Entity, EntityConstructor } from "../model/entity";
 import { asArray } from "../../../utils/asArray";
 import { splitArrayValue } from "../../import/split-array-value";
+import type { ColumnMapping } from "../../import/column-mapping";
+import type { ImportProcessingContext } from "../../import/import-processing-context";
+
+/**
+ * A single column mapped to a target field during import, with the raw cell
+ * value from the current row.
+ */
+export interface ColumnImportInput {
+  mapping: ColumnMapping;
+  rawCell: unknown;
+}
 
 /**
  * Definition of an export column contributed by a datatype.
@@ -211,57 +222,74 @@ export class DefaultDatatype<EntityType = any, DBType = any> {
    */
   async importMatchField(
     schemaField: EntitySchemaField,
-    columns: { mapping: any; rawCell: any }[],
-    importProcessingContext?: any,
-  ): Promise<any> {
-    const additionalSettings =
-      importProcessingContext?.importSettings?.additionalSettings;
-    const separator = additionalSettings?.multiValueSeparator ?? ",";
-
-    let value;
+    columns: ColumnImportInput[],
+    importProcessingContext?: ImportProcessingContext,
+  ): Promise<unknown> {
+    let value: unknown;
     // if several columns map to the same field, the last one with a value wins
-    for (const { mapping, rawCell } of columns) {
-      if (rawCell === undefined || rawCell === null) {
-        continue;
-      }
-
-      let val = rawCell;
-      const shouldTrim =
-        typeof val === "string" &&
-        schemaField.trim !== false &&
-        additionalSettings?.trimValues !== false;
-      if (shouldTrim) {
-        val = val.trim();
-      }
-
-      const shouldSplit =
-        schemaField.isArray && (mapping.additional?.enableSplitting ?? true);
-
-      if (!shouldSplit) {
-        value = await this.importMapFunction(
-          val,
-          schemaField,
-          mapping.additional,
-          importProcessingContext,
-        );
-      } else {
-        // split the cell and map each item individually
-        const mapped = [];
-        for (const rawValue of splitArrayValue(val, separator)) {
-          const item = await this.importMapFunction(
-            rawValue,
-            { ...schemaField, isArray: false },
-            mapping.additional,
-            importProcessingContext,
-          );
-          if (item !== undefined && item !== null && item !== "") {
-            mapped.push(item);
-          }
-        }
-        value = [...new Set(mapped)];
+    for (const column of columns) {
+      const mapped = await this.mapColumnValue(
+        schemaField,
+        column,
+        importProcessingContext,
+      );
+      if (mapped !== undefined) {
+        value = mapped;
       }
     }
     return value;
+  }
+
+  /**
+   * Map a single column's raw cell to this field's value: trim and (for array
+   * fields) split the cell, then delegate each value to {@link importMapFunction}.
+   */
+  private async mapColumnValue(
+    schemaField: EntitySchemaField,
+    { mapping, rawCell }: ColumnImportInput,
+    importProcessingContext?: ImportProcessingContext,
+  ): Promise<unknown> {
+    if (rawCell === undefined || rawCell === null) {
+      return undefined;
+    }
+    const additionalSettings =
+      importProcessingContext?.importSettings?.additionalSettings;
+
+    let val: unknown = rawCell;
+    const shouldTrim =
+      typeof val === "string" &&
+      schemaField.trim !== false &&
+      additionalSettings?.trimValues !== false;
+    if (shouldTrim) {
+      val = (val as string).trim();
+    }
+
+    const shouldSplit =
+      schemaField.isArray && (mapping.additional?.enableSplitting ?? true);
+    if (!shouldSplit) {
+      return this.importMapFunction(
+        val,
+        schemaField,
+        mapping.additional,
+        importProcessingContext,
+      );
+    }
+
+    // split the cell and map each item individually
+    const separator = additionalSettings?.multiValueSeparator ?? ",";
+    const mapped: unknown[] = [];
+    for (const rawValue of splitArrayValue(val, separator)) {
+      const item = await this.importMapFunction(
+        rawValue,
+        { ...schemaField, isArray: false },
+        mapping.additional,
+        importProcessingContext,
+      );
+      if (item !== undefined && item !== null && item !== "") {
+        mapped.push(item);
+      }
+    }
+    return [...new Set(mapped)];
   }
 
   /**

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -19,6 +19,7 @@ import { $localize } from "@angular/localize/init"; // import needed to make thi
 import { EntitySchemaField } from "../schema/entity-schema-field";
 import { Entity, EntityConstructor } from "../model/entity";
 import { asArray } from "../../../utils/asArray";
+import { splitArrayValue } from "../../import/split-array-value";
 
 /**
  * Definition of an export column contributed by a datatype.
@@ -194,28 +195,74 @@ export class DefaultDatatype<EntityType = any, DBType = any> {
   }
 
   /**
-   * Optional per-field import matching.
+   * Map all columns mapped to one target field to the value(s) stored there.
    *
-   * When implemented, ImportService calls this once per target field per row,
-   * passing all columns mapped to that field together, and lets the datatype
-   * own value splitting and cross-column combination. This is required for
-   * matches that depend on several columns at once, which the per-value
-   * importMapFunction cannot express.
-   *
-   * Datatypes that leave this undefined keep the default per-column /
-   * per-value importMapFunction path (ImportService handles array splitting).
+   * ImportService calls this once per target field per row with every column
+   * mapped to that field. The default handles trimming and array splitting and
+   * delegates each individual value to {@link importMapFunction}. Datatypes that
+   * need to consider several columns together (e.g. matching an entity by more
+   * than one property) override this.
    *
    * @param schemaField the target property the value(s) are imported into
    * @param columns every column mapped to this field, with its raw cell value
    * @param importProcessingContext shared context across columns and rows
-   * @returns a single value (isArray=false) or array of values (isArray=true),
-   *   or undefined if nothing matched
+   * @returns the value to store: a single value (isArray=false) or array
+   *   (isArray=true), or undefined if nothing was mapped
    */
-  importMatchField?(
+  async importMatchField(
     schemaField: EntitySchemaField,
     columns: { mapping: any; rawCell: any }[],
     importProcessingContext?: any,
-  ): Promise<any>;
+  ): Promise<any> {
+    const additionalSettings =
+      importProcessingContext?.importSettings?.additionalSettings;
+    const separator = additionalSettings?.multiValueSeparator ?? ",";
+
+    let value;
+    // if several columns map to the same field, the last one with a value wins
+    for (const { mapping, rawCell } of columns) {
+      if (rawCell === undefined || rawCell === null) {
+        continue;
+      }
+
+      let val = rawCell;
+      const shouldTrim =
+        typeof val === "string" &&
+        schemaField.trim !== false &&
+        additionalSettings?.trimValues !== false;
+      if (shouldTrim) {
+        val = val.trim();
+      }
+
+      const shouldSplit =
+        schemaField.isArray && (mapping.additional?.enableSplitting ?? true);
+
+      if (!shouldSplit) {
+        value = await this.importMapFunction(
+          val,
+          schemaField,
+          mapping.additional,
+          importProcessingContext,
+        );
+      } else {
+        // split the cell and map each item individually
+        const mapped = [];
+        for (const rawValue of splitArrayValue(val, separator)) {
+          const item = await this.importMapFunction(
+            rawValue,
+            { ...schemaField, isArray: false },
+            mapping.additional,
+            importProcessingContext,
+          );
+          if (item !== undefined && item !== null && item !== "") {
+            mapped.push(item);
+          }
+        }
+        value = [...new Set(mapped)];
+      }
+    }
+    return value;
+  }
 
   /**
    * A component to be rendered inline to configure the import transformation

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -194,6 +194,30 @@ export class DefaultDatatype<EntityType = any, DBType = any> {
   }
 
   /**
+   * Optional per-field import matching.
+   *
+   * When implemented, ImportService calls this once per target field per row,
+   * passing all columns mapped to that field together, and lets the datatype
+   * own value splitting and cross-column combination. This is required for
+   * matches that depend on several columns at once, which the per-value
+   * importMapFunction cannot express.
+   *
+   * Datatypes that leave this undefined keep the default per-column /
+   * per-value importMapFunction path (ImportService handles array splitting).
+   *
+   * @param schemaField the target property the value(s) are imported into
+   * @param columns every column mapped to this field, with its raw cell value
+   * @param importProcessingContext shared context across columns and rows
+   * @returns a single value (isArray=false) or array of values (isArray=true),
+   *   or undefined if nothing matched
+   */
+  importMatchField?(
+    schemaField: EntitySchemaField,
+    columns: { mapping: any; rawCell: any }[],
+    importProcessingContext?: any,
+  ): Promise<any>;
+
+  /**
    * A component to be rendered inline to configure the import transformation
    * (e.g. defining a format or value mapping).
    *

--- a/src/app/core/import/import.service.ts
+++ b/src/app/core/import/import.service.ts
@@ -179,51 +179,42 @@ export class ImportService {
 
     for (const [propertyName, mappings] of mappingsByProperty) {
       const schema = entity.getSchema().get(propertyName);
-      const datatype = schema
-        ? this.schemaService.getDatatypeOrDefault(schema.dataType)
-        : undefined;
-
-      let value;
-      if (schema && datatype?.importMatchField) {
-        // per-field matching: the datatype owns splitting and cross-column combination
-        try {
-          value = await datatype.importMatchField(
-            schema,
-            mappings.map((mapping) => ({
-              mapping,
-              rawCell: row[mapping.column],
-            })),
-            importProcessingContext,
-          );
-        } catch (e) {
-          errors.push({
-            column: mappings[0].column,
-            propertyName,
-            rowIndex: importProcessingContext.rowIndex,
-            error: e,
-          });
-          continue;
-        }
-      } else {
-        // default per-column path (last mapped column present in the row wins)
-        for (const mapping of mappings) {
-          if (!(mapping.column in row)) {
-            continue;
-          }
-          const parsed = await this.parseCell(
-            row[mapping.column],
-            mapping,
-            entity,
-            importProcessingContext,
-            errors,
-          );
-          if (parsed !== undefined) {
-            value = parsed;
-          }
-        }
+      if (!schema) {
+        continue;
       }
 
-      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+      let value;
+      try {
+        // failSilently: false - a broken/unknown dataType should surface as a
+        // clear import error (caught below) rather than silently importing the
+        // raw, untransformed value into a field of an unknown type.
+        const datatype = this.schemaService.getDatatypeOrDefault(
+          schema.dataType,
+          false,
+        );
+        value = await datatype.importMatchField(
+          schema,
+          mappings.map((mapping) => ({
+            mapping,
+            rawCell: row[mapping.column],
+          })),
+          importProcessingContext,
+        );
+      } catch (e) {
+        errors.push({
+          column: mappings[0].column,
+          propertyName,
+          rowIndex: importProcessingContext.rowIndex,
+          error: e,
+        });
+        continue;
+      }
+
+      // ignore empty or invalid values for import (falsy except 0 / false, or empty array)
+      if (
+        (!value && value !== 0 && value !== false) ||
+        (Array.isArray(value) && value.length === 0)
+      ) {
         continue;
       }
       entity[propertyName] = value;
@@ -235,137 +226,4 @@ export class ImportService {
       return entity;
     }
   }
-
-  private async parseCell(
-    val: any,
-    mapping: ColumnMapping,
-    entity: Entity,
-    importProcessingContext: ImportProcessingContext,
-    errors: ImportCellError[],
-  ) {
-    if (val === undefined || val === null) {
-      return undefined;
-    }
-
-    const schema = entity.getSchema().get(mapping.propertyName);
-    if (!schema) {
-      return undefined;
-    }
-
-    const shouldTrim =
-      typeof val === "string" &&
-      schema.trim !== false &&
-      importProcessingContext.importSettings.additionalSettings?.trimValues !==
-        false;
-    if (shouldTrim) {
-      val = val.trim();
-    }
-
-    let value;
-
-    // Determine if we should split array values based on enableSplitting flag
-    const shouldSplit =
-      schema.isArray && (mapping.additional?.enableSplitting ?? true);
-
-    try {
-      // failSilently: false - a broken dataType should surface as a clear per-cell
-      // import error (caught below) rather than silently importing the raw,
-      // untransformed value into a field of an unknown type.
-      const datatype = this.schemaService.getDatatypeOrDefault(
-        schema.dataType,
-        false,
-      );
-      if (!shouldSplit) {
-        // Handle as single value (either non-array field or array field with splitting disabled)
-        value = await datatype.importMapFunction(
-          val,
-          schema,
-          mapping.additional,
-          importProcessingContext,
-        );
-      } else {
-        // For array fields with splitting enabled, split the value and map each item individually
-        const separator =
-          importProcessingContext.importSettings.additionalSettings
-            ?.multiValueSeparator ?? ",";
-        const rawValues = splitArrayValue(val, separator);
-        value = [];
-        for (const rawValue of rawValues) {
-          const mapped = await datatype.importMapFunction(
-            rawValue,
-            {
-              ...schema,
-              isArray: false, // transform here only for single values, array mapping is handled here separately
-            },
-            mapping.additional,
-            importProcessingContext,
-          );
-          if (mapped !== undefined && mapped !== null && mapped !== "") {
-            value.push(mapped);
-          }
-        }
-        // Filter duplicate values
-        value = [...new Set(value)];
-      }
-    } catch (e) {
-      errors.push({
-        column: mapping.column,
-        propertyName: mapping.propertyName,
-        rowIndex: importProcessingContext.rowIndex,
-        error: e,
-      });
-      return undefined;
-    }
-
-    // ignore empty or invalid values for import
-    if (
-      (!value && value !== 0 && value !== false) ||
-      (Array.isArray(value) && value.length === 0)
-    ) {
-      // falsy values except 0 (=> null, undefined, empty string, NaN, ...)
-      return undefined;
-    }
-
-    return value;
-  }
-}
-
-/**
- * Split a raw value into an array of individual values.
- * Supports JSON arrays and separator-delimited strings.
- * @param val The raw value to split
- * @param separator The separator character to use for splitting (default: ",")
- * @returns Array of individual string values
- */
-export function splitArrayValue(val: any, separator: string = ","): string[] {
-  if (val === null || val === undefined) {
-    return [];
-  }
-
-  if (Array.isArray(val)) {
-    return val;
-  }
-
-  if (typeof val !== "string") {
-    return [String(val)];
-  }
-
-  val = val.trim();
-  // Try parsing as JSON array first
-  if (val.startsWith("[")) {
-    try {
-      const parsed = JSON.parse(val);
-      if (Array.isArray(parsed)) {
-        return parsed;
-      }
-    } catch {
-      // Invalid JSON, fall through to separator-based parsing
-    }
-  }
-
-  // Split by separator and trim whitespace
-  return val
-    .split(separator)
-    .map((e) => e.trim())
-    .filter((e) => e?.length > 0);
 }

--- a/src/app/core/import/import.service.ts
+++ b/src/app/core/import/import.service.ts
@@ -163,27 +163,70 @@ export class ImportService {
     let entity = new entityConstructor();
     let hasMappedProperty = false; // to avoid empty records being created
 
-    for (const col in row) {
-      const mapping: ColumnMapping = importSettings.columnMapping.find(
-        (c) => c.column === col,
-      );
-      if (!mapping) {
+    // group mappings by target property so datatypes that match across multiple
+    // columns (see importMatchField) see all their columns at once. All mapped
+    // columns are kept (even ones missing from this row) so a missing identifier
+    // can still block a match.
+    const mappingsByProperty = new Map<string, ColumnMapping[]>();
+    for (const mapping of importSettings.columnMapping) {
+      if (!mapping?.propertyName) {
         continue;
       }
+      const group = mappingsByProperty.get(mapping.propertyName) ?? [];
+      group.push(mapping);
+      mappingsByProperty.set(mapping.propertyName, group);
+    }
 
-      const parsed = await this.parseCell(
-        row[col],
-        mapping,
-        entity,
-        importProcessingContext,
-        errors,
-      );
+    for (const [propertyName, mappings] of mappingsByProperty) {
+      const schema = entity.getSchema().get(propertyName);
+      const datatype = schema
+        ? this.schemaService.getDatatypeOrDefault(schema.dataType)
+        : undefined;
 
-      if (parsed === undefined) {
-        continue;
+      let value;
+      if (schema && datatype?.importMatchField) {
+        // per-field matching: the datatype owns splitting and cross-column combination
+        try {
+          value = await datatype.importMatchField(
+            schema,
+            mappings.map((mapping) => ({
+              mapping,
+              rawCell: row[mapping.column],
+            })),
+            importProcessingContext,
+          );
+        } catch (e) {
+          errors.push({
+            column: mappings[0].column,
+            propertyName,
+            rowIndex: importProcessingContext.rowIndex,
+            error: e,
+          });
+          continue;
+        }
+      } else {
+        // default per-column path (last mapped column present in the row wins)
+        for (const mapping of mappings) {
+          if (!(mapping.column in row)) {
+            continue;
+          }
+          const parsed = await this.parseCell(
+            row[mapping.column],
+            mapping,
+            entity,
+            importProcessingContext,
+            errors,
+          );
+          if (parsed !== undefined) {
+            value = parsed;
+          }
+        }
       }
 
-      entity[mapping.propertyName] = parsed;
+      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+        continue;
+      }
+      entity[propertyName] = value;
       hasMappedProperty = true;
     }
 

--- a/src/app/core/import/split-array-value.ts
+++ b/src/app/core/import/split-array-value.ts
@@ -1,0 +1,56 @@
+/*
+ *     This file is part of ndb-core.
+ *
+ *     ndb-core is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ndb-core is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Split a raw value into an array of individual values.
+ * Supports JSON arrays and separator-delimited strings.
+ * @param val The raw value to split
+ * @param separator The separator character to use for splitting (default: ",")
+ * @returns Array of individual string values
+ */
+export function splitArrayValue(val: any, separator: string = ","): string[] {
+  if (val === null || val === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(val)) {
+    return val;
+  }
+
+  if (typeof val !== "string") {
+    return [String(val)];
+  }
+
+  val = val.trim();
+  // Try parsing as JSON array first
+  if (val.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(val);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Invalid JSON, fall through to separator-based parsing
+    }
+  }
+
+  // Split by separator and trim whitespace
+  return val
+    .split(separator)
+    .map((e) => e.trim())
+    .filter((e) => e?.length > 0);
+}


### PR DESCRIPTION
- closes #4145

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

1. Open the **Import** feature.
2. Upload a file where one column holds multiple comma-separated values that reference existing records (e.g. two student names, or two staff first names, in a single cell).
3. Select an import target type that has a multi-value entity-reference field (e.g. **Note**).
4. Map that column to the entity-reference field and pick a **"Match by ... property"** (e.g. Name / First Name).
5. Open the **preview**: every referenced record should now be listed. Before this fix the field stayed empty.
6. Run the import and open the created record to confirm all references are linked.

---
 **Root cause: An earlier change (multi-column matching https://github.com/Aam-Digital/ndb-core/pull/3082) broke the reference lookup**

- It ignored the individual split value it was given and re-read the whole cell ("Anna, Bob"), then searched for a record named exactly "Anna, Bob".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CSV imports for multi-value fields, including comma-separated and JSON array formats.
  * Added support for matching multiple referenced entities using combinations of mapped columns.
  * Duplicate references are automatically removed during import.

* **Bug Fixes**
  * Improved handling of whitespace, empty values, and numeric-versus-text matching during imports.
  * Enhanced support for importing both single and multiple entity references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->