### PR TITLE
test: fix flaky screenshot comparison from scroll

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -73,12 +73,40 @@ export async function argosScreenshot(
 ): Promise<void> {
   if (process.env.CI || process.env.SCREENSHOT) {
     const { argosCSS, ...restOptions } = options || {};
+    await resetMainContentScroll(page);
     await argosScreenshotBase(page, name, {
       fullPage: true,
       argosCSS: argosCSS ? `${ARGOS_BASE_CSS}\n${argosCSS}` : ARGOS_BASE_CSS,
       ...restOptions,
     });
   }
+}
+
+/**
+ * Pin the main content area to the top before capturing a screenshot.
+ *
+ * The app scrolls inside `mat-sidenav-content` rather than the window, so the
+ * document itself never overflows and a `fullPage` screenshot effectively
+ * captures just the viewport. Neither Playwright's `fullPage` nor Argos reset
+ * the scroll offset of such an inner container. Actions like `fill()` call
+ * `scrollIntoViewIfNeeded()`, which can leave the container scrolled by a few
+ * pixels whenever the content is just slightly taller than the viewport. That
+ * stray, timing-dependent offset shifts the whole content pane and produces
+ * flaky screenshot diffs (notably the `site-settings-edited` screenshot).
+ *
+ * Skip resetting while an interactive overlay is open: dialogs, selects and
+ * menus create a `.cdk-overlay-backdrop`, and some screenshots intentionally
+ * scroll within a dialog (e.g. `i18n-de_init`) or show an open panel. Tooltips
+ * do not create a backdrop, so lingering tooltips don't block the reset.
+ */
+async function resetMainContentScroll(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (document.querySelector(".cdk-overlay-backdrop")) return;
+    document
+      .querySelectorAll(".mat-drawer-content")
+      .forEach((el) => ((el as HTMLElement).scrollTop = 0));
+    window.scrollTo(0, 0);
+  });
 }
 
 /**


### PR DESCRIPTION
closes #4149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot captures now consistently start at the top of the main content.
  * Active dialogs, menus, and select overlays are preserved without unexpected scroll changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->