### PR TITLE
docs(reporting): document built-in SQL columns and enum label view

### DIFF
--- a/doc/compodoc_sources/summary.json
+++ b/doc/compodoc_sources/summary.json
@@ -74,6 +74,10 @@
       {
         "title": "Documentation Structure",
         "file": "concepts/documentation-structure.md"
+      },
+      {
+        "title": "Reports",
+        "file": "../../src/app/features/reporting/README.md"
       }
     ]
   },
@@ -110,10 +114,6 @@
       {
         "title": "Create a New Datatype",
         "file": "../../src/app/core/basic-datatypes/README.md"
-      },
-      {
-        "title": "Create a Report",
-        "file": "../../src/app/features/reporting/README.md"
       },
       {
         "title": "End-to-end tests",

--- a/src/app/features/reporting/README.md
+++ b/src/app/features/reporting/README.md
@@ -21,7 +21,6 @@ Follow the instructions on the _aam-services_ repository to set up and enable th
 ### Using AI agents to generate SQL Queries
 
 LLMs like ChatGPT or Claude can generate report queries for you.
-We have a [guide / context document for this](https://docs.google.com/document/d/13yxJkqqoA9tBTbld65Y1FYA51l0W057m4D1wvoCILeQ/edit?usp=sharing).
 
 ## Configuration
 
@@ -32,6 +31,10 @@ There are different modes for `ReportConfig`:
 ### sql
 
 Requirements: SQS
+
+Queries are based on SQLite and do not support multiple queries in one string
+or some SQL commands.
+Do _not_ use special characters, like accents, in IDs or report column names as they cause unstable outputs.
 
 #### Available tables and columns
 
@@ -46,7 +49,6 @@ without being listed in the config document:
 | -------------- | -------------- | -------------------------------------------------- |
 | `_id`          | `_id`          | full document id, e.g. `Child:123`                 |
 | `_rev`         | `_rev`         | CouchDB revision                                   |
-| `_attachments` | `_attachments` | attachment metadata of the document                |
 | `_created_at`  | `created.at`   | timestamp when the record was created (ISO format) |
 | `_created_by`  | `created.by`   | user who created the record                        |
 | `_updated_at`  | `updated.at`   | timestamp of the last edit (ISO format)            |

--- a/src/app/features/reporting/README.md
+++ b/src/app/features/reporting/README.md
@@ -33,7 +33,54 @@ There are different modes for `ReportConfig`:
 
 Requirements: SQS
 
-Some useful SQL query snippets for Aam Digital contexts are collected here: [Aam Digital SQL Snippets](https://docs.google.com/document/d/14JqS6xgZzC1xHUogDho5n1kyNLzX1Eoyv6MeZtRejuM/edit?usp=sharing)
+#### Available tables and columns
+
+Every entity type defined in the `Config:CONFIG_ENTITY` document becomes a SQL table (e.g. `Child`, `School`),
+with one column per configured field. Fields of dataType `file` are skipped and have no column.
+
+In addition, the backend hard-wires some columns into every such entity table.
+These are derived from internal metadata that every entity has, so they are available
+without being listed in the config document:
+
+| Column         | Source field   | Description                                        |
+| -------------- | -------------- | -------------------------------------------------- |
+| `_id`          | `_id`          | full document id, e.g. `Child:123`                 |
+| `_rev`         | `_rev`         | CouchDB revision                                   |
+| `_attachments` | `_attachments` | attachment metadata of the document                |
+| `_created_at`  | `created.at`   | timestamp when the record was created (ISO format) |
+| `_created_by`  | `created.by`   | user who created the record                        |
+| `_updated_at`  | `updated.at`   | timestamp of the last edit (ISO format)            |
+| `_updated_by`  | `updated.by`   | user who made the last edit                        |
+| `inactive`     | `inactive`     | 1 if the record is archived                        |
+| `anonymized`   | `anonymized`   | 1 if the record is anonymized                      |
+
+The `_` prefix marks columns that are generated from internal metadata rather than configured entity fields
+and avoids clashes with custom fields of the same name.
+For example, to count records created within the reporting period:
+
+```sql
+SELECT count(*) AS "newly registered"
+FROM Child
+WHERE _created_at BETWEEN $startDate AND $endDate
+```
+
+#### Human-readable labels for dropdown (configurable-enum) fields
+
+Dropdown fields store the option id (e.g. `gender = "M"`), not its label.
+The hard-wired `ConfigurableEnumOption` view provides one row per dropdown option
+(`enum_id`, `option_id`, `label`), so labels can be joined in directly:
+
+```sql
+SELECT c.name, COALESCE(g.label, c.gender) AS gender
+FROM Child c
+LEFT JOIN ConfigurableEnumOption g
+  ON g.enum_id = 'genders' AND g.option_id = c.gender
+```
+
+`enum_id` is the id of the enum definition without its `ConfigurableEnum:` prefix.
+The `COALESCE` keeps the raw id visible for values that have no matching option.
+The underlying raw `ConfigurableEnum` table (one row per enum, options as JSON array in `values`)
+is also available for special cases. It only has these two columns, none of the default columns listed above.
 
 #### Simple SQL Report
 
@@ -67,7 +114,7 @@ Use named placeholders in the SQL query (for example `$startDate` and `$endDate`
   },
   "reportDefinition": [
     {
-      "query": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c WHERE created_at BETWEEN $startDate AND $endDate"
+      "query": "SELECT c.name as name, c.dateOfBirth as dateOfBirth FROM Child c WHERE _created_at BETWEEN $startDate AND $endDate"
     }
   ]
 }
@@ -112,6 +159,94 @@ If a query returns multiple columns, only one value is shown as the row value an
 ```
 
 In the UI, grouped SQL reports are rendered as a hierarchical report view, while single-query SQL reports are shown as a flat table.
+
+#### SQL recipes
+
+Useful patterns for common Aam Digital reporting questions.
+
+##### Calculate age from date of birth
+
+```sql
+SELECT name,
+  (strftime('%Y', 'now') - strftime('%Y', dateOfBirth))
+    - (strftime('%m-%d', 'now') < strftime('%m-%d', dateOfBirth)) AS age
+FROM Child
+```
+
+##### Conditional counting ("COUNT IF")
+
+```sql
+SELECT COUNT(CASE WHEN c.gender = 'F' THEN c._id END) AS total_female FROM Child c
+```
+
+##### Attendance status of individual participants from EventNote
+
+`childrenAttendance` stores one `[childId, {status, remarks}]` pair per participant as a JSON array,
+which can be unpacked with [SQLite's `json_each()`](https://www.sqlite.org/json1.html#jeach):
+
+```sql
+SELECT json_extract(value, '$[0]') AS participant_id,
+  json_extract(value, '$[1].status') AS status,
+  json_extract(e.schools, '$[0]') AS team_id
+FROM EventNote e, json_each(e.childrenAttendance)
+JOIN Child AS c ON c._id = participant_id
+JOIN School AS s ON s._id = team_id
+```
+
+The same pattern calculates an attendance percentage per participant, filtered by event category:
+
+```sql
+SELECT json_extract(value, '$[0]') AS participant_id, e.category,
+  ROUND((SUM(CASE WHEN json_extract(value, '$[1].status') = 'PRESENT' THEN 1 ELSE 0 END) * 100.0
+    / COUNT(e._id)), 2) AS attendance_percentage
+FROM EventNote e, json_each(e.childrenAttendance)
+JOIN Child c ON c._id = json_extract(value, '$[0]')
+WHERE e.category IN ('LEARNING_GROUP', 'PIC') AND e.date BETWEEN $startDate AND $endDate
+GROUP BY c._id, e.category
+```
+
+##### Group by each option of a multi-select dropdown
+
+A multi-select (`isArray`) field is stored as a JSON array of option ids (e.g. `["pizza", "burger"]`).
+To count each selected option individually (a row counts towards every option it includes):
+
+```sql
+SELECT COALESCE(opt.label, sel.value) AS option, COUNT(*) AS count
+FROM Child c, json_each(c.favoriteFoods) sel
+LEFT JOIN ConfigurableEnumOption opt
+  ON opt.enum_id = 'favoriteFoods' AND opt.option_id = sel.value
+WHERE json_valid(c.favoriteFoods)
+GROUP BY option
+ORDER BY count DESC, option
+```
+
+##### Combine EventNote and Note rows for a joint query
+
+```sql
+SELECT n.subject, n.date FROM (SELECT * FROM EventNote UNION SELECT * FROM Note) n
+```
+
+WARNING: double-check that `Config:CONFIG_ENTITY` lists the same attributes in the exact same order
+for `entity:Note` and `entity:EventNote`.
+Otherwise the two queries will not be merged correctly and some columns may be missing data!
+
+##### Compare multiple records linked to one person (e.g. pre vs. post test results)
+
+Count children who have two linked observation records where the "post" value is higher than the "pre" value:
+
+```sql
+SELECT COUNT(DISTINCT c._id) AS "children who improved"
+FROM Child c
+INNER JOIN HistoricalEntityData hd_pre
+  ON c._id = hd_pre.relatedEntity AND hd_pre.type = 'PRE'
+INNER JOIN HistoricalEntityData hd_post
+  ON c._id = hd_post.relatedEntity AND hd_post.type = 'POST'
+WHERE hd_post.value > hd_pre.value
+```
+
+##### Known limitations
+
+- `CONCAT` is not supported; use the SQLite `||` operator instead (e.g. `firstname || ' ' || lastname`).
 
 ### JSON-Query Reports (legacy)
 


### PR DESCRIPTION
- closes Aam-Digital/aam-services#161
- part of Aam-Digital/aam-services#156

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

Documentation companion to Aam-Digital/aam-services#160 (documentation only, no code changes):

- Document the built-in SQL columns that the backend hard-wires into every table (`_created_at`, `_created_by`, `_updated_at`, `_updated_by`, `inactive`, `anonymized`, ...) with a date-range filter example.
- Document the `ConfigurableEnumOption` view for translating dropdown option ids into human-readable labels with a plain JOIN.
- Migrate the SQL recipes from the shared "SQL Snippets" GoogleDoc into the guide (age calculation, conditional counting, attendance unpacking via json_each, multi-select disaggregation, EventNote+Note UNION caveat, pre/post comparison, CONCAT limitation), so the GoogleDoc can be deleted afterwards.
- Move the "Reports" page from How-To Guides to Concepts in the docs navigation.

Because that move renames the page URL (`how-to-guides/create-a-report.html` -> `concepts/reports.html`), two companion PRs update the links that point here from other repositories, and add the backend-side schema documentation:

- Aam-Digital/aam-services (docs/modules/reporting.md)
- Aam-Digital/ndb-setup (README.md)

## Manual Testing Steps

1. Documentation-only change: review the rendered `src/app/features/reporting/README.md` in the "Files changed" tab.
2. Verify the docs navigation change in `doc/compodoc_sources/summary.json`: "Reports" is now listed under Concepts instead of How-To Guides.
3. The SQL examples were verified against a backend running the companion PR (Aam-Digital/aam-services#160).
