### PR TITLE
fix(sync): recover from a stalled sync instead of freezing liveSync

### DIFF
--- a/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
@@ -336,32 +336,36 @@ describe("SyncedPouchDatabase", () => {
     }
   });
 
-  it("should recover and keep syncing after a sync stalls with no progress", async () => {
+  it("should fail a stalled sync (not complete it) and keep retrying", async () => {
     vi.useFakeTimers();
     try {
       const { mockLocalDb } = mockPouchDatabaseService();
-      // a push that stalls forever: the sync promise never settles and emits no
-      // progress events (a stale/half-open connection; writes have no timeout).
+      // a push that stalls: the thenable never settles on its own and only
+      // resolves when cancel() is called - as PouchDB's replication does.
       mockLocalDb.sync.mockImplementation(() => {
-        const handler = mockSyncHandler();
-        handler.then = () => new Promise(() => {});
-        return handler;
+        let resolve: (v: any) => void;
+        return {
+          on: vi.fn().mockReturnThis(),
+          cancel: vi.fn(() => resolve?.({})),
+          then: (onFulfilled: any, onRejected: any) =>
+            new Promise((r) => (resolve = r)).then(onFulfilled, onRejected),
+        };
       });
-      const mockChanges = new Subject();
-      vi.spyOn(service, "changes").mockReturnValue(mockChanges);
+      const states: SyncState[] = [];
+      service.localSyncState.subscribe((s) => states.push(s));
 
       loginState.next(LoginState.LOGGED_IN);
       await vi.advanceTimersByTimeAsync(1000);
       expect(mockLocalDb.sync).toHaveBeenCalledTimes(1); // first sync starts, then stalls
 
-      // user keeps saving edits locally while many sync intervals pass
-      for (let i = 0; i < 10; i++) {
-        mockChanges.next({});
-        await vi.advanceTimersByTimeAsync(service.SYNC_INTERVAL);
-      }
+      await vi.advanceTimersByTimeAsync(
+        service.SYNC_STALL_TIMEOUT + service.SYNC_INTERVAL,
+      );
 
-      // the stalled sync must not block liveSync forever: sync is retried so the
-      // locally-saved edits can still upload
+      // the stalled sync is reported FAILED (not COMPLETED, which would falsely
+      // record a successful sync) and liveSync retries so offline edits still upload
+      expect(states).toContain(SyncState.FAILED);
+      expect(states).not.toContain(SyncState.COMPLETED);
       expect(mockLocalDb.sync.mock.calls.length).toBeGreaterThan(1);
 
       await stopPeriodicTimer();

--- a/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
@@ -67,6 +67,7 @@ describe("SyncedPouchDatabase", () => {
   function mockSyncHandler(result: any = {}, shouldReject = false): any {
     const handler = {
       on: vi.fn().mockReturnThis(),
+      cancel: vi.fn(),
       then(onFulfilled, onRejected) {
         const promise = shouldReject
           ? Promise.reject(result)
@@ -330,6 +331,40 @@ describe("SyncedPouchDatabase", () => {
       // stop periodic timer:
       service.liveSyncEnabled = false;
       await vi.advanceTimersByTimeAsync(LONG_SYNC_TIME);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should recover and keep syncing after a sync stalls with no progress", async () => {
+    vi.useFakeTimers();
+    try {
+      const { mockLocalDb } = mockPouchDatabaseService();
+      // a push that stalls forever: the sync promise never settles and emits no
+      // progress events (a stale/half-open connection; writes have no timeout).
+      mockLocalDb.sync.mockImplementation(() => {
+        const handler = mockSyncHandler();
+        handler.then = () => new Promise(() => {});
+        return handler;
+      });
+      const mockChanges = new Subject();
+      vi.spyOn(service, "changes").mockReturnValue(mockChanges);
+
+      loginState.next(LoginState.LOGGED_IN);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mockLocalDb.sync).toHaveBeenCalledTimes(1); // first sync starts, then stalls
+
+      // user keeps saving edits locally while many sync intervals pass
+      for (let i = 0; i < 10; i++) {
+        mockChanges.next({});
+        await vi.advanceTimersByTimeAsync(service.SYNC_INTERVAL);
+      }
+
+      // the stalled sync must not block liveSync forever: sync is retried so the
+      // locally-saved edits can still upload
+      expect(mockLocalDb.sync.mock.calls.length).toBeGreaterThan(1);
+
+      await stopPeriodicTimer();
     } finally {
       vi.useRealTimers();
     }

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -43,6 +43,16 @@ export class SyncedPouchDatabase extends PouchDatabase {
   POUCHDB_SYNC_BATCH_SIZE = 100;
   SYNC_INTERVAL = 30000;
 
+  /**
+   * Abort a sync that makes no progress within this window (ms).
+   * Push writes have no per-request abort timeout, so a stale/half-open
+   * connection can leave the replication promise unsettled forever - which would
+   * keep syncState at STARTED and block liveSync from starting any further sync.
+   * Chosen well above a normal sync's duration so only a genuinely stalled sync
+   * is cancelled; the timer resets on every replication progress event.
+   */
+  SYNC_STALL_TIMEOUT = 120000;
+
   private readonly navigator: Navigator;
   private readonly loginStateSubject: LoginStateSubject;
   private readonly alertService?: AlertService;
@@ -180,12 +190,35 @@ export class SyncedPouchDatabase extends PouchDatabase {
       ? this.ngZone.runOutsideAngular(createSyncHandler)
       : createSyncHandler();
 
+    // Guard against a stalled sync (see SYNC_STALL_TIMEOUT): if replication makes
+    // no progress within the timeout, cancel it so the promise settles and
+    // liveSync can retry, instead of staying blocked in STARTED forever.
+    let stallTimer: ReturnType<typeof setTimeout>;
+    let rejectStalled: (err: any) => void;
+    const stallGuard = new Promise<never>((_, reject) => {
+      rejectStalled = reject;
+    });
+    const armStallTimer = () => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => {
+        Logging.debug(`sync stalled, cancelling to allow retry`, {
+          db: this.dbName,
+        });
+        syncHandler.cancel();
+        rejectStalled(new SyncStalledError());
+      }, this.SYNC_STALL_TIMEOUT);
+    };
+
     syncHandler.on("change", (info) => {
+      armStallTimer();
       lastSyncedDocIds =
         info?.change?.docs?.map((d) => d._id).filter(Boolean) ?? [];
     });
+    syncHandler.on("active", () => armStallTimer());
+    syncHandler.on("paused", () => armStallTimer());
+    armStallTimer();
 
-    return syncHandler
+    return Promise.race([syncHandler, stallGuard])
       .then(async (res) => {
         if (res) res["dbName"] = this.dbName; // add for debugging information
         Logging.debug("sync completed", res);
@@ -217,7 +250,10 @@ export class SyncedPouchDatabase extends PouchDatabase {
             err,
             `sync failed [${this.dbName}]: likely multi-tab IndexedDB corruption. Last synced batch: [${lastSyncedDocIds.join(", ")}]`,
           );
-        } else if (this.isSyncConnectivityError(err)) {
+        } else if (
+          this.isSyncConnectivityError(err) ||
+          err instanceof SyncStalledError
+        ) {
           Logging.debug(`sync failed (connectivity)`, { db: this.dbName }, err);
         } else if (err?.status === 401 || err?.statusCode === 401) {
           // expired session; the fetch layer already triggers re-login
@@ -229,6 +265,7 @@ export class SyncedPouchDatabase extends PouchDatabase {
         throw err;
       })
       .finally(() => {
+        clearTimeout(stallTimer);
         if (isFirstSync) {
           this.remoteDatabase.trackLostPermissions = true;
         }
@@ -369,3 +406,6 @@ export class SyncedPouchDatabase extends PouchDatabase {
 }
 
 type SyncResult = PouchDB.Replication.SyncResultComplete<any>;
+
+/** Thrown internally when a sync is cancelled for making no progress. */
+class SyncStalledError extends Error {}

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -204,8 +204,11 @@ export class SyncedPouchDatabase extends PouchDatabase {
         Logging.debug(`sync stalled, cancelling to allow retry`, {
           db: this.dbName,
         });
-        syncHandler.cancel();
+        // Reject BEFORE cancelling: PouchDB's replication thenable resolves
+        // (fires "complete") on cancel(), so cancelling first could let
+        // Promise.race take the success path and mark a stalled sync COMPLETED.
         rejectStalled(new SyncStalledError());
+        syncHandler.cancel();
       }, this.SYNC_STALL_TIMEOUT);
     };
 

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -48,10 +48,19 @@ export class SyncedPouchDatabase extends PouchDatabase {
    * Push writes have no per-request abort timeout, so a stale/half-open
    * connection can leave the replication promise unsettled forever - which would
    * keep syncState at STARTED and block liveSync from starting any further sync.
-   * Chosen well above a normal sync's duration so only a genuinely stalled sync
-   * is cancelled; the timer resets on every replication progress event.
+   *
+   * The timer resets on every replication progress event, so this is an
+   * inactivity window per batch (see POUCHDB_SYNC_BATCH_SIZE) and not a budget
+   * for the total sync duration - a long initial sync of a large database keeps
+   * resetting the timer and is never cancelled while it makes progress.
+   * The window still has to cover the slowest legitimate gap between events:
+   * the checkpoint lookup and first `_changes` response before any batch
+   * arrives, and a single batch of documents with attachments over a poor
+   * connection. If that gap is exceeded no batch completes, so no checkpoint is
+   * written and every retry restarts from the same position - which is why this
+   * is set generously rather than close to a normal sync's duration.
    */
-  SYNC_STALL_TIMEOUT = 120000;
+  SYNC_STALL_TIMEOUT = 300000;
 
   private readonly navigator: Navigator;
   private readonly loginStateSubject: LoginStateSubject;


### PR DESCRIPTION
- closes #4162

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

In synced (offline-first) mode, a push write on a stale/half-open connection can leave the replication promise unsettled forever. That keeps `syncState` at `STARTED`, and `liveSync` only starts a new sync when the state is not `STARTED`, so background sync stops permanently: edits entered afterwards are saved locally but never upload and never appear on other devices, until the app is reloaded. The fix cancels a sync that makes no progress within `SYNC_STALL_TIMEOUT` so the next trigger can retry.

Reproducing the raw hang by hand needs a proxy, so the regression is covered by an automated unit test; manual steps confirm normal sync is unaffected.

**Automated (the core proof)**
- `npx ng test --include src/app/core/database/pouchdb/synced-pouch-database.spec.ts`
- New test `should recover and keep syncing after a sync stalls with no progress` fails without the fix, passes with it.

**Manual (normal sync still works)**
1. Log in in synced mode and let the initial sync complete.
2. DevTools > Network > Offline. Edit and save a record (saved locally, no error).
3. DevTools > Network > Online. Within ~30s the change syncs to the server / a second device.
4. Repeat a few offline/online cycles; sync keeps working and the sync indicator settles.

**Optional (observe recovery from a hung push)**
- Route the app through a proxy that holds `POST .../_bulk_docs` and `.../_revs_diff` open without responding, then trigger a sync. Before the fix the sync indicator spins forever and later edits never upload; after the fix the sync auto-cancels after `SYNC_STALL_TIMEOUT` and background sync resumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reliability by detecting stalled replication and cancelling it after a timeout.
  * Ensures failed/stalled sync attempts are retried so local changes continue syncing.
  * Prevents lingering sync monitoring timers to improve runtime stability.
* **Tests**
  * Added coverage for stalled sync behavior and verified retry behavior with mocked timer-based watchdog logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->