### PR TITLE
fix(boolean-datatype): coerce imported checkbox values to real booleans

### DIFF
--- a/src/app/core/basic-datatypes/boolean/boolean.datatype.spec.ts
+++ b/src/app/core/basic-datatypes/boolean/boolean.datatype.spec.ts
@@ -3,4 +3,12 @@ import { BooleanDatatype } from "./boolean.datatype";
 
 describe("Schema data type: boolean", () => {
   testDatatype(new BooleanDatatype(), true, true);
+
+  it("coerces string/number values to real booleans (import)", () => {
+    const datatype = new BooleanDatatype();
+    expect(datatype.transformToObjectFormat("true")).toBe(true);
+    expect(datatype.transformToObjectFormat("false")).toBe(false);
+    expect(datatype.transformToObjectFormat(true)).toBe(true);
+    expect(datatype.transformToObjectFormat(false)).toBe(false);
+  });
 });

--- a/src/app/core/basic-datatypes/boolean/boolean.datatype.ts
+++ b/src/app/core/basic-datatypes/boolean/boolean.datatype.ts
@@ -9,11 +9,29 @@ export class BooleanDatatype extends DiscreteDatatype<boolean, boolean> {
   override editComponent = "EditBoolean";
   override viewComponent = "DisplayCheckmark";
 
-  override transformToDatabaseFormat(value: boolean) {
-    return value;
+  override transformToDatabaseFormat(value) {
+    return this.parseBoolean(value);
   }
 
-  override transformToObjectFormat(value: boolean) {
-    return value;
+  override transformToObjectFormat(value) {
+    return this.parseBoolean(value);
+  }
+
+  /**
+   * Coerce values into a real boolean.
+   * Values from import or external sources may arrive as strings ("true"/"false")
+   * or numbers (1/0) and need to be normalized so storage and display stay consistent.
+   */
+  private parseBoolean(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      return (
+        normalized === "true" || normalized === "1" || normalized === "yes"
+      );
+    }
+    return !!value;
   }
 }


### PR DESCRIPTION
- closes #4165

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

1. Add a checkbox (boolean) field to an entity type (e.g. School > "Private School").
2. Prepare an import file with that column containing both `true` and `false` values.
3. Start the import and open the value-mapping dialog for the column: confirm `false` defaults to **unchecked** and `true` to **checked** (previously both defaulted to [checked).  [test-boolean-import.csv](https://github.com/user-attachments/files/30294044/test-boolean-import.csv)
4. Complete the import.
5. Manually create a record of the same type and tick the checkbox.
6. Open a SQL report that includes this field and compare the imported records with the manual one: both now store a real boolean (checked rows show `1`, unchecked show `0`), instead of imported rows showing the string `true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boolean value handling by converting common string and numeric inputs into consistent `true` or `false` values.
  * Preserved empty values such as `null` and `undefined` during conversion.

* **Tests**
  * Added coverage for boolean conversion from string and numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->