### PR TITLE
fix(Admin UI): distance column gets missing on Admin UI for matching view 

### DIFF
--- a/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
+++ b/src/app/core/common-components/entity-fields-menu/entity-fields-menu.component.ts
@@ -57,7 +57,10 @@ export class EntityFieldsMenuComponent implements OnInit {
 
         return mappedField;
       })
-      .filter((field) => !field.isInternalField && field.label);
+      .filter(
+        (field) =>
+          field["_customField"] || (!field.isInternalField && field.label),
+      );
 
     const deduplicatedFieldsById: Record<string, FormFieldConfig> = {};
     for (const field of fieldsConfig) {

--- a/src/app/core/entity/entity-field-select/entity-field-select.component.spec.ts
+++ b/src/app/core/entity/entity-field-select/entity-field-select.component.spec.ts
@@ -4,6 +4,7 @@ import { EntityFieldSelectComponent } from "./entity-field-select.component";
 import { EntityRegistry } from "../database-entity.decorator";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ReactiveFormsModule } from "@angular/forms";
+import { TestEntity } from "#src/app/utils/test-utils/TestEntity";
 
 describe("EntityFieldSelectComponent", () => {
   let component: EntityFieldSelectComponent;
@@ -26,5 +27,21 @@ describe("EntityFieldSelectComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should offer the explicitly given options, including fields that are not part of the entity schema", () => {
+    fixture.componentRef.setInput("entityType", TestEntity);
+    fixture.componentRef.setInput("options", [
+      { id: "name", label: "Name" },
+      { id: "distance", label: "Distance" },
+    ]);
+    fixture.detectChanges();
+
+    component.autocompleteForm.setValue("");
+
+    expect(component.autocompleteOptions().map((o) => o.asValue)).toEqual([
+      "name",
+      "distance",
+    ]);
   });
 });

--- a/src/app/core/entity/entity-field-select/entity-field-select.component.spec.ts
+++ b/src/app/core/entity/entity-field-select/entity-field-select.component.spec.ts
@@ -29,19 +29,24 @@ describe("EntityFieldSelectComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should offer the explicitly given options, including fields that are not part of the entity schema", () => {
+  it("should merge the explicitly given options with the fields inferred from the entity schema", () => {
     fixture.componentRef.setInput("entityType", TestEntity);
     fixture.componentRef.setInput("options", [
-      { id: "name", label: "Name" },
+      { id: "name", label: "Custom Name" },
       { id: "distance", label: "Distance" },
     ]);
     fixture.detectChanges();
 
     component.autocompleteForm.setValue("");
 
-    expect(component.autocompleteOptions().map((o) => o.asValue)).toEqual([
-      "name",
-      "distance",
-    ]);
+    const offeredOptions = component.autocompleteOptions();
+    const offeredIds = offeredOptions.map((o) => o.asValue);
+    expect(offeredIds).toContain("distance");
+    expect(offeredIds).toContain("other");
+    // a field given both ways is offered once, with the explicit config winning
+    expect(offeredIds.filter((id) => id === "name")).toEqual(["name"]);
+    expect(offeredOptions.find((o) => o.asValue === "name").asString).toBe(
+      "Custom Name",
+    );
   });
 });

--- a/src/app/core/entity/entity-field-select/entity-field-select.component.ts
+++ b/src/app/core/entity/entity-field-select/entity-field-select.component.ts
@@ -78,13 +78,22 @@ export class EntityFieldSelectComponent extends BasicAutocompleteComponent<
   });
 
   /**
-   * Explicitly given options take precedence over the entity's schema fields,
+   * Explicitly given options are merged with the fields inferred from the entity's schema,
    * so that callers can offer additional, calculated columns (e.g. "distance")
    * that do not exist as a field in the schema.
+   * An explicit config takes precedence over the inferred field of the same id.
    */
   protected override optionsSource = computed(() => {
-    const explicitOptions = this.options();
-    return explicitOptions?.length ? explicitOptions : this.fieldOptions();
+    const optionsById = new Map<string, FormFieldConfig>();
+    for (const option of this.options() ?? []) {
+      optionsById.set(option.id, option);
+    }
+    for (const inferredOption of this.fieldOptions()) {
+      if (!optionsById.has(inferredOption.id)) {
+        optionsById.set(inferredOption.id, inferredOption);
+      }
+    }
+    return [...optionsById.values()];
   });
 
   private getAllFieldProps(schema: EntitySchema): FormFieldConfig[] {

--- a/src/app/core/entity/entity-field-select/entity-field-select.component.ts
+++ b/src/app/core/entity/entity-field-select/entity-field-select.component.ts
@@ -77,7 +77,15 @@ export class EntityFieldSelectComponent extends BasicAutocompleteComponent<
     return this.getAllFieldProps(entityType.schema);
   });
 
-  protected override optionsSource = computed(() => this.fieldOptions());
+  /**
+   * Explicitly given options take precedence over the entity's schema fields,
+   * so that callers can offer additional, calculated columns (e.g. "distance")
+   * that do not exist as a field in the schema.
+   */
+  protected override optionsSource = computed(() => {
+    const explicitOptions = this.options();
+    return explicitOptions?.length ? explicitOptions : this.fieldOptions();
+  });
 
   private getAllFieldProps(schema: EntitySchema): FormFieldConfig[] {
     return [...schema.entries()]

--- a/src/app/features/matching-entities/admin-matching-entities/edit-matching-entity-side/edit-matching-entity-side.component.spec.ts
+++ b/src/app/features/matching-entities/admin-matching-entities/edit-matching-entity-side/edit-matching-entity-side.component.spec.ts
@@ -7,6 +7,9 @@ import {
 } from "#src/app/core/entity/database-entity.decorator";
 import { TestEntity } from "#src/app/utils/test-utils/TestEntity";
 import { MockedTestingModule } from "#src/app/utils/mocked-testing.module";
+import { By } from "@angular/platform-browser";
+import { AdminListManagerComponent } from "#src/app/core/admin/admin-list-manager/admin-list-manager.component";
+import { EntityFieldSelectComponent } from "#src/app/core/entity/entity-field-select/entity-field-select.component";
 
 describe("EditMatchingEntitySideComponent", () => {
   let component: EditMatchingEntitySideComponent;
@@ -41,5 +44,20 @@ describe("EditMatchingEntitySideComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should offer the calculated 'distance' column for selection", () => {
+    const columnsManager = fixture.debugElement.queryAll(
+      By.directive(AdminListManagerComponent),
+    )[0];
+    const fieldSelect: EntityFieldSelectComponent = columnsManager.query(
+      By.directive(EntityFieldSelectComponent),
+    ).componentInstance;
+
+    fieldSelect.autocompleteForm.setValue("");
+
+    expect(fieldSelect.autocompleteOptions().map((o) => o.asValue)).toContain(
+      "distance",
+    );
   });
 });

--- a/src/app/features/matching-entities/admin-matching-entities/edit-matching-entity-side/edit-matching-entity-side.component.spec.ts
+++ b/src/app/features/matching-entities/admin-matching-entities/edit-matching-entity-side/edit-matching-entity-side.component.spec.ts
@@ -46,7 +46,7 @@ describe("EditMatchingEntitySideComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should offer the calculated 'distance' column for selection", () => {
+  it("should offer the special columns 'distance' and record preview for selection", () => {
     const columnsManager = fixture.debugElement.queryAll(
       By.directive(AdminListManagerComponent),
     )[0];
@@ -56,8 +56,10 @@ describe("EditMatchingEntitySideComponent", () => {
 
     fieldSelect.autocompleteForm.setValue("");
 
-    expect(fieldSelect.autocompleteOptions().map((o) => o.asValue)).toContain(
-      "distance",
-    );
+    const offeredFields = fieldSelect
+      .autocompleteOptions()
+      .map((o) => o.asValue);
+    expect(offeredFields).toContain("distance");
+    expect(offeredFields).toContain("_id");
   });
 });

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.html
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.html
@@ -18,7 +18,7 @@
 <div class="margin-bottom-small" #matchComparison>
   <table
     mat-table
-    [dataSource]="resolvedColumns()"
+    [dataSource]="comparisonColumns()"
     class="match-comparison-table mat-elevation-z1"
   >
     @for (side of sideDetails(); track $index; let i = $index) {

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
@@ -20,6 +20,8 @@ import {
   DatabaseEntity,
   EntityRegistry,
 } from "../../../core/entity/database-entity.decorator";
+import { By } from "@angular/platform-browser";
+import { MatTable } from "@angular/material/table";
 
 describe("MatchingEntitiesComponent", () => {
   let component: MatchingEntitiesComponent;
@@ -359,7 +361,7 @@ describe("MatchingEntitiesComponent", () => {
     expect(component.lockedMatching()).toBe(false);
   });
 
-  it("should create distance column and publish updates", async () => {
+  it("should create distance column for table and summary view and publish updates", async () => {
     TestEntity.schema.set("address", { dataType: "location" });
     fixture.componentRef.setInput("entity", new TestEntity());
     fixture.componentRef.setInput("columns", [[undefined, "distance"]]);
@@ -383,6 +385,11 @@ describe("MatchingEntitiesComponent", () => {
       },
     });
     expect(component.columns()?.[0][1]).toBe("distance");
+    expect(component.comparisonColumns()[0][1]).toBe(distanceColumn);
+    const comparisonTable = fixture.debugElement.query(
+      By.directive(MatTable),
+    ).componentInstance;
+    expect(comparisonTable.dataSource).toEqual(component.comparisonColumns());
 
     let newCoordinates: Coordinates[];
     distanceColumn.additional.compareCoordinates.subscribe(

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
@@ -179,12 +179,17 @@ export class MatchingEntitiesComponent implements OnInit {
     return { ...this.globalConfig, ...structuredClone(routeConf) };
   });
 
-  private columnsState: [ColumnConfig, ColumnConfig][] = [];
+  /**
+   * Columns of the summary comparison view, as a working copy of the configured columns
+   * so that generated configs (like the calculated "distance" column) can be filled in
+   * without changing the given config.
+   */
+  readonly comparisonColumns = signal<[ColumnConfig, ColumnConfig][]>([]);
 
   // TODO: fill selection on hover already?
 
   async ngOnInit() {
-    this.columnsState = this.cloneColumns(this.resolvedColumns());
+    this.comparisonColumns.set(this.cloneColumns(this.resolvedColumns()));
     const sides: [MatchingSide, MatchingSide] = [
       await this.initSideDetails(this.resolvedLeftSide(), 0),
       await this.initSideDetails(this.resolvedRightSide(), 1),
@@ -205,7 +210,7 @@ export class MatchingEntitiesComponent implements OnInit {
   ): Promise<MatchingSide> {
     const newSide = buildMatchingSideConfig(
       side,
-      this.columnsState,
+      this.comparisonColumns(),
       sideIndex,
     ) as MatchingSide;
 
@@ -441,14 +446,21 @@ export class MatchingEntitiesComponent implements OnInit {
       side.columns[sideIndex] = columnConfig;
       side.distanceColumn = columnConfig.additional;
       this.setDistanceValuesForSide(side);
-      const colIndex = this.columnsState.findIndex((row) => {
+      const columns = this.comparisonColumns();
+      const colIndex = columns.findIndex((row) => {
         const col = row[index];
         return typeof col === "string"
           ? col === "distance"
           : col?.id === "distance";
       });
       if (colIndex !== -1) {
-        this.columnsState[colIndex][index] = columnConfig;
+        const updatedColumns = [...columns];
+        updatedColumns[colIndex] = [...updatedColumns[colIndex]] as [
+          ColumnConfig,
+          ColumnConfig,
+        ];
+        updatedColumns[colIndex][index] = columnConfig;
+        this.comparisonColumns.set(updatedColumns);
       }
     }
   }

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -43,7 +43,7 @@
           "entityType": "School",
           "subMenu": [
             {
-              "label": "Matchig View",
+              "label": "Matching View",
               "icon": "people-arrows",
               "link": "/matching"
             }

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -40,7 +40,14 @@
           "entityType": "Child"
         },
         {
-          "entityType": "School"
+          "entityType": "School",
+          "subMenu": [
+            {
+              "label": "Matchig View",
+              "icon": "people-arrows",
+              "link": "/matching"
+            }
+          ]
         },
         {
           "label": "Attendance",


### PR DESCRIPTION
- closes #4161

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

The special columns of the Matching View ("Distance" and the record preview column) were missing from the "Add columns" dropdown in the Admin UI. Since they could not be selected there, they were also silently dropped from the config as soon as any other column was changed and the config was saved.

Both special columns are covered here: "Distance" was not offered because explicitly configured fields that do not exist in the entity schema were discarded, and "Name (record preview)" was not offered because the internal `_id` field was filtered out even though it was explicitly configured.

While testing this, the calculated "Distance" also turned out to be missing in the top summary comparison view of the Matching View itself, even though it was configured and worked in the tables below. The generated column config was only applied to the tables, not to the summary view. That is fixed here as well.

Use the `[All Features]` demo setup.

### Prerequisite: make the Matching View reachable

The demo config contains a Matching View but no menu entry for it, so add one first:

1. Go to Admin > Admin Overview > "Main Menu".
2. Click **"Add New Item"**.
3. Under **"Link"** select the Matching View entry, enter any **"Label"** (e.g. "Matching") and click **"Apply"**.
4. Save the menu configuration. The Matching View now appears in the left sidebar.

### The actual fix

1. Open the Matching View from the left sidebar.
2. Click the three-dot menu in the top right of the Matching View and select **"Edit Matching Entities"**.
3. Under "Available columns" for either side, open the "Add columns" dropdown.
4. Verify **"Distance"** is listed and can be checked and unchecked.
5. Verify **"Name (record preview)"** is listed as well.
6. Keep both selected, additionally select another column (e.g. "Name") and click "Save".
7. Go back into "Edit Matching Entities" and verify that "Distance" and "Name (record preview)" are still configured. Before this fix they were removed from the config at this point.
8. Back in the Matching View, select a record on one side and verify the Distance column in the table below shows the calculated values. Records without geo coordinates on their location field correctly show "-".
9. With a record selected on both sides, verify that the top summary comparison view now also shows a **"Distance"** row with the calculated value. Before this fix that row stayed empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom fields now appear in field-selection menus even without standard labels.
  * Field selection now merges explicitly provided autocomplete options with inferred schema fields, with explicit configuration taking precedence.
  * Matching-entity field selection includes the special selectable `distance` and `_id` columns.
  * Added a **Matching View** link to the **School** navigation submenu.
* **Bug Fixes**
  * Matching comparison tables now render from the correct comparison column set, keeping distance and summary views synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->