### PR TITLE
fix: prevent entity type label pipe from crashing on unregistered types

### DIFF
--- a/src/app/core/common-components/entity-type-label/entity-type-label.pipe.spec.ts
+++ b/src/app/core/common-components/entity-type-label/entity-type-label.pipe.spec.ts
@@ -41,7 +41,13 @@ describe("EntityTypeLabelPipeEntity", () => {
     );
   });
 
-  it("throws error on invalid entity type", () => {
-    expect(() => pipe.transform("unknown type")).toThrow();
+  it("falls back to the raw key for an unregistered entity type", () => {
+    expect(pipe.transform("unknown type")).toBe("unknown type");
+  });
+
+  it("keeps labels for known types and falls back to the raw key for unknown types in an array", () => {
+    expect(
+      pipe.transform([EntityTypeLabelPipeEntity.ENTITY_TYPE, "unknown type"]),
+    ).toBe(`${EntityTypeLabelPipeEntity.label} / unknown type`);
   });
 });

--- a/src/app/core/common-components/entity-type-label/entity-type-label.pipe.ts
+++ b/src/app/core/common-components/entity-type-label/entity-type-label.pipe.ts
@@ -15,15 +15,25 @@ export class EntityTypeLabelPipe implements PipeTransform {
     // If value is an array, map each to label and join with "/"
     if (Array.isArray(value)) {
       return value
-        .map((v) => {
-          const entity = this.entityTypes.get(v);
-          return entity ? (plural ? entity.labelPlural : entity.label) : v;
-        })
+        .map((v) => this.getLabel(v, plural))
         .filter(Boolean)
         .join(" / ");
     } else {
-      const entity = this.entityTypes.get(value);
-      return plural ? entity?.labelPlural : entity?.label;
+      return this.getLabel(value, plural);
     }
+  }
+
+  /**
+   * Look up the label for a single entity type key,
+   * falling back to the raw key if the type is not registered
+   * (e.g. a config still references a type that was removed/renamed).
+   */
+  private getLabel(key: string, plural: boolean): string {
+    // `EntityRegistry.get` throws for unregistered keys, so guard with `has`
+    // to degrade gracefully instead of crashing the surrounding view.
+    const entity = this.entityTypes.has(key)
+      ? this.entityTypes.get(key)
+      : undefined;
+    return entity ? (plural ? entity.labelPlural : entity.label) : key;
   }
 }


### PR DESCRIPTION
## Problem

`EntityRegistry.get()` **throws** for unregistered keys, so the fallbacks in `EntityTypeLabelPipe` were dead code — the pipe threw before it could degrade to the raw key:

```ts
const entity = this.entityTypes.get(value); // throws here
return plural ? entity?.labelPlural : entity?.label; // never reached
```

Used in a template without its own fallback, that unhandled error propagates out of change detection and breaks the surrounding view.

This triggers when a config still references an entity type that is not registered on the instance (a type removed or renamed, but still present in existing records). Observed on a production instance, where it repeatedly broke a list view.

## Fix

Look the type up via `has()` first, and fall back to the raw key. Also fixes the scalar branch returning `undefined` despite its declared `: string` return type.

`Registry.get()` itself is unchanged — the fail-fast throw is intentional for dynamic component loading. Only the display pipe should degrade.

## Notes

- Existing consumers already tolerate a falsy return (`?? entityType()`, `|| id`), so no call site changes are needed.
- The previous spec asserted the pipe *throws* on an unknown type; that is replaced with fallback assertions plus a mixed known/unknown array case (the array branch's fallback was also unreachable).
- Same bug class as #4102, which fixed two other call sites with the same `has()` guard.

Sentry: AAM-DIGITAL-73Y

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity type labels now gracefully display the original key when a type is unknown or unavailable, instead of causing an error.
  * Lists containing mixed known and unknown entity types now render correctly, with labels separated by ` / `.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->