### PR TITLE
fix: stabilize automated field update log message for Sentry grouping

### DIFF
--- a/src/app/features/inherited-field/automated-field-update/automated-field-update-config.service.ts
+++ b/src/app/features/inherited-field/automated-field-update/automated-field-update-config.service.ts
@@ -348,7 +348,9 @@ export class AutomatedFieldUpdateConfigService {
           return entity;
         } catch (error) {
           Logging.warn(
-            `AutomatedFieldUpdateConfigService: Failed to load entity of type ${entityType.ENTITY_TYPE} with ID ${id}: ${error}`,
+            "AutomatedFieldUpdateConfigService: Failed to load entity for automated field update",
+            { entityType: entityType.ENTITY_TYPE, entityId: id },
+            error,
           );
           return null;
         }


### PR DESCRIPTION
## Problem

`AutomatedFieldUpdateConfigService.loadEntitiesByIds` interpolated the entity type, the **full entity ID** and the error into the log message:

```ts
Logging.warn(
  `AutomatedFieldUpdateConfigService: Failed to load entity of type ${entityType.ENTITY_TYPE} with ID ${id}: ${error}`,
);
```

Sentry groups issues by the message string, so every affected record produced a separate issue — fragmenting one recurring problem into many near-duplicates and making triage harder.

## Fix

Keep the message static and move the specifics into context arguments, matching the convention used elsewhere in the codebase.

The underlying load failure is a transient offline error, so this stays at `warn` — this change is only about grouping.

Sentry: AAM-DIGITAL-73S

🤖 Generated with [Claude Code](https://claude.com/claude-code)