### PR TITLE
fix: log only the document ID when a save conflict cannot be resolved

### DIFF
--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -500,9 +500,9 @@ export class PouchDatabase extends Database {
       newObject._rev = existingObject._rev;
       return this.put(newObject);
     } else {
-      existingError.message = `${
-        existingError.message
-      } (unable to resolve) ID: ${JSON.stringify(newObject)}`;
+      // only include the document's ID here: the full document would leak
+      // record contents into logs and fragment Sentry grouping per document
+      existingError.message = `${existingError.message} (unable to resolve) ID: ${newObject._id}`;
       throw new DatabaseException(existingError);
     }
   }


### PR DESCRIPTION
## Problem

When a `409` save conflict could not be resolved, `resolveConflict` built the error message like this:

```ts
existingError.message = `${existingError.message} (unable to resolve) ID: ${JSON.stringify(newObject)}`;
```

Despite the `ID:` label, this serialises the **entire document**. The resulting error text — and the monitoring issue title — contained all of the record's field values plus the `created`/`updated` user references.

Two consequences:

1. **Record contents leak into monitoring.** Observed in production, where the issue title carried a full config document including user identifiers.
2. **Grouping breaks.** Issues are grouped by message string, so each distinct document became its own group, splitting one recurring problem into many.

## Fix

Log `newObject._id` instead. This matches the two branches directly above it in the same method, which already log `_id` only — so this was an isolated inconsistency rather than an intentional dump.

## Notes

- No test asserted the old message text; the 26 existing `pouch-database` tests pass.
- This is the only place in the codebase that interpolated `JSON.stringify` into a log or error message.
- Not addressed here: `mergeObjects()` is still a `return undefined` stub, so conflicts are never merged automatically and always fall through to overwrite-or-throw. That is the reason this path is reached in bulk, and is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)