### PR TITLE
chore(renovate): disable Dependency Dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "schedule": [
     "after 00:00 and before 09:00 on Monday"
   ],
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": [
@@ -50,7 +50,6 @@
         "major"
       ],
       "draftPR": true,
-      "dependencyDashboardApproval": true,
       "labels": [
         "Final Review"
       ]


### PR DESCRIPTION
Sets `"dependencyDashboard": false` so Renovate stops creating and maintaining the **Dependency Dashboard** issue.

Where a `packageRule` gated major updates behind `dependencyDashboardApproval`, that gate is removed too. Renovate recreates the dashboard whenever *any* packageRule sets `dependencyDashboardApproval`, independent of the `dependencyDashboard` setting ([source](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/dependency-dashboard.ts)):

```ts
config.dependencyDashboard === true ||
config.dependencyDashboardApproval === true ||
config.packageRules?.some((rule) => rule.dependencyDashboardApproval) === true || ...
```

Major updates therefore now open directly as **draft** PRs (`draftPR: true` is kept) rather than waiting for a dashboard checkbox.

Renovate closes the existing dashboard issue itself on the next run — no need to close it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)