### PR TITLE
fix(test): always use an in-memory database in DatabaseTestingModule

### DIFF
--- a/src/app/utils/database-testing.module.ts
+++ b/src/app/utils/database-testing.module.ts
@@ -1,4 +1,4 @@
-import { inject, NgModule, provideAppInitializer } from "@angular/core";
+import { inject, NgModule, NgZone, provideAppInitializer } from "@angular/core";
 import { ConfigService } from "../core/config/config.service";
 import { SessionType } from "../core/session/session-type";
 import { environment } from "../../environments/environment";
@@ -13,6 +13,10 @@ import { getDefaultConfigEntity } from "../core/config/testing-config-service";
 import { getDefaultEnumEntities } from "app/core/basic-datatypes/configurable-enum/configurable-enum-testing";
 import { firstValueFrom } from "rxjs";
 import { AttendanceInitService } from "../features/attendance/attendance-init.service";
+import { DatabaseFactoryService } from "../core/database/database-factory.service";
+import { MemoryPouchDatabase } from "../core/database/pouchdb/memory-pouch-database";
+import { SyncStateSubject } from "../core/session/session-type";
+import { Database } from "../core/database/database";
 
 /**
  * Utility module that creates a simple environment where a correctly configured database and session is set up.
@@ -30,6 +34,37 @@ import { AttendanceInitService } from "../features/attendance/attendance-init.se
     ConfigService,
     ConfigurableEnumService,
     { provide: SwRegistrationOptions, useValue: { enabled: false } },
+    {
+      // Always hand out an in-memory database, whatever `environment.session_type`
+      // happens to be.
+      //
+      // The real factory picks the adapter from that global at the moment the
+      // database is created. AppModule sits in `imports`, so its app initializers
+      // run before the one below can force SessionType.mock — if any of them
+      // touches the database while another spec has left the session type as
+      // "synced" or "local", the factory hands back a PouchDB on the `indexeddb`
+      // adapter. jsdom has no indexedDB, so its deferred work later throws
+      // "ReferenceError: indexedDB is not defined" into whatever test is running.
+      //
+      // No test wants a real indexedDB, so do not let the choice depend on
+      // ambient state at all.
+      provide: DatabaseFactoryService,
+      useFactory: () => {
+        const syncState = inject(SyncStateSubject);
+        const ngZone = inject(NgZone);
+        const create = (dbName: string) =>
+          new MemoryPouchDatabase(dbName, syncState, ngZone);
+
+        return {
+          createDatabase: create,
+          createRemoteDatabase: (dbName: string): Database => {
+            const db = create(dbName);
+            db.init(dbName);
+            return db;
+          },
+        } as Partial<DatabaseFactoryService> as DatabaseFactoryService;
+      },
+    },
     {
       provide: AttendanceInitService,
       useValue: { registerDefaultAttendanceStatusEnum: () => {} },


### PR DESCRIPTION
## Problem

`qa / test-unit` still fails intermittently after #4186 — e.g. [#4181](https://github.com/Aam-Digital/ndb-core/pull/4181), where all 16 tests in `children.service.spec.ts` plus one in `select-report.component.spec.ts` failed with:

```
Cannot configure the test module when the test module has already been instantiated.
```

That's a cascade. The root error appears 62 times in the same log:

```
ReferenceError: indexedDB is not defined
  at openDatabase (pouchdb-adapter-indexeddb/lib/index.es.js:328:5)
```

## Cause

**No unit test wants a real indexedDB.** Only 6 specs use a real PouchDB via `DatabaseTestingModule`, and they already expect the in-memory adapter. The other ~440 never touch one. The `indexeddb` adapter only ever appeared by accident.

`DatabaseFactoryService` picks the adapter from `environment.session_type` **at the moment the database is created**. `DatabaseTestingModule` forces `SessionType.mock` in its app initializer — but `AppModule` is in its `imports`, so AppModule's initializers run *first*. If one of them touches the database while another spec has left the session type as `synced` or `local`, the factory returns a PouchDB on the `indexeddb` adapter.

jsdom provides no `indexedDB`, so that database's deferred task queue throws later — into whichever test happens to be running. In `children.service.spec.ts` it aborted the initializer *after* the TestBed was instantiated, so every subsequent `beforeEach` hit "already been instantiated".

This is why the failure looked random, moved between specs, and hit branches that changed nothing but `e2e/` files.

## Change

Override `DatabaseFactoryService` in `DatabaseTestingModule` so it always returns a `MemoryPouchDatabase`. The adapter no longer depends on ambient global state.

## Testing

- Full suite: **445 files / 2417 tests green in 38s**, and **zero** `indexedDB is not defined` anywhere in the log (was 62)
- All 6 real-database specs pass individually: `children.service` (16), `query.service` (46), `search.service` (8), `historical-data.service` (3), `group-participant-resolver` (3), `todos-related-to-entity` (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)