### PR TITLE
fix: cancel the dynamic-component preload when the app is destroyed

### DIFF
--- a/src/app/core/config/config.app-initializer.ts
+++ b/src/app/core/config/config.app-initializer.ts
@@ -26,7 +26,7 @@ export const APP_INITIALIZER_PROPAGATE_CONFIG_UPDATES = provideAppInitializer(
         router.navigateByUrl(url, { skipLocationChange: true });
 
         // Preload all dynamic component chunks in the background for offline availability
-        preloadDynamicComponents(componentRegistry);
+        preloadDynamicComponents(componentRegistry, destroyRef);
       });
   },
 );
@@ -39,7 +39,10 @@ export const APP_INITIALIZER_PROPAGATE_CONFIG_UPDATES = provideAppInitializer(
  * Runs once in an idle callback to avoid blocking the main thread after login.
  */
 let preloadScheduled = false;
-function preloadDynamicComponents(registry: ComponentRegistry) {
+function preloadDynamicComponents(
+  registry: ComponentRegistry,
+  destroyRef: DestroyRef,
+) {
   if (preloadScheduled) {
     return;
   }
@@ -53,9 +56,21 @@ function preloadDynamicComponents(registry: ComponentRegistry) {
     }
   };
 
-  if ("requestIdleCallback" in window) {
-    requestIdleCallback(load, { timeout: 10_000 });
-  } else {
-    setTimeout(load, 3_000);
-  }
+  const useIdleCallback = "requestIdleCallback" in window;
+  const handle = useIdleCallback
+    ? requestIdleCallback(load, { timeout: 10_000 })
+    : setTimeout(load, 3_000);
+
+  // Cancel if the app (or, in tests, the TestBed injector) goes away first.
+  // Otherwise this fires seconds later and dynamically imports every registered
+  // component. A unit test is long gone by then, so those imports land after
+  // Vitest tore the environment down and fail an unrelated spec file with
+  // "EnvironmentTeardownError: Cannot load '/chunk-....js' ...".
+  destroyRef.onDestroy(() => {
+    if (useIdleCallback) {
+      cancelIdleCallback(handle as number);
+    } else {
+      clearTimeout(handle as ReturnType<typeof setTimeout>);
+    }
+  });
 }


### PR DESCRIPTION
## Problem

`qa / test-unit` failed on master ([run 30518816135](https://github.com/Aam-Digital/ndb-core/actions/runs/30518816135)) with a telling shape:

```
Test Files  1 failed | 444 passed | 2 skipped (447)
     Tests  2410 passed | 21 skipped (2431)
```

**Zero failing tests, one failing file.** The error is reported against the *file*, not a test:

```
FAIL  src/app/features/location/map-popup/map-popup.component.spec.ts
EnvironmentTeardownError: Cannot load '/chunk-VNROAAVV.js' ... after the environment was torn down
last recorded callstack:
  - edit-location.component-7YHXLCGZ.js
  - spec-app-features-public-form-public-form.component.js
  - src/app/features/public-form/public-form.component.spec.ts
```

Note the mismatch: blamed on `map-popup`, caused by `public-form`.

## Cause

`APP_INITIALIZER_PROPAGATE_CONFIG_UPDATES` schedules `preloadDynamicComponents` via `requestIdleCallback(..., { timeout: 10_000 })`, falling back to a 3s `setTimeout`. When it fires it calls `loadFn()` for **every** entry in the `ComponentRegistry` — a dynamic `import()` each.

Nothing cancelled it. A unit test finishes in milliseconds, so those imports resolve long after Vitest tore the environment down, and land on whichever spec file is running by then.

This is a production preload firing inside unit tests, which makes it a genuine cross-file flake source: the blamed file is essentially random.

## Change

Cancel on `DestroyRef`, which the initializer already injects. In production this only matters at shutdown; in tests the TestBed injector is destroyed after every test, so the preload can never outlive its spec.

## Scan for related flakiness

I checked the other patterns that survive across spec files:

| pattern | result |
|---|---|
| specs stubbing shared prototypes (`Storage`/`Element`/`Date`.prototype) | none |
| `vi.stubGlobal` without `unstubAllGlobals` | none |
| unbalanced `useFakeTimers` / `useRealTimers` | none |
| `EnvironmentTeardownError` sources across saved runs | only `public-form.component.spec.ts` |

So this was the remaining one in that class.

## Testing

Full suite: **445 files / 2417 tests green**, zero `EnvironmentTeardownError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)