### PR TITLE
fix(Admin UI): keep focus in the field group title field while typing

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
@@ -73,8 +73,8 @@
               <div class="dummy-form-field">
                 <app-entity-field-edit
                   [field]="field"
-                  [entity]="dummyEntity"
-                  [form]="dummyForm"
+                  [entity]="dummyEntity()"
+                  [form]="dummyForm()"
                 ></app-entity-field-edit>
               </div>
             </div>

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
@@ -9,7 +9,7 @@
     [class.fieldsOnlyMode]="fieldsOnlyMode()"
   >
     <!-- FIELD GROUPS -->
-    @for (group of fieldGroups(); track group; let i = $index) {
+    @for (group of fieldGroups(); track i; let i = $index) {
       <div class="entity-form-cell admin-form-column section-container" cdkDrag>
         @if (!fieldsOnlyMode()) {
           <div class="flex-row align-center">

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -322,6 +322,35 @@ describe("AdminEntityFormComponent", () => {
     }
   });
 
+  it("should keep the group header input while typing, without rebuilding the form", async () => {
+    // the parent (e.g. AdminEntityDetailsComponent) feeds the emitted config back into the input
+    component.configChange.subscribe((newConfig) =>
+      fixture.componentRef.setInput("config", newConfig),
+    );
+    const getHeaderInput = () =>
+      fixture.nativeElement.querySelector(
+        "app-admin-section-header input",
+      ) as HTMLInputElement;
+
+    const inputBefore = getHeaderInput();
+    inputBefore.focus();
+    const createFormCallsBefore =
+      mockFormService.createEntityForm.mock.calls.length;
+
+    inputBefore.value = "Group 1x";
+    inputBefore.dispatchEvent(new Event("input"));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getHeaderInput()).toBe(inputBefore);
+    expect(document.activeElement).toBe(inputBefore);
+    expect(component.fieldGroups()[0].header).toBe("Group 1x");
+    expect(mockFormService.createEntityForm.mock.calls.length).toBe(
+      createFormCallsBefore,
+    );
+  });
+
   it("should prefill label when creating new field with search text", async () => {
     vi.useFakeTimers();
     try {

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -99,8 +99,8 @@ describe("AdminEntityFormComponent", () => {
   it("should create and init a form", () => {
     expect(component).toBeTruthy();
 
-    expect(component.dummyEntity).toBeTruthy();
-    expect(component.dummyForm).toBeTruthy();
+    expect(component.dummyEntity()).toBeTruthy();
+    expect(component.dummyForm()).toBeTruthy();
   });
 
   it("should load all fields from schema that are not already in form as available fields", async () => {

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -4,6 +4,7 @@ import { EntityForm } from "#src/app/core/common-components/entity-form/entity-f
 import { CdkDragDrop } from "@angular/cdk/drag-drop";
 import { FormGroup } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { of } from "rxjs";
@@ -349,6 +350,31 @@ describe("AdminEntityFormComponent", () => {
     expect(mockFormService.createEntityForm.mock.calls.length).toBe(
       createFormCallsBefore,
     );
+  });
+
+  it("should update the preview of a field whose schema was changed", async () => {
+    vi.useFakeTimers();
+    const originalSchema = TestEntity.schema.get("name");
+    try {
+      const previewLabels = () =>
+        fixture.debugElement
+          .queryAll(By.css("app-entity-field-edit"))
+          .map((field) => field.componentInstance._field()?.label);
+      fixture.detectChanges();
+      expect(previewLabels()).toContain("Name");
+
+      TestBed.inject(AdminEntityService).updateSchemaField(TestEntity, "name", {
+        ...originalSchema,
+        label: "Full Legal Title",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      fixture.detectChanges();
+
+      expect(previewLabels()).toContain("Full Legal Title");
+    } finally {
+      TestEntity.schema.set("name", originalSchema);
+      vi.useRealTimers();
+    }
   });
 
   it("should prefill label when creating new field with search text", async () => {

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -200,16 +200,26 @@ export class AdminEntityFormComponent {
     });
   }
 
+  /** counter to discard the results of outdated, concurrent initForm calls */
+  private initFormVersion = 0;
+
   private async initForm() {
+    const version = ++this.initFormVersion;
     const dummyEntity = new (this.entityType() as any)();
-    this.dummyEntity.set(dummyEntity);
 
     const dummyForm = await this.entityFormService.createEntityForm(
       [...this.getUsedFields(this.fieldGroups()), ...this.availableFields()],
       dummyEntity,
       this.destroyRef,
     );
+    if (version !== this.initFormVersion) {
+      // a newer initForm has been started in the meantime, its result takes precedence
+      return;
+    }
+
     dummyForm.formGroup.disable();
+    // set both together so that entity and form always match
+    this.dummyEntity.set(dummyEntity);
     this.dummyForm.set(dummyForm);
   }
 

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -152,22 +152,20 @@ export class AdminEntityFormComponent {
   );
 
   /**
-   * Ids of the fields currently used in the form (null while not initialized yet).
+   * Configurations of the fields currently used in the form (null while not initialized yet).
    * The dummy form only has to be rebuilt when these change,
    * not when other details like a field group header are edited.
    */
-  private readonly usedFieldIds = computed(() => {
+  private readonly usedFieldConfigurations = computed(() => {
     if (!this.config() || !this.entityType()) {
       return null;
     }
-    return this.getUsedFields(this.fieldGroups())
-      .map((field) => toFormFieldConfig(field).id)
-      .join(",");
+    return JSON.stringify(this.getUsedFields(this.fieldGroups()));
   });
 
   constructor() {
     effect(() => {
-      if (this.usedFieldIds() === null) {
+      if (this.usedFieldConfigurations() === null) {
         return;
       }
 

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -15,6 +15,7 @@ import {
   input,
   linkedSignal,
   output,
+  signal,
   untracked,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
@@ -104,8 +105,13 @@ export class AdminEntityFormComponent {
    */
   readonly fieldsOnlyMode = input<boolean>();
 
-  dummyEntity: Entity;
-  dummyForm: EntityForm<any>;
+  /**
+   * Dummy entity and form backing the form preview.
+   * These are signals so that rebuilding them updates the rendered field components,
+   * which extend their config (e.g. the label) from the entity type's schema.
+   */
+  readonly dummyEntity = signal<Entity | undefined>(undefined);
+  readonly dummyForm = signal<EntityForm<any> | undefined>(undefined);
 
   availableFields = linkedSignal<ColumnConfig[]>(() =>
     this.computeAvailableFieldsList(),
@@ -195,13 +201,16 @@ export class AdminEntityFormComponent {
   }
 
   private async initForm() {
-    this.dummyEntity = new (this.entityType() as any)();
-    this.dummyForm = await this.entityFormService.createEntityForm(
+    const dummyEntity = new (this.entityType() as any)();
+    this.dummyEntity.set(dummyEntity);
+
+    const dummyForm = await this.entityFormService.createEntityForm(
       [...this.getUsedFields(this.fieldGroups()), ...this.availableFields()],
-      this.dummyEntity,
+      dummyEntity,
       this.destroyRef,
     );
-    this.dummyForm.formGroup.disable();
+    dummyForm.formGroup.disable();
+    this.dummyForm.set(dummyForm);
   }
 
   private getUsedFields(fieldGroups: FieldGroup[]): ColumnConfig[] {
@@ -452,8 +461,8 @@ export class AdminEntityFormComponent {
       }
     }
 
-    this.dummyForm.formGroup.addControl(newFieldId, new FormControl());
-    this.dummyForm.formGroup.disable();
+    this.dummyForm().formGroup.addControl(newFieldId, new FormControl());
+    this.dummyForm().formGroup.disable();
     event.container.data.splice(event.currentIndex, 0, newFieldId);
     this.fieldGroups.update((g) => [...g]); // notify signal of in-place mutation
   }
@@ -476,8 +485,8 @@ export class AdminEntityFormComponent {
       return;
     }
 
-    this.dummyForm.formGroup.addControl(newTextField.id, new FormControl());
-    this.dummyForm.formGroup.disable();
+    this.dummyForm().formGroup.addControl(newTextField.id, new FormControl());
+    this.dummyForm().formGroup.disable();
     event.container.data.splice(event.currentIndex, 0, newTextField);
     this.fieldGroups.update((g) => [...g]);
 

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -15,6 +15,7 @@ import {
   input,
   linkedSignal,
   output,
+  untracked,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
@@ -116,9 +117,21 @@ export class AdminEntityFormComponent {
    * `availableFields` and `connectedGroups` derive from this signal,
    * so all structural changes automatically propagate.
    */
-  fieldGroups = linkedSignal<FieldGroup[]>(() =>
-    structuredClone(this.config()?.fieldGroups ?? []),
-  );
+  fieldGroups = linkedSignal<FormConfig | undefined, FieldGroup[]>({
+    source: this.config,
+    computation: (config, previous) => {
+      const incoming = config?.fieldGroups ?? [];
+      if (
+        previous &&
+        JSON.stringify(previous.value) === JSON.stringify(incoming)
+      ) {
+        // the config input only re-states what this component emitted itself,
+        // so keep the existing objects instead of replacing them with clones
+        return previous.value;
+      }
+      return structuredClone(incoming);
+    },
+  });
   readonly createNewFieldPlaceholder: FormFieldConfig = {
     id: null,
     label: $localize`:Label drag and drop item:Create New Field`,
@@ -138,16 +151,28 @@ export class AdminEntityFormComponent {
     },
   );
 
+  /**
+   * Ids of the fields currently used in the form (null while not initialized yet).
+   * The dummy form only has to be rebuilt when these change,
+   * not when other details like a field group header are edited.
+   */
+  private readonly usedFieldIds = computed(() => {
+    if (!this.config() || !this.entityType()) {
+      return null;
+    }
+    return this.getUsedFields(this.fieldGroups())
+      .map((field) => toFormFieldConfig(field).id)
+      .join(",");
+  });
+
   constructor() {
     effect(() => {
-      const config = this.config();
-      const entityType = this.entityType();
-
-      if (!config || !entityType) {
+      if (this.usedFieldIds() === null) {
         return;
       }
 
-      void this.initForm();
+      // initForm reads several signals that must not re-trigger this effect
+      untracked(() => void this.initForm());
     });
 
     this.adminEntityService.entitySchemaUpdated


### PR DESCRIPTION
- closes #4180

Editing a field group title in the Admin UI ("Configure Datastructure") lost focus after every single character, and the view jumped down.

Three causes, all triggered by one keystroke:

1. `fieldGroups` was a `linkedSignal` that re-ran `structuredClone(config.fieldGroups)` whenever the `config` input changed. Since the component emits `configChange` on every edit and the parent feeds that straight back into `[config]`, every keystroke replaced all field group and field objects with fresh clones. The `@for` blocks track by object identity, so the whole form preview (including the focused input) was destroyed and rebuilt. The pre-signals version had an explicit guard for exactly this re-input, which was lost in the signals migration. It is now restored: the working copy is kept when the incoming config only re-states what this component emitted itself.
2. `updateGroupHeader` replaces the edited group with a new object, which changed the `track group` identity and destroyed that group's view. Field groups have no stable id, so the loop now tracks by index.
3. The effect that rebuilds the dummy form depended on the whole `config` (and, through `initForm`, on `fieldGroups` and `availableFields`). It now depends only on the ids of the fields used in the form, so editing a group header no longer rebuilds the form and re-binds every field editor.

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [x] reviewed the "Files changed" section of the PR briefly
- [x] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [x] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

1. Open the Admin UI of any entity type: Settings > Entity types > e.g. "Students" > tab "Details View".
2. Expand a section that uses the "Form" component and type a longer word into a field group's "Title" field.
   - The cursor stays in the field and the whole word is typed in one go.
   - The page does not scroll or jump while typing.
   - The fields shown in the group do not flicker / get re-rendered.
3. Leave the field, save the config, reload the page and open the same screen again: the new title is persisted.
4. Field group titles are also shown to users: open a record of that entity type and confirm the section title matches.
5. Drag & drop still works after editing a title:
   - drag a field from the "hidden fields" toolbar into a group and back out,
   - drag a field from one group into another,
   - drag a whole field group to a different position (grip handle next to the title),
   - drop a field on "drop here to create new field group" and give the new group a title.
6. Remove a group via the "x" next to its title and confirm its fields move back to the "hidden fields" toolbar.
7. Repeat step 2 in the other places that embed the same form builder: "Configure Datastructure" of a related-records section, the Note details config, and the Public Form column config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved input focus and DOM stability in the form preview when editing field group headers.
  * Avoided unnecessary form rebuilding when updated configuration is echoed back during editing.
  * Improved retention of existing field group content when incoming configuration is structurally unchanged.

* **Tests**
  * Added coverage to verify focus/DOM preservation and that form initialization is not triggered redundantly during header edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->