### PR TITLE
fix(import): resolve entity references matched through a nested entity reference

### DIFF
--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -156,6 +156,52 @@ export class EntityDatatype extends StringDatatype {
   }
 
   /**
+   * Resolve a single import value to the id of the referenced entity,
+   * looking that entity up by the property given in `additional.refField`.
+   *
+   * This is relevant when an entity reference is matched through another entity
+   * reference (e.g. import a Note's related Child, identified by the name of the
+   * user linked in the Child's "responsible user" field). The nested value has to
+   * be resolved to an id before it can be compared with the stored reference.
+   *
+   * @returns the id of the single matching entity or undefined if there is no unique match
+   */
+  override async importMapFunction(
+    val: any,
+    schemaField: EntitySchemaField,
+    additional?: any,
+    importProcessingContext?: ImportProcessingContext,
+  ): Promise<string> {
+    const config = normalizeEntityAdditional(additional);
+    if (!config?.refField || !importProcessingContext) {
+      return super.importMapFunction(
+        val,
+        schemaField,
+        additional,
+        importProcessingContext,
+      );
+    }
+
+    const match = await this.importMatchField(
+      // the caller compares against a single stored value, so never return an array here
+      { ...schemaField, isArray: false },
+      [
+        {
+          mapping: {
+            column: "",
+            propertyName: schemaField.id,
+            // the value has already been split by the calling column
+            additional: { ...config, enableSplitting: false },
+          },
+          rawCell: val,
+        },
+      ],
+      importProcessingContext,
+    );
+    return match as string;
+  }
+
+  /**
    * Build one match criterion per mapped column: the referenced field to
    * compare and the acceptable (normalized) values parsed from the column cell.
    */
@@ -182,16 +228,20 @@ export class EntityDatatype extends StringDatatype {
         mapping,
         separator,
       )) {
-        values.push(
-          await this.resolveColumnValue(
-            rawValue,
-            config.refField,
-            config.valueMapping,
-            context,
-            importProcessingContext,
-          ),
+        const value = await this.resolveColumnValue(
+          rawValue,
+          config.refField,
+          config.valueMapping,
+          context,
+          importProcessingContext,
         );
+        if (value !== undefined) {
+          values.push(value);
+        }
       }
+      // the criterion is added even if no value could be resolved:
+      // an empty list matches nothing, whereas dropping the criterion would
+      // silently relax the condition and match unrelated records
       criteria.push({ refField: config.refField, values });
     }
     return criteria;
@@ -216,6 +266,9 @@ export class EntityDatatype extends StringDatatype {
   /**
    * Resolves the effective comparison value for a column,
    * applying any configured value mapping through the referenced field's datatype.
+   *
+   * @returns the normalized value to compare against, or undefined if the value
+   *   mapping could not resolve the import value (which must match nothing)
    */
   private async resolveColumnValue(
     rawValue: any,
@@ -223,7 +276,7 @@ export class EntityDatatype extends StringDatatype {
     valueMapping: any | undefined,
     context: EntityFieldImportContext,
     importProcessingContext: ImportProcessingContext,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     if (valueMapping === undefined) {
       return normalizeValue(rawValue);
     }
@@ -243,6 +296,11 @@ export class EntityDatatype extends StringDatatype {
       valueMapping,
       importProcessingContext,
     );
+    if (mappedValue === undefined || mappedValue === null) {
+      // the import value could not be interpreted, so it cannot identify a record
+      return undefined;
+    }
+
     const dbFormat = refDatatype.transformToDatabaseFormat(
       mappedValue,
       refFieldSchema,

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -149,6 +149,50 @@ describe("Schema data type: entity (advanced functionality)", () => {
     ).resolves.toEqual(entity.getId());
   });
 
+  // Orthogonal: the matching field is itself an entity reference, so the raw
+  // import value has to be resolved to the referenced record's id before it can
+  // be compared with the candidates' stored ids.
+  // (e.g. match a Note's related Child by the Child's "responsible user", given the user's name)
+  it("should match an entity ref through a nested entity ref", async () => {
+    const supervisor = TestEntity.create({ name: "test user" });
+    const child = TestEntity.create({
+      name: "Child A",
+      ref: supervisor.getId(),
+    });
+    await entityMapper.saveAll([supervisor, child]);
+
+    await expect(
+      matchField([
+        {
+          additional: { refField: "ref", valueMapping: { refField: "name" } },
+          rawCell: "test user",
+        },
+      ]),
+    ).resolves.toEqual(child.getId());
+  });
+
+  // A nested entity ref that cannot be resolved must match nothing.
+  // Guard against resolving to an empty value instead, which would silently
+  // match every candidate that has no value in the matching field.
+  it("should not match anything if the nested entity ref cannot be resolved", async () => {
+    const supervisor = TestEntity.create({ name: "test user" });
+    // the only record without a "ref" value: must not be matched by a failed lookup
+    const child = TestEntity.create({
+      name: "Child A",
+      ref: supervisor.getId(),
+    });
+    await entityMapper.saveAll([supervisor, child]);
+
+    await expect(
+      matchField([
+        {
+          additional: { refField: "ref", valueMapping: { refField: "name" } },
+          rawCell: "not an existing user",
+        },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
   /**
    * Call importMatchField directly with the given columns mapped to `schema`
    * (a single-value entity-reference field on TestEntity).

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -805,8 +805,7 @@
                     {
                       "fields": [
                         "photo",
-                        "schoolId",
-                        "responsibleUser"
+                        "schoolId"
                       ]
                     },
                     {

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -1343,12 +1343,6 @@
           "label": "Linked School",
           "anonymize": "retain"
         },
-        "responsibleUser": {
-          "dataType": "entity",
-          "additional": "User",
-          "label": "Responsible User",
-          "anonymize": "retain"
-        },
         "center": {
           "dataType": "configurable-enum",
           "additional": "center",

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -805,7 +805,8 @@
                     {
                       "fields": [
                         "photo",
-                        "schoolId"
+                        "schoolId",
+                        "responsibleUser"
                       ]
                     },
                     {
@@ -1340,6 +1341,12 @@
           "dataType": "entity",
           "additional": "School",
           "label": "Linked School",
+          "anonymize": "retain"
+        },
+        "responsibleUser": {
+          "dataType": "entity",
+          "additional": "User",
+          "label": "Responsible User",
           "anonymize": "retain"
         },
         "center": {


### PR DESCRIPTION
Fixes #4195

## Problem

`EntityDatatype` overrides `importMatchField` but **not** `importMapFunction`. When the selected matching field is itself an `entity` field, `resolveColumnValue()` runs the raw cell through that field's datatype via `importMapFunction` — which for `EntityDatatype` falls through to the inherited `StringDatatype` implementation and just returns `String(val)`. The match criterion therefore holds the raw import value (e.g. a user name) instead of the resolved `User:…` id, and never matches the id stored on the `Child`.

## Fix

`EntityDatatype.importMapFunction` resolves a single value to the referenced record's id by delegating to its own `importMatchField`. This recurses correctly for deeper nesting and reuses the per-entity-type candidate cache in the import processing context.

A second, related problem had to be fixed along with it: when a value mapping cannot resolve a value, `normalizeValue(undefined)` produced `""`, which matches every candidate whose matching field is *empty*. The fix above makes that path reachable for entity references, so an unresolvable value would have silently linked the wrong record. Unresolvable values are now dropped from the criterion's value list while the criterion itself is kept — an empty list matches nothing rather than relaxing the condition.

## Tests

Two unit tests in `entity.datatype_advanced.spec.ts`:
- matching an entity reference through a nested entity reference (fails before the fix)
- an unresolvable nested entity reference must match nothing (guards the `""` false-match above)

## Sample config (second commit — see review comment)

The All Features config had no `entity` field on `Child` pointing at `User`, so the reported case could not be configured at all. `303b9624` adds a `responsibleUser` field to `entity:Child` and to the Child details form.

This commit is **optional** and can be dropped — see the review comment with a revert suggestion. Note that keeping it adds a visible field to the Child details form and will require updating the Argos e2e screenshots.

## Manual test

Set *Responsible User* on one or two Child records (demo data does not populate the new field), then import as `Note`:

```csv
Subject,Notes,Responsible User of Child
Follow-up call,Discussed progress with the family.,demo
Home visit,Met the family at their home.,demo-admin
Phone call,Should stay unmatched (no such user).,not-an-existing-user
```

Map `Responsible User of Child` → **Children** → *Match by Child property:* **Responsible User** → *Match by User property:* **Name**.
Rows 1 and 2 link the assigned Child records; row 3 links nothing (and must not link a Child that has no responsible user).

> `Note.relatedEntities` ("Related Records") has no `additional` entity type in the All Features config, so no "Match by … property" dropdown renders for it. `Note.children` is the equivalent `entity`/`Child` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing entity references by matching configured fields.
  * Added a “Responsible User” field to Child records in the Basic Information form.

* **Bug Fixes**
  * Improved entity matching when referenced values cannot be resolved, preventing invalid matches.
  * Enhanced nested entity reference resolution during imports.

* **Tests**
  * Added coverage for nested entity matching and unresolved reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->