### PR TITLE
fix(logging): group monitoring issues by error chain instead of stack trace

### DIFF
--- a/src/app/core/common-components/entity-form/dynamic-form-validators/dynamic-validators.service.ts
+++ b/src/app/core/common-components/entity-form/dynamic-form-validators/dynamic-validators.service.ts
@@ -122,9 +122,9 @@ export class DynamicValidatorsService {
       case "readonlyAfterSet":
         return value ? buildReadonlyValidator(entity) : null;
       default:
-        Logging.warn(
-          `Trying to generate validator ${key} but it does not exist`,
-        );
+        Logging.warn("Trying to generate a validator that does not exist", {
+          validator: key,
+        });
         return null;
     }
   }
@@ -259,11 +259,10 @@ export class DynamicValidatorsService {
       case "readonlyAfterSet":
         return validationValue;
       default:
-        Logging.error(
-          `No description defined for validator "${validator}": ${JSON.stringify(
-            validationValue,
-          )}`,
-        );
+        Logging.error("No description defined for validator", {
+          validator,
+          validationValue,
+        });
         throw $localize`Invalid input`;
     }
   }

--- a/src/app/core/config/dynamic-routing/router.service.ts
+++ b/src/app/core/config/dynamic-routing/router.service.ts
@@ -56,9 +56,10 @@ export class RouterService {
         const newRoute = this.createRoute(view, runtimePath, additionalRoutes);
         routes.push(newRoute);
       } catch (e) {
-        Logging.warn(
-          `Failed to create route for view ${view._id}: ${e instanceof Error ? e.message : e}`,
-        );
+        Logging.warn("Failed to create route for view", {
+          view: view._id,
+          error: e instanceof Error ? e.message : e,
+        });
       }
     }
 

--- a/src/app/core/config/registry/dynamic-registry.spec.ts
+++ b/src/app/core/config/registry/dynamic-registry.spec.ts
@@ -1,4 +1,9 @@
-import { Registry } from "./dynamic-registry";
+import {
+  Registry,
+  RegistryDuplicateError,
+  RegistryLookupError,
+} from "./dynamic-registry";
+import { entityRegistry } from "../../entity/database-entity.decorator";
 
 describe("DynamicRegistry", () => {
   let registry: Registry<string>;
@@ -20,5 +25,62 @@ describe("DynamicRegistry", () => {
 
     expect(() => registry.add(key, "updated value 2")).not.toThrowError();
     expect(registry.get(key)).toBe("updated value 2");
+  });
+
+  it("should name the concrete registry in errors, not the minifiable class name", () => {
+    // subclasses have to set registryName explicitly: `this.constructor.name` is
+    // minified in production, which makes remote error reports unusable
+    expect(() => entityRegistry.get("NoSuchEntityType")).toThrowError(
+      "Requested item is not registered in EntityRegistry. Key: NoSuchEntityType",
+    );
+  });
+
+  it("should throw a RegistryLookupError carrying registry and key", () => {
+    let thrown: unknown;
+    try {
+      entityRegistry.get("NoSuchEntityType");
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RegistryLookupError);
+    expect(thrown).toMatchObject({
+      registryName: "EntityRegistry",
+      key: "NoSuchEntityType",
+    });
+  });
+
+  it("should report the error type as RegistryLookupError to remote monitoring", () => {
+    // remote monitoring reads `error.name || error.constructor.name`, and a
+    // subclass inherits "Error" unless `name` is set - without it this error
+    // would silently drop out of fingerprint-based grouping in production,
+    // where the constructor name is minified too
+    const error = new RegistryLookupError("EntityRegistry", "SomeKey");
+
+    expect(error.name).toBe("RegistryLookupError");
+  });
+
+  it("should throw a RegistryDuplicateError without dumping the registered element", () => {
+    class ElementRegistry extends Registry<string> {
+      protected override readonly registryName = "ElementRegistry";
+    }
+    const elementRegistry = new ElementRegistry();
+    elementRegistry.allowDuplicates(false);
+    elementRegistry.add("key", "a very long registered element");
+
+    let thrown: unknown;
+    try {
+      elementRegistry.add("key", "other");
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RegistryDuplicateError);
+    // reaches monitoring via the bootstrap error handler, so the type has to
+    // survive minification the same way RegistryLookupError's does
+    expect((thrown as Error).name).toBe("RegistryDuplicateError");
+    expect((thrown as Error).message).toBe(
+      'ElementRegistry: Duplicate definition, "key" is already registered',
+    );
   });
 });

--- a/src/app/core/config/registry/dynamic-registry.ts
+++ b/src/app/core/config/registry/dynamic-registry.ts
@@ -1,6 +1,52 @@
 import { environment } from "../../../../environments/environment";
 
 /**
+ * Thrown when an item that the config refers to - a dynamic component, an entity
+ * type, a route - is looked up in a {@link Registry} without having been registered.
+ */
+export class RegistryLookupError extends Error {
+  constructor(
+    readonly registryName: string,
+    readonly key: string,
+  ) {
+    super(`Requested item is not registered in ${registryName}. Key: ${key}`);
+
+    // Set explicitly, and to a literal: remote monitoring reads the exception
+    // type as `error.name || error.constructor.name`. A subclass inherits
+    // "Error" from Error.prototype, so without this the error would be reported
+    // as a plain "Error" and drop out of the fingerprint-based grouping
+    // (CAUSE_GROUPED_ERROR_TYPES in logging.service.ts). The constructor name is
+    // no alternative either - it is minified in production builds.
+    this.name = "RegistryLookupError";
+  }
+}
+
+/**
+ * Thrown when the same key is registered twice in a {@link Registry},
+ * which usually means two modules define the same component or entity type.
+ *
+ * Only thrown in production builds (see {@link Registry.allowDuplicates}), where
+ * it aborts bootstrap - so it reaches remote monitoring through the top-level
+ * bootstrap error handler in `main.ts`.
+ */
+export class RegistryDuplicateError extends Error {
+  constructor(
+    readonly registryName: string,
+    readonly key: string,
+  ) {
+    // the already-registered element is deliberately not interpolated here:
+    // stringifying it dumps a whole class constructor or async import function
+    // into the message
+    super(
+      `${registryName}: Duplicate definition, "${key}" is already registered`,
+    );
+
+    // set explicitly for the same reason as in RegistryLookupError above
+    this.name = "RegistryDuplicateError";
+  }
+}
+
+/**
  * A registry is an affordance to register dynamic objects to strings.
  * It is commonly used to dynamically load entities, views or routes from the config
  *
@@ -9,6 +55,17 @@ import { environment } from "../../../../environments/environment";
  * @see EntityRegistry for an example
  */
 export abstract class Registry<T> extends Map<string, T> {
+  /**
+   * Name of this registry, used in error messages.
+   *
+   * Set explicitly by each subclass rather than read from `this.constructor.name`,
+   * which is minified in production builds. That minified name is baked into the
+   * message when the error is created, so - unlike the stack trace - source maps
+   * cannot repair it later: remote reports permanently read "not registered in u",
+   * which is neither understandable nor searchable.
+   */
+  protected readonly registryName: string = "Registry";
+
   // This controls whether the registry will throw an error when a key is added multiple times
   private failOnDuplicate = true;
 
@@ -21,13 +78,7 @@ export abstract class Registry<T> extends Map<string, T> {
   public add(key: string, mapping: T) {
     this.beforeAddCheck?.(key, mapping);
     if (this.has(key) && this.failOnDuplicate) {
-      throw Error(
-        `${
-          this.constructor.name
-        }: Duplicate entity definition: ${key} is already registered with element ${this.get(
-          key,
-        )}`,
-      );
+      throw new RegistryDuplicateError(this.registryName, key);
     }
     this.set(key, mapping);
   }
@@ -38,9 +89,11 @@ export abstract class Registry<T> extends Map<string, T> {
 
   public override get(key: string): T {
     if (!this.has(key)) {
-      throw Error(
-        `Requested item is not registered in ${this.constructor.name}. Key: ${key}`,
-      );
+      // A missing registration is one problem no matter which component, pipe or
+      // route hit it first. The dedicated error type lets remote monitoring group
+      // it by registry and key instead of by stack trace, which otherwise opens a
+      // separate issue per call site (see CAUSE_GROUPED_ERROR_TYPES).
+      throw new RegistryLookupError(this.registryName, key);
       // To register a component, add @DynamicComponent("COMPONENTNAME") to the components .ts-file and implement the onInitFromDynamicConfig method, e.g. onInitFromDynamicConfig(config: any) {}
     }
     return super.get(key);

--- a/src/app/core/database/indexeddb-migration.service.ts
+++ b/src/app/core/database/indexeddb-migration.service.ts
@@ -181,10 +181,10 @@ export class IndexeddbMigrationService {
         checkBothComplete();
       })
       .catch((err) => {
-        Logging.warn(
-          `IndexeddbMigration: replication into "${newDbName}" failed`,
-          err,
-        );
+        Logging.warn("IndexeddbMigration: replication into new db failed", {
+          newDbName,
+          error: err,
+        });
         newDb.close();
       });
 
@@ -325,10 +325,11 @@ export class IndexeddbMigrationService {
             `IndexeddbMigration: deleted legacy ${key} database "${dbInfo.name}"`,
           );
         } catch (e) {
-          Logging.warn(
-            `IndexeddbMigration: failed to delete legacy ${key} database "${dbInfo.name}"`,
-            e,
-          );
+          Logging.warn("IndexeddbMigration: failed to delete legacy database", {
+            key,
+            database: dbInfo.name,
+            error: e,
+          });
         }
       }
     }
@@ -349,7 +350,8 @@ export class IndexeddbMigrationService {
       req.onerror = () => reject(req.error);
       req.onblocked = () => {
         Logging.warn(
-          `IndexeddbMigration: deletion of "${name}" is blocked by open connections; resolving anyway`,
+          "IndexeddbMigration: deletion is blocked by open connections; resolving anyway",
+          { database: name },
         );
         // Deletion will proceed once connections close; treat as non-fatal.
         resolve();

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -500,10 +500,11 @@ export class PouchDatabase extends Database {
       newObject._rev = existingObject._rev;
       return this.put(newObject);
     } else {
-      // only include the document's ID here: the full document would leak
-      // record contents into logs and fragment Sentry grouping per document
-      existingError.message = `${existingError.message} (unable to resolve) ID: ${newObject._id}`;
-      throw new DatabaseException(existingError);
+      // the document's ID is passed as entityId rather than appended to the
+      // message: remote monitoring groups by message, so an ID in there would
+      // fragment one recurring problem into a separate issue per document
+      existingError.message = `${existingError.message} (unable to resolve)`;
+      throw new DatabaseException(existingError, newObject._id);
     }
   }
 

--- a/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.ts
+++ b/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.ts
@@ -47,8 +47,8 @@ export class EntityActionsMenuService {
       } catch (err) {
         // a single misbehaving action must not break the whole context menu
         Logging.warn(
-          `EntityActionsMenu: visibility check for action "${action.action}" failed; hiding it.`,
-          err,
+          "EntityActionsMenu: visibility check for action failed; hiding it.",
+          { action: action.action, error: err },
         );
         isVisible = false;
       }

--- a/src/app/core/entity/database-entity.decorator.ts
+++ b/src/app/core/entity/database-entity.decorator.ts
@@ -3,6 +3,8 @@ import { Registry } from "../config/registry/dynamic-registry";
 import { getEntitySchema } from "./database-field.decorator";
 
 export class EntityRegistry extends Registry<EntityConstructor> {
+  protected override readonly registryName = "EntityRegistry";
+
   /**
    * Get an array of entity types, optionally filtered to exclude internal, administrative types.
    * @param onlyUserFacing Whether to only include types that are explicitly defined and customized in the config, from which we infer they are user-facing.

--- a/src/app/core/export/download-service/download.service.ts
+++ b/src/app/core/export/download-service/download.service.ts
@@ -136,7 +136,7 @@ export class DownloadService {
       case "zip":
         return new Blob([data], { type: "application/zip" });
       default:
-        Logging.warn(`Not supported format: ${format}`);
+        Logging.warn("Export format not supported", { format });
         return new Blob([""]);
     }
   }

--- a/src/app/core/language/language.module.ts
+++ b/src/app/core/language/language.module.ts
@@ -41,9 +41,9 @@ export class LanguageModule {
         },
       });
     } catch (e) {
-      Logging.warn(
-        `Could not determine first day of week for locale "${locale}".`,
-      );
+      Logging.warn("Could not determine first day of week for locale", {
+        locale,
+      });
     }
   }
 }

--- a/src/app/core/logging/README.md
+++ b/src/app/core/logging/README.md
@@ -23,10 +23,72 @@ that control whether log messages are sent to the remote monitoring and how they
 ## Remote Logging
 
 Higher log levels (`warn` and `error`) are forwarded to our remote monitoring service, [Sentry](https://sentry.io/).
+
+### Keep message strings static
+
 How messages are grouped there depends on the (static) message text, so keep `Logging.warn()` / `Logging.error()`
-message strings constant and pass variable data as additional context arguments.
+message strings constant and pass variable data as additional context arguments:
+
+```ts
+// don't - one separate issue per entity type, and the details are lost from the title
+Logging.warn(`Config references unknown entity type "${config.entity}"`);
+
+// do - one issue for the problem, details available in the event's "context"
+Logging.warn("Config references an unknown entity type", {
+  entityType: config.entity,
+});
+```
+
+For thrown `Error`s, which reach the monitoring through Angular's `ErrorHandler`, whether the message
+affects grouping depends on whether the error type is fingerprinted — see below. Either way it is the
+issue title, so the readability rule always applies. Never interpolate `this.constructor.name` into
+one: it is minified in production, and because the message is built when the error is created, source
+maps cannot repair it the way they repair a stack trace. Such a report permanently reads
+`not registered in u`.
+
+### Grouping by error chain
+
+Sentry groups errors **by their stack trace** whenever one is available — the exception message is not
+part of the grouping key then. (You can confirm this on any issue that holds events with several
+different `error.value`s.) So for a thrown error, rewording the message changes the issue title but
+never splits or merges issues; only a fingerprint does.
+
+Stack-based grouping is counterproductive for our own wrapper error classes (`DatabaseException`,
+`ConfigLoadError`, ...): they are thrown from one central place but reached from many components and
+routes, so a single problem scatters across a dozen issues - and archiving one of them does not
+silence the others.
+
+`processSentryEvent` (the `beforeSend` hook) therefore sets an explicit `fingerprint` for the error types
+listed in `CAUSE_GROUPED_ERROR_TYPES`, built from the thrown error plus its root cause instead of the stack.
+Ids, URLs and numbers are masked so that occurrences of the same problem match. The route stays available
+as the `transaction` tag, so failures can still be filtered by where they happened.
+
+When adding a new error type, add its name to `CAUSE_GROUPED_ERROR_TYPES`. What Sentry reports as the
+exception type is `error.name || error.constructor.name`, so the name has to be set explicitly and to
+a literal — an `Error` subclass otherwise inherits `"Error"` from `Error.prototype` and would silently
+fall out of this list, and the constructor name is minified. Both the dedicated classes
+(`RegistryLookupError`) and the plain errors that just set `error.name` (`ConfigLoadError`) do this.
+
+Fingerprinting inverts the message rule stated above: once an error is fingerprinted its message _is_
+part of the grouping key, so whatever stays in it becomes a deliberate grouping dimension. Interpolate
+a value there only when both hold:
+
+- its cardinality is **bounded** — a component name or entity type, not a user id, URL or document revision;
+- each distinct value is a **separately actionable bug**, so a separate issue is what you want.
+
+`RegistryLookupError` and `RegistryDuplicateError` keep the registry name and the requested key in
+their message on exactly that basis: a missing `Event` component and a missing `Child` entity are
+separate problems to fix, while everything they had in common — which component, pipe or route
+happened to trigger the lookup — is what the fingerprint now collapses. Note that values are still
+normalized, so keys differing only in digits would collide.
+
+Generic errors (`Error`, `TypeError`, ...) must keep the default grouping - for those the stack trace
+is the only thing telling two unrelated bugs apart.
+
+Note that changing a fingerprint does not re-group events already in Sentry: existing issues stay as they
+are and the new grouping applies to events reported from then on.
 
 ## Key files
 
-- `logging.service.ts` — `LoggingService` and the `Logging` singleton (`export const Logging = new LoggingService()`); implements the log levels and Sentry forwarding
+- `logging.service.ts` — `LoggingService` and the `Logging` singleton (`export const Logging = new LoggingService()`); implements the log levels, Sentry forwarding and the `beforeSend` filtering/grouping
 - `log-level.ts` — the `LogLevel` definitions

--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -121,6 +121,151 @@ describe("LoggingService", () => {
       expect(processSentryEvent(messageEvent(), {})).toBeNull();
     });
 
+    describe("grouping fingerprint", () => {
+      const chainedEvent = (
+        rootCause: { type: string; value: string },
+        thrown: { type: string; value: string },
+      ) =>
+        ({
+          // Sentry orders the chain innermost-first: the thrown error is last
+          exception: { values: [rootCause, thrown] },
+        }) as any;
+
+      it("should group our wrapper errors by thrown error and root cause", () => {
+        const event = processSentryEvent(
+          chainedEvent(
+            { type: "DatabaseException", value: "Failed to fetch from DB" },
+            {
+              type: "ConfigLoadError",
+              value: "Failed to load configuration from the database.",
+            },
+          ),
+          {},
+        );
+
+        expect(event.fingerprint).toEqual([
+          "ConfigLoadError",
+          "Failed to load configuration from the database.",
+          "DatabaseException",
+          "Failed to fetch from DB",
+        ]);
+      });
+
+      it("should give the same wrapper error a different fingerprint per root cause", () => {
+        const offline = processSentryEvent(
+          chainedEvent(
+            { type: "DatabaseException", value: "Failed to fetch from DB" },
+            { type: "ConfigLoadError", value: "Failed to load configuration." },
+          ),
+          {},
+        );
+        const unauthorized = processSentryEvent(
+          chainedEvent(
+            { type: "DatabaseException", value: "unauthorized" },
+            { type: "ConfigLoadError", value: "Failed to load configuration." },
+          ),
+          {},
+        );
+
+        expect(offline.fingerprint).not.toEqual(unauthorized.fingerprint);
+      });
+
+      it("should mask ids, urls and numbers so the same problem matches", () => {
+        const withId = processSentryEvent(
+          {
+            exception: {
+              values: [
+                {
+                  type: "DatabaseException",
+                  value:
+                    'Document update conflict. ID: "8f2b1c7e-1234-4a5b-9c8d-0e1f2a3b4c5d"',
+                },
+              ],
+            },
+          } as any,
+          {},
+        );
+        const withOtherId = processSentryEvent(
+          {
+            exception: {
+              values: [
+                {
+                  type: "DatabaseException",
+                  value:
+                    'Document update conflict. ID: "1a2b3c4d-9999-4eee-8fff-abcdef012345"',
+                },
+              ],
+            },
+          } as any,
+          {},
+        );
+
+        expect(withId.fingerprint).toEqual(withOtherId.fingerprint);
+      });
+
+      it("should give a self-wrapping error the same fingerprint as the unwrapped one", () => {
+        const cause = {
+          type: "DatabaseException",
+          value: "database is destroyed",
+        };
+
+        const unwrapped = processSentryEvent(
+          { exception: { values: [cause] } } as any,
+          {},
+        );
+        const selfWrapped = processSentryEvent(
+          chainedEvent({ ...cause }, { ...cause }),
+          {},
+        );
+
+        expect(selfWrapped.fingerprint).toEqual(unwrapped.fingerprint);
+      });
+
+      it("should group a registry lookup by key, not by the call site's stack", () => {
+        const lookupEvent = (key: string) =>
+          ({
+            exception: {
+              values: [
+                {
+                  type: "RegistryLookupError",
+                  value: `Requested item is not registered in EntityRegistry. Key: ${key}`,
+                },
+              ],
+            },
+          }) as any;
+
+        const fromPipe = processSentryEvent(lookupEvent("Event"), {});
+        const fromImport = processSentryEvent(lookupEvent("Event"), {});
+        const otherKey = processSentryEvent(lookupEvent("Child"), {});
+
+        expect(fromPipe.fingerprint).toEqual(fromImport.fingerprint);
+        // a different missing registration is a different problem to fix
+        expect(otherKey.fingerprint).not.toEqual(fromPipe.fingerprint);
+      });
+
+      it("should not fingerprint generic errors, keeping Sentry's stack-based grouping", () => {
+        const event = processSentryEvent(
+          {
+            exception: {
+              values: [{ type: "TypeError", value: "x is not a function" }],
+            },
+          } as any,
+          {},
+        );
+
+        expect(event.fingerprint).toBeUndefined();
+      });
+
+      it("should not fingerprint message-only events", () => {
+        const event = processSentryEvent(
+          { message: "some static warning" } as any,
+          {},
+        );
+
+        expect(event.fingerprint).toBeUndefined();
+      });
+    });
+
     describe("offline network errors", () => {
       afterEach(() => vi.unstubAllGlobals());
 

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -307,7 +307,8 @@ const NETWORK_ERROR_PATTERNS = [
 /**
  * Sentry `beforeSend` hook: drops network failures of offline devices
  * and excessive repeats of an identical event,
- * and enriches the remaining events with structured extra data.
+ * and enriches the remaining events with structured extra data
+ * and a stable grouping fingerprint.
  */
 export function processSentryEvent(
   event: Sentry.ErrorEvent,
@@ -316,7 +317,7 @@ export function processSentryEvent(
   if (isOfflineNetworkError(event) || isExcessiveRepeat(event)) {
     return null;
   }
-  return enrichSentryEvent(event, hint);
+  return fingerprintSentryEvent(enrichSentryEvent(event, hint));
 }
 
 /**
@@ -341,23 +342,23 @@ function isOfflineNetworkError(event: Sentry.ErrorEvent): boolean {
 /**
  * Count occurrences of an event and check whether it exceeded the session cap.
  *
- * The key is deliberately coarse: error class + message of the root cause
- * (`values[0]` is the deepest `cause` in the chain; the originally thrown,
+ * The key is deliberately coarse: error class + normalized message of the root
+ * cause (`values[0]` is the deepest `cause` in the chain; the originally thrown,
  * outermost error is last), without any stack information.
  * Consequences:
  * - Same-message errors from different code paths share one budget,
  *   and all wrappers of a cascading failure are capped via their common
  *   root cause. This is a flood guard, not a grouping mechanism -
- *   Sentry's server-side, stack-based grouping remains authoritative
- *   for separating issues, and the first occurrences always get through.
- * - Errors that interpolate data (e.g. entity IDs) into their message
- *   get a separate budget per variant, so the cap is weaker for those.
+ *   see {@link fingerprintSentryEvent} for how issues are separated.
+ * - Errors that interpolate data (e.g. entity IDs) into their message still
+ *   share one budget, because the key is normalized the same way as the
+ *   grouping fingerprint.
  */
 function isExcessiveRepeat(event: Sentry.ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
   const key = exception
-    ? `${exception.type}: ${exception.value}`
-    : String(event.message ?? "unknown");
+    ? `${exception.type}: ${normalizeErrorValue(exception.value)}`
+    : normalizeErrorValue(String(event.message ?? "unknown"));
 
   const count = (sentryEventCounts.get(key) ?? 0) + 1;
   sentryEventCounts.set(key, count);
@@ -373,13 +374,113 @@ function isExcessiveRepeat(event: Sentry.ErrorEvent): boolean {
 }
 
 /**
+ * Our own error classes that describe *what* failed precisely enough that all
+ * their occurrences belong into a single issue in remote monitoring,
+ * no matter which component, route or async call site ran into them.
+ *
+ * For these, Sentry's default grouping by stack trace actively hurts: they are
+ * thrown from one central place, while the stack differs per caller and even
+ * per build (releases without source maps report minified frames). One problem
+ * then scatters across a dozen issues that each have to be triaged separately,
+ * and archiving one of them does not silence the others.
+ *
+ * Only add error types whose name and message already identify the problem on
+ * their own, so that the stack adds nothing but noise. Generic errors (`Error`,
+ * `TypeError`, ...) must keep the default grouping - for those the stack trace
+ * is the only thing telling two unrelated bugs apart.
+ */
+const CAUSE_GROUPED_ERROR_TYPES = [
+  "DatabaseException",
+  "ConfigLoadError",
+  "PermissionRulesLoadError",
+  "SiteSettingsLoadError",
+  "RegistryLookupError",
+  "RegistryDuplicateError",
+];
+
+/**
+ * Data that varies between occurrences of the same problem and therefore has to
+ * be masked before an error message can be used as a grouping key.
+ * Order matters: the more specific patterns have to run before the plain number.
+ */
+const VOLATILE_VALUE_PATTERNS: [RegExp, string][] = [
+  [/https?:\/\/\S+/gi, "<url>"],
+  [
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+    "<uuid>",
+  ],
+  [/\b\d+-[0-9a-f]{32}\b/gi, "<rev>"],
+  [/\d+/g, "<n>"],
+];
+
+/**
+ * Mask volatile details (ids, urls, numbers) so that different occurrences of
+ * the same problem produce the same string.
+ */
+function normalizeErrorValue(value: string | undefined): string {
+  if (!value) {
+    return "<none>";
+  }
+  return VOLATILE_VALUE_PATTERNS.reduce(
+    (normalized, [pattern, placeholder]) =>
+      normalized.replace(pattern, placeholder),
+    value,
+  );
+}
+
+/**
+ * Group events of our own wrapper error classes (see
+ * {@link CAUSE_GROUPED_ERROR_TYPES}) by their error chain instead of by stack
+ * trace, so that one problem shows up as one issue.
+ *
+ * `exception.values` is ordered innermost-first: `values[0]` is the deepest
+ * `cause`, the originally thrown error is last. Both ends matter - the thrown
+ * error says which operation failed, the root cause says why (e.g. a config
+ * load failing because the device is offline is a different problem from the
+ * same load failing because the user is unauthorized).
+ *
+ * The route remains available as the `transaction` tag, so a failure can still
+ * be filtered by where it happened without splitting it into separate issues.
+ */
+function fingerprintSentryEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  const values = event.exception?.values;
+  if (!values?.length) {
+    // captureMessage events group by their message,
+    // which is kept free of variable data by convention
+    return event;
+  }
+
+  const thrownError = values[values.length - 1];
+  const thrownType = thrownError.type ?? "";
+  if (!CAUSE_GROUPED_ERROR_TYPES.includes(thrownType)) {
+    return event;
+  }
+
+  const thrownValue = normalizeErrorValue(thrownError.value);
+  const fingerprint = [thrownType, thrownValue];
+
+  const rootCause = values[0];
+  const rootType = rootCause.type ?? "";
+  const rootValue = normalizeErrorValue(rootCause.value);
+  // compared by content, not by identity: an error wrapping another error of
+  // the same type and message describes one failure, not two, and has to match
+  // the fingerprint of the same failure reported without the extra wrapper
+  if (rootType !== thrownType || rootValue !== thrownValue) {
+    fingerprint.push(rootType, rootValue);
+  }
+
+  event.fingerprint = fingerprint;
+  return event;
+}
+
+/**
  * Enrich events with structured extra data
  * from custom Error properties (e.g. DatabaseException's entityId, status, reason).
  */
 function enrichSentryEvent(
   event: Sentry.ErrorEvent,
   hint: Sentry.EventHint,
-): Sentry.ErrorEvent | null {
+): Sentry.ErrorEvent {
   // Attach structured properties from custom Error subclasses (e.g. DatabaseException)
   // so that details like entityId, status, reason are visible in Sentry's "Additional Data"
   const err = hint.originalException;

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -113,9 +113,9 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
 
     if (rawUserRules.length === 0 && sessionInfo) {
       // No rules or only default rules defined
-      Logging.warn(
-        `no rules found for user "${sessionInfo.name}" with roles "${sessionInfo.roles}"`,
-      );
+      Logging.warn("No permission rules found for user", {
+        roles: sessionInfo.roles,
+      });
     }
 
     return rawUserRules;
@@ -157,9 +157,9 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
 
       if (!has(dynamicPlaceholders, name)) {
         // log instead of silent failure
-        Logging.warn(
-          `Variable ${name} is not defined for user ${sessionInfo.id}`,
-        );
+        Logging.warn("Rule variable is not defined for user", {
+          variable: name,
+        });
         return AbilityService.USER_PROPERTY_UNDEFINED;
       }
 

--- a/src/app/core/setup/setup.service.ts
+++ b/src/app/core/setup/setup.service.ts
@@ -79,7 +79,7 @@ export class SetupService {
         ),
     );
     if (!entries) {
-      Logging.warn("Failed to load config descriptor: " + url);
+      Logging.warn("Failed to load config descriptor", { url });
       return [];
     }
     return asArray(entries).map((entry) => ({ ...entry, baseUrl }));

--- a/src/app/core/site-settings/site-settings.service.ts
+++ b/src/app/core/site-settings/site-settings.service.ts
@@ -96,9 +96,9 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
       ) {
         return;
       }
-      Logging.warn(
-        `SiteSettingsService: anonymous fetch returned status ${response.status}`,
-      );
+      Logging.warn("SiteSettingsService: anonymous fetch failed", {
+        status: response.status,
+      });
       return;
     }
 
@@ -199,10 +199,11 @@ export class SiteSettingsService extends LatestEntityLoader<SiteSettings> {
             ),
           );
         } catch (e) {
-          Logging.warn(
-            `SiteSettingsService: invalid color value for "${property}": ${color}`,
-            e,
-          );
+          Logging.warn("SiteSettingsService: invalid color value", {
+            property,
+            color,
+            error: e,
+          });
         }
       }
     });

--- a/src/app/core/ui/latest-changes/update-manager.service.spec.ts
+++ b/src/app/core/ui/latest-changes/update-manager.service.spec.ts
@@ -228,7 +228,8 @@ describe("UpdateManagerService", () => {
     });
 
     expect(Logging.error).toHaveBeenCalledWith(
-      expect.stringContaining("ERROR REASON"),
+      "App is in unrecoverable state",
+      { reason: "ERROR REASON" },
     );
     expect(mockLocation.reload).toHaveBeenCalled();
   });

--- a/src/app/core/ui/latest-changes/update-manager.service.ts
+++ b/src/app/core/ui/latest-changes/update-manager.service.ts
@@ -29,7 +29,7 @@ export class UpdateManagerService {
 
   constructor() {
     this.updates.unrecoverable.subscribe((err) => {
-      Logging.error("App is in unrecoverable state: " + err.reason);
+      Logging.error("App is in unrecoverable state", { reason: err.reason });
       this.location.reload();
     });
     const currentVersion = this.localStorage.getItem(
@@ -120,7 +120,7 @@ export class UpdateManagerService {
     }
 
     this.updates.unrecoverable.subscribe(({ reason }) => {
-      Logging.warn(`SW in unrecoverable state: ${reason}`);
+      Logging.warn("SW in unrecoverable state", { reason });
       this.snackBar
         .open(
           $localize`The app is in a unrecoverable state, please reload.`,

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.ts
@@ -292,7 +292,10 @@ export class KeycloakAdminService extends UserAdminService {
             })),
             catchError((error) => {
               // Log the error but don't fail the entire operation
-              Logging.warn(`Failed to fetch roles for user ${user.id}`, error);
+              Logging.warn("Failed to fetch roles for user", {
+                userId: user.id,
+                error,
+              });
               // Return user without roles
               return of({
                 id: user.id,

--- a/src/app/dynamic-components.ts
+++ b/src/app/dynamic-components.ts
@@ -6,7 +6,9 @@ export type AsyncComponent = () => Promise<Type<any>>;
 /**
  * This registry hold all the loading functions for components that can be used dynamically with lazy loading.
  */
-export class ComponentRegistry extends Registry<AsyncComponent> {}
+export class ComponentRegistry extends Registry<AsyncComponent> {
+  protected override readonly registryName = "ComponentRegistry";
+}
 
 // TODO make a build script that looks for annotations and creates this
 export const componentRegistry = new ComponentRegistry();

--- a/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
+++ b/src/app/features/attendance/add-day-attendance/roll-call/roll-call.component.ts
@@ -256,7 +256,7 @@ export class RollCallComponent {
       const entity = await this.entityMapper.load(entityType, id);
       event = this.attendanceService.wrapEventEntity(entity);
     } catch (e) {
-      Logging.warn("Could not load event " + id, e);
+      Logging.warn("Could not load event", { eventId: id, error: e });
       void this.router.navigate(["/404"]);
       return undefined;
     }

--- a/src/app/features/attendance/attendance.service.ts
+++ b/src/app/features/attendance/attendance.service.ts
@@ -73,8 +73,9 @@ export class AttendanceService {
           typeConfig.dateField ?? DateDatatype.detectFieldInEntity(eventType);
         if (!resolvedDateField) {
           Logging.warn(
-            `[AttendanceService] No date field found for event type "${eventTypeName}". ` +
+            `[AttendanceService] No date field found for an event type. ` +
               `Set "dateField" in the attendance config or add a @DatabaseField with dataType "date" to the entity.`,
+            { eventType: eventTypeName },
           );
         }
 

--- a/src/app/features/file/edit-file/edit-file.component.ts
+++ b/src/app/features/file/edit-file/edit-file.component.ts
@@ -161,7 +161,10 @@ export class EditFileComponent
     } else if (err instanceof NotAvailableOfflineError) {
       errorMessage = $localize`:File Upload Error Message:Changes to file attachments are not available offline.`;
     } else {
-      Logging.error("Failed to update file: " + JSON.stringify(err));
+      Logging.error("Failed to update file", {
+        status: err?.status,
+        message: err?.message,
+      });
       errorMessage = $localize`:File Upload Error Message:Failed to update file attachment. Please try again.`;
     }
     this.alertService.addDanger(errorMessage);

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
@@ -253,9 +253,11 @@ export class MatchingEntitiesComponent implements OnInit {
       const records = await this.entityMapper
         .loadType(newSide.entityType)
         .catch((err) => {
-          Logging.error(
-            `Failed to initialize entities (${newSide.entityType}) for matching side ${sideIndex}. Reasons: ${err}`,
-          );
+          Logging.error("Failed to initialize entities for matching side", {
+            entityType: newSide.entityType,
+            sideIndex,
+            error: err,
+          });
           return [];
         });
       newSide.dataSource.allRecords.set(records);

--- a/src/app/features/notification/notification-settings/notification-settings.component.ts
+++ b/src/app/features/notification/notification-settings/notification-settings.component.ts
@@ -273,7 +273,9 @@ export class NotificationSettingsComponent {
    */
   testNotification() {
     this.notificationService.testNotification().catch((reason) => {
-      Logging.error("Could not send test notification: " + reason.message);
+      Logging.error("Could not send test notification", {
+        reason: reason.message,
+      });
     });
   }
 }

--- a/src/app/features/public-form/public-forms.service.ts
+++ b/src/app/features/public-form/public-forms.service.ts
@@ -196,7 +196,8 @@ export class PublicFormsService {
 
     if (!this.entities.has(formConfig.entity)) {
       Logging.warn(
-        `PublicForm config references unknown entity type "${formConfig.entity}" — skipping. Check this PublicFormConfig.`,
+        "PublicForm config references an unknown entity type — skipping. Check this PublicFormConfig.",
+        { entityType: formConfig.entity },
       );
       return [];
     }


### PR DESCRIPTION
## Problem

A single production problem is currently scattered across many monitoring issues, so triage
repeats the same work every week — and archiving one of them does not silence the others.
Aggregating the last 30 days of events by exception chain rather than by issue:

| chain signature | distinct issues | events |
| --- | --- | --- |
| `DatabaseException` (unwrapped) | 14 | 1031 |
| `Error` | 31 | 301 |
| `DatabaseException` → `Error` | 11 | 159 |
| `DatabaseException` → `ConfigLoadError` | 6 | 216 |
| `DatabaseException` → `SiteSettingsLoadError` | 2 | 15 |

**Sentry groups an exception by its stack trace whenever one is available, and ignores the
message.** (Visible on any issue holding events with several different `error.value`s — the
archived `DatabaseException` issue holds three.) Our wrapper errors are thrown from one central
place but reached from many components, routes and async call sites, so the stack differs per
caller — and per build, since releases without source maps report minified frames.
[AAM-DIGITAL-731](https://aam-digital.sentry.io/issues/AAM-DIGITAL-731) and
[72E](https://aam-digital.sentry.io/issues/AAM-DIGITAL-72E) have an identical error chain and
overlapping releases, yet are separate issues; one renders symbolicated, the other minified. At
the same time 731 lumps two different root causes together, and
[735](https://aam-digital.sentry.io/issues/AAM-DIGITAL-735) — an `unauthorized` failure, a
genuine problem rather than offline noise — is indistinguishable by title from its neighbours.

Separately, `Logging.warn`/`Logging.error` messages *are* grouped by their text, because they go
through `captureMessage`. Interpolating an id, URL or status code into one splits the problem per
value and puts record content into issue titles.

## Changes

- `beforeSend` sets an explicit `fingerprint` for our own wrapper error classes
  (`CAUSE_GROUPED_ERROR_TYPES`), built from the thrown error plus its root cause with ids, URLs
  and numbers masked. The thrown error says which operation failed, the root cause says why — so
  offline and unauthorized config failures separate, while the same failure reported from ten
  different screens collapses into one issue.
- The route stays available as the `transaction` tag, so failures can still be filtered by where
  they happened without splitting the issue.
- The session repeat cap reuses the same normalization, so errors interpolating ids no longer get
  a separate flood budget per variant.
- The registry gets dedicated `RegistryLookupError` and `RegistryDuplicateError` classes,
  following `DatabaseException` and `EntityPermissionError`. A missing registration is one problem
  no matter which component or pipe hit it first, but today it opens an issue per call site (73Y on
  `/import/` and 6YW on `/` are the same missing-registration bug). Both set `this.name` to a
  literal — Sentry derives the exception type as `error.name || error.constructor.name`, and a
  subclass otherwise inherits `"Error"` from `Error.prototype`, which would silently drop them out
  of the fingerprint list while the constructor name would be minified. Specs lock that. Their
  messages deliberately keep the requested key — for a fingerprinted error the message *is* part of
  the grouping key, and a missing `Event` component is a different fix from a missing `Child`
  entity. The duplicate-registration message also no longer interpolates the registered element,
  which stringified a whole class constructor or async import function.
- Registries take an explicit `registryName`. This is a **readability** fix, not a grouping one:
  the minified class name is baked into the message when the error is constructed, so unlike a
  stack frame source maps can never repair it and the report permanently reads
  `not registered in u`.
- All `Logging.warn`/`Logging.error` call sites move interpolated values into the context
  argument, including a JSON-stringified HTTP error response that was being dumped into a title.
- The conflicting document's ID is passed as `entityId` — already surfaced as structured extra
  data — rather than appended to the message.
- Convention and rationale documented in `src/app/core/logging/README.md`.

## Deliberate limitations

- **Generic errors keep the default grouping.** `["DatabaseException", "Error"]` (11 issues) stays
  split, because only the *thrown* type is matched and it is a plain `Error` there. For generic
  errors the stack trace is the only thing telling two unrelated bugs apart, so fingerprinting
  them would merge real distinct problems.
- Inconsistent symbolication contributes to the splitting; the sourcemap upload failing on release
  tags is tracked separately and not addressed here.
- `replication-backend` has the same pattern on the message side; handled in
  Aam-Digital/replication-backend#302.

## After deploying

Changing a fingerprint does **not** re-group events already in Sentry. Existing issues stop
receiving events and the merged clusters show up as new, unresolved, high-volume issues — the
already-archived `DatabaseException` issue among them. They need to be archived once more after
the first release containing this.

## Testing

- New specs cover the fingerprint for chained errors, root-cause separation, id/URL masking,
  self-wrapping errors matching their unwrapped form, registry lookups grouping by key rather than
  call site, and generic and message-only events keeping the default grouping.
- Specs lock the registry name, the `RegistryLookupError` name, and the duplicate-key message.
- Full unit suite: 2435 passed, 21 skipped. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


