### PR TITLE
feat(import): let user review value mapping config of every mapped column

### DIFF
--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -61,9 +61,13 @@ test("Import children with entity reference, date and enum column mappings", asy
 
   // --- "Name" column is auto-mapped to "Name" field ---
   // --- "Date of Birth" column is auto-mapped to "Date of birth" field ---
-  // Every mapped column that requires configuration gets its dialog opened
-  // automatically in column order, so the date format for "Date of Birth" comes up
-  // first, followed by the value mapping for "Gender".
+  // Automatically mapped columns keep their dialog closed and are only marked as
+  // unconfigured, so the date format has to be opened from the row itself.
+  const dobRow = page
+    .locator("app-edit-import-column-mapping")
+    .filter({ hasText: "Date of Birth" });
+  await dobRow.getByRole("button", { name: "Configure value mapping" }).click();
+
   const dateDialog = page.getByRole("dialog");
   await expect(dateDialog.getByLabel("Date format")).toBeVisible();
 
@@ -76,9 +80,17 @@ test("Import children with entity reference, date and enum column mappings", asy
   await argosScreenshot(page, "import-date-format-dialog");
 
   await dateDialog.getByRole("button", { name: "Save & Close" }).click();
+  await expect(dateDialog).not.toBeVisible();
 
   // --- "Gender" column is auto-mapped to "Gender" field (configurable-enum) ---
-  // its value mapping dialog follows right after the date format dialog was closed
+  // Configure enum value mapping
+  const genderRow = page
+    .locator("app-edit-import-column-mapping")
+    .filter({ hasText: "Gender" });
+  await genderRow
+    .getByRole("button", { name: "Configure value mapping" })
+    .click();
+
   const enumDialog = page.getByRole("dialog");
   await expect(enumDialog.getByText("Imported values")).toBeVisible();
 

--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -61,14 +61,11 @@ test("Import children with entity reference, date and enum column mappings", asy
 
   // --- "Name" column is auto-mapped to "Name" field ---
   // --- "Date of Birth" column is auto-mapped to "Date of birth" field ---
-  // Configure date format for the Date of Birth column
-  const dobRow = page
-    .locator("app-edit-import-column-mapping")
-    .filter({ hasText: "Date of Birth" });
-  await dobRow.getByRole("button", { name: "Configure value mapping" }).click();
-
+  // Every mapped column that requires configuration gets its dialog opened
+  // automatically in column order, so the date format for "Date of Birth" comes up
+  // first, followed by the value mapping for "Gender".
   const dateDialog = page.getByRole("dialog");
-  await expect(dateDialog).toBeVisible();
+  await expect(dateDialog.getByLabel("Date format")).toBeVisible();
 
   // Enter the date format matching our CSV data
   await dateDialog.getByLabel("Date format").fill("DD.MM.YYYY");
@@ -79,19 +76,10 @@ test("Import children with entity reference, date and enum column mappings", asy
   await argosScreenshot(page, "import-date-format-dialog");
 
   await dateDialog.getByRole("button", { name: "Save & Close" }).click();
-  await expect(dateDialog).not.toBeVisible();
 
   // --- "Gender" column is auto-mapped to "Gender" field (configurable-enum) ---
-  // Configure enum value mapping
-  const genderRow = page
-    .locator("app-edit-import-column-mapping")
-    .filter({ hasText: "Gender" });
-  await genderRow
-    .getByRole("button", { name: "Configure value mapping" })
-    .click();
-
+  // its value mapping dialog follows right after the date format dialog was closed
   const enumDialog = page.getByRole("dialog");
-  await expect(enumDialog).toBeVisible();
   await expect(enumDialog.getByText("Imported values")).toBeVisible();
 
   // Map each imported gender value to the system's enum values

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.html
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.html
@@ -3,6 +3,10 @@
   mat-stroked-button
   (click)="openConfig()"
   i18n="import - column mapping - configure date format button"
+  [matBadge]="badge()"
+  [matBadgeHidden]="!badge()"
+  matBadgeColor="warn"
+  [matTooltip]="tooltip()"
 >
   Configure value mapping
 </button>

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
@@ -33,6 +33,25 @@ describe("DateImportConfigComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  it("should mark the column as not configured until a date format is set", () => {
+    fixture.componentRef.setInput("col", {
+      column: "date",
+      propertyName: "dateOfBirth",
+    });
+
+    expect(component.badge()).toBe("?");
+    expect(component.tooltip()).toContain("No date format");
+
+    fixture.componentRef.setInput("col", {
+      column: "date",
+      propertyName: "dateOfBirth",
+      additional: "DD.MM.YYYY",
+    });
+
+    expect(component.badge()).toBeUndefined();
+    expect(component.tooltip()).toContain("DD.MM.YYYY");
+  });
+
   it("should open dialog and notify with the configured mapping", async () => {
     const onChangeFn = vi.fn();
     const rawData = [{ date: "2024-01-01" }, { date: "2024-02-01" }];

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
@@ -50,6 +50,16 @@ describe("DateImportConfigComponent", () => {
 
     expect(component.badge()).toBeUndefined();
     expect(component.tooltip()).toContain("DD.MM.YYYY");
+
+    // confirming without a format is a valid config for dates the system reads on its own
+    fixture.componentRef.setInput("col", {
+      column: "date",
+      propertyName: "dateOfBirth",
+      additional: "",
+    });
+
+    expect(component.badge()).toBeUndefined();
+    expect(component.tooltip()).toContain("without a format");
   });
 
   it("should open dialog and notify with the configured mapping", async () => {

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.spec.ts
@@ -1,22 +1,28 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { DateImportConfigComponent } from "./date-import-config.component";
-import { MatDialog } from "@angular/material/dialog";
-import { of } from "rxjs";
 import { TestEntity } from "../../../../utils/test-utils/TestEntity";
+import { ImportConfigDialogService } from "../../../import/import-column-mapping/import-config-dialog.service";
+import { ColumnMapping } from "../../../import/column-mapping";
 
 describe("DateImportConfigComponent", () => {
   let component: DateImportConfigComponent;
   let fixture: ComponentFixture<DateImportConfigComponent>;
-  let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let mockConfigDialogs: { openConfigDialog: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
-    mockDialog = {
-      open: vi.fn().mockReturnValue({ afterClosed: () => of(undefined) }),
+    mockConfigDialogs = {
+      openConfigDialog: vi
+        .fn()
+        .mockImplementation((col: ColumnMapping) =>
+          Promise.resolve({ ...col, additional: "YYYY-MM-DD" }),
+        ),
     };
 
     await TestBed.configureTestingModule({
       imports: [DateImportConfigComponent],
-      providers: [{ provide: MatDialog, useValue: mockDialog }],
+      providers: [
+        { provide: ImportConfigDialogService, useValue: mockConfigDialogs },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DateImportConfigComponent);
@@ -27,22 +33,27 @@ describe("DateImportConfigComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should open dialog and notify on close", () => {
+  it("should open dialog and notify with the configured mapping", async () => {
     const onChangeFn = vi.fn();
+    const rawData = [{ date: "2024-01-01" }, { date: "2024-02-01" }];
     fixture.componentRef.setInput("col", {
       column: "date",
       propertyName: "dateOfBirth",
     });
-    fixture.componentRef.setInput("rawData", [
-      { date: "2024-01-01" },
-      { date: "2024-02-01" },
-    ]);
+    fixture.componentRef.setInput("rawData", rawData);
     fixture.componentRef.setInput("entityType", TestEntity);
     fixture.componentRef.setInput("onColumnMappingChange", onChangeFn);
 
-    component.openConfig();
+    await component.openConfig();
 
-    expect(mockDialog.open).toHaveBeenCalled();
-    expect(onChangeFn).toHaveBeenCalledWith(component.col());
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledWith(
+      component.col(),
+      rawData,
+      TestEntity,
+      undefined,
+    );
+    expect(onChangeFn).toHaveBeenCalledWith(
+      expect.objectContaining({ additional: "YYYY-MM-DD" }),
+    );
   });
 });

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   input,
 } from "@angular/core";
@@ -9,6 +10,8 @@ import { EntityConstructor } from "../../../entity/model/entity";
 import { ImportAdditionalSettings } from "../../../import/import-additional-settings";
 import { ImportConfigDialogService } from "../../../import/import-column-mapping/import-config-dialog.service";
 import { MatButtonModule } from "@angular/material/button";
+import { MatBadgeModule } from "@angular/material/badge";
+import { MatTooltipModule } from "@angular/material/tooltip";
 import { DynamicComponent } from "../../../config/dynamic-components/dynamic-component.decorator";
 
 /**
@@ -20,7 +23,7 @@ import { DynamicComponent } from "../../../config/dynamic-components/dynamic-com
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "app-date-import-config",
   templateUrl: "./date-import-config.component.html",
-  imports: [MatButtonModule],
+  imports: [MatButtonModule, MatBadgeModule, MatTooltipModule],
 })
 export class DateImportConfigComponent {
   private readonly configDialogs = inject(ImportConfigDialogService);
@@ -31,6 +34,15 @@ export class DateImportConfigComponent {
   otherColumnMappings = input<ColumnMapping[]>([]);
   additionalSettings = input<ImportAdditionalSettings>();
   onColumnMappingChange = input<(col: ColumnMapping) => void>();
+
+  /** marks the column as not configured, same indicator as for value mappings */
+  readonly badge = computed(() => (this.col()?.additional ? undefined : "?"));
+
+  readonly tooltip = computed(() =>
+    this.badge()
+      ? $localize`:import date format tooltip - not configured:No date format is defined for this column. Dates that the system cannot read on its own are skipped during import.`
+      : $localize`:import date format tooltip - configured:Dates of this column are read with the format "${this.col()?.additional}:format:". Open to review or change it.`,
+  );
 
   async openConfig() {
     const updated = await this.configDialogs.openConfigDialog(

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
@@ -7,9 +7,7 @@ import {
 import { ColumnMapping } from "../../../import/column-mapping";
 import { EntityConstructor } from "../../../entity/model/entity";
 import { ImportAdditionalSettings } from "../../../import/import-additional-settings";
-import { MatDialog } from "@angular/material/dialog";
-import { MappingDialogData } from "../../../import/import-column-mapping/mapping-dialog-data";
-import { DateImportDialogComponent } from "./date-import-dialog.component";
+import { ImportConfigDialogService } from "../../../import/import-column-mapping/import-config-dialog.service";
 import { MatButtonModule } from "@angular/material/button";
 import { DynamicComponent } from "../../../config/dynamic-components/dynamic-component.decorator";
 
@@ -25,7 +23,7 @@ import { DynamicComponent } from "../../../config/dynamic-components/dynamic-com
   imports: [MatButtonModule],
 })
 export class DateImportConfigComponent {
-  private readonly dialog = inject(MatDialog);
+  private readonly configDialogs = inject(ImportConfigDialogService);
 
   col = input<ColumnMapping>();
   rawData = input<any[]>([]);
@@ -34,28 +32,13 @@ export class DateImportConfigComponent {
   additionalSettings = input<ImportAdditionalSettings>();
   onColumnMappingChange = input<(col: ColumnMapping) => void>();
 
-  openConfig() {
-    const col = this.col();
-    const uniqueValues = new Set<any>(
-      this.rawData().map((row) => row[col.column]),
+  async openConfig() {
+    const updated = await this.configDialogs.openConfigDialog(
+      this.col(),
+      this.rawData(),
+      this.entityType(),
+      this.additionalSettings(),
     );
-
-    this.dialog
-      .open<DateImportDialogComponent, MappingDialogData>(
-        DateImportDialogComponent,
-        {
-          data: {
-            col: col,
-            values: [...uniqueValues],
-            totalRowCount: this.rawData().length,
-            entityType: this.entityType(),
-            additionalSettings: this.additionalSettings(),
-          },
-          width: "80vw",
-          disableClose: true,
-        },
-      )
-      .afterClosed()
-      .subscribe(() => this.onColumnMappingChange()?.(col));
+    this.onColumnMappingChange()?.(updated);
   }
 }

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-config.component.ts
@@ -35,14 +35,24 @@ export class DateImportConfigComponent {
   additionalSettings = input<ImportAdditionalSettings>();
   onColumnMappingChange = input<(col: ColumnMapping) => void>();
 
-  /** marks the column as not configured, same indicator as for value mappings */
-  readonly badge = computed(() => (this.col()?.additional ? undefined : "?"));
-
-  readonly tooltip = computed(() =>
-    this.badge()
-      ? $localize`:import date format tooltip - not configured:No date format is defined for this column. Dates that the system cannot read on its own are skipped during import.`
-      : $localize`:import date format tooltip - configured:Dates of this column are read with the format "${this.col()?.additional}:format:". Open to review or change it.`,
+  /**
+   * Marks the column as not configured, same indicator as for value mappings.
+   * An empty format is a configured state: it reads the dates the system understands on its own.
+   */
+  readonly badge = computed(() =>
+    this.col()?.additional == null ? "?" : undefined,
   );
+
+  readonly tooltip = computed(() => {
+    const format = this.col()?.additional;
+    if (format == null) {
+      return $localize`:import date format tooltip - not configured:No date format is defined for this column. Dates that the system cannot read on its own are skipped during import.`;
+    }
+    if (format === "") {
+      return $localize`:import date format tooltip - no format needed:The dates of this column are read without a format. Open to define one if they are not imported correctly.`;
+    }
+    return $localize`:import date format tooltip - configured:Dates of this column are read with the format "${format}:format:". Open to review or change it.`;
+  });
 
   async openConfig() {
     const updated = await this.configDialogs.openConfigDialog(

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-dialog.component.ts
@@ -99,7 +99,7 @@ export class DateImportDialogComponent {
 
     if (confirmed) {
       this.data.col.additional = this.format.value;
-      this.dialog.close();
+      this.dialog.close(true);
     }
   }
 }

--- a/src/app/core/basic-datatypes/date/date-import-config/date-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/date/date-import-config/date-import-dialog.component.ts
@@ -98,8 +98,10 @@ export class DateImportDialogComponent {
       ));
 
     if (confirmed) {
-      this.data.col.additional = this.format.value;
-      this.dialog.close(true);
+      // an empty format is a valid choice (dates the system reads on its own), but it has to be
+      // stored as a value so that the column does not count as unconfigured afterwards
+      this.data.col.additional = this.format.value ?? "";
+      this.dialog.close();
     }
   }
 }

--- a/src/app/core/basic-datatypes/date/date.datatype.ts
+++ b/src/app/core/basic-datatypes/date/date.datatype.ts
@@ -84,6 +84,7 @@ export class DateDatatype<DBFormat = string> extends DefaultDatatype<
   }
 
   override importConfigComponent = "DateImportConfig";
+  override importConfigDialog = "DateImportDialog";
 
   override async importMapFunction(
     val: any,

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.html
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.html
@@ -6,6 +6,7 @@
   [matBadge]="badge()"
   [matBadgeHidden]="!badge()"
   matBadgeColor="warn"
+  [matTooltip]="tooltip()"
 >
   Configure value mapping
 </button>

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
@@ -33,16 +33,17 @@ describe("DiscreteImportConfigComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should show badge with ? when no value mappings exist", () => {
+  it("should mark the column as not configured while no value mappings exist", () => {
     fixture.componentRef.setInput("col", {
       column: "gender",
       propertyName: "category",
     });
 
     expect(component.badge()).toBe("?");
+    expect(component.tooltip()).toContain("not mapped yet");
   });
 
-  it("should show badge count for unmapped values", () => {
+  it("should show badge count and tooltip for unmapped values", () => {
     fixture.componentRef.setInput("col", {
       column: "gender",
       propertyName: "category",
@@ -50,6 +51,16 @@ describe("DiscreteImportConfigComponent", () => {
     });
 
     expect(component.badge()).toBe("1");
+    expect(component.tooltip()).toContain("1");
+
+    fixture.componentRef.setInput("col", {
+      column: "gender",
+      propertyName: "category",
+      additional: { values: { male: "M" } },
+    });
+
+    expect(component.badge()).toBeUndefined();
+    expect(component.tooltip()).toContain("All values");
   });
 
   it("should open dialog and notify with the configured mapping", async () => {

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
@@ -1,22 +1,28 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { DiscreteImportConfigComponent } from "./discrete-import-config.component";
-import { MatDialog } from "@angular/material/dialog";
-import { of } from "rxjs";
 import { TestEntity } from "../../../../utils/test-utils/TestEntity";
+import { ImportConfigDialogService } from "../../../import/import-column-mapping/import-config-dialog.service";
+import { ColumnMapping } from "../../../import/column-mapping";
 
 describe("DiscreteImportConfigComponent", () => {
   let component: DiscreteImportConfigComponent;
   let fixture: ComponentFixture<DiscreteImportConfigComponent>;
-  let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let mockConfigDialogs: { openConfigDialog: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
-    mockDialog = {
-      open: vi.fn().mockReturnValue({ afterClosed: () => of(undefined) }),
+    mockConfigDialogs = {
+      openConfigDialog: vi
+        .fn()
+        .mockImplementation((col: ColumnMapping) =>
+          Promise.resolve({ ...col, additional: { values: { male: "M" } } }),
+        ),
     };
 
     await TestBed.configureTestingModule({
       imports: [DiscreteImportConfigComponent],
-      providers: [{ provide: MatDialog, useValue: mockDialog }],
+      providers: [
+        { provide: ImportConfigDialogService, useValue: mockConfigDialogs },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DiscreteImportConfigComponent);
@@ -46,22 +52,27 @@ describe("DiscreteImportConfigComponent", () => {
     expect(component.badge()).toBe("1");
   });
 
-  it("should open dialog and notify on close", () => {
+  it("should open dialog and notify with the configured mapping", async () => {
     const onChangeFn = vi.fn();
+    const rawData = [{ gender: "male" }, { gender: "female" }];
     fixture.componentRef.setInput("col", {
       column: "gender",
       propertyName: "category",
     });
-    fixture.componentRef.setInput("rawData", [
-      { gender: "male" },
-      { gender: "female" },
-    ]);
+    fixture.componentRef.setInput("rawData", rawData);
     fixture.componentRef.setInput("entityType", TestEntity);
     fixture.componentRef.setInput("onColumnMappingChange", onChangeFn);
 
-    component.openConfig();
+    await component.openConfig();
 
-    expect(mockDialog.open).toHaveBeenCalled();
-    expect(onChangeFn).toHaveBeenCalledWith(component.col());
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledWith(
+      component.col(),
+      rawData,
+      TestEntity,
+      undefined,
+    );
+    expect(onChangeFn).toHaveBeenCalledWith(
+      expect.objectContaining({ additional: { values: { male: "M" } } }),
+    );
   });
 });

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   input,
 } from "@angular/core";
@@ -11,6 +12,7 @@ import { ImportConfigDialogService } from "../../../import/import-column-mapping
 import { DiscreteColumnMappingAdditional } from "../discrete.datatype";
 import { MatButtonModule } from "@angular/material/button";
 import { MatBadgeModule } from "@angular/material/badge";
+import { MatTooltipModule } from "@angular/material/tooltip";
 import { DynamicComponent } from "../../../config/dynamic-components/dynamic-component.decorator";
 
 /**
@@ -22,7 +24,7 @@ import { DynamicComponent } from "../../../config/dynamic-components/dynamic-com
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "app-discrete-import-config",
   templateUrl: "./discrete-import-config.component.html",
-  imports: [MatButtonModule, MatBadgeModule],
+  imports: [MatButtonModule, MatBadgeModule, MatTooltipModule],
 })
 export class DiscreteImportConfigComponent {
   private readonly configDialogs = inject(ImportConfigDialogService);
@@ -34,18 +36,35 @@ export class DiscreteImportConfigComponent {
   additionalSettings = input<ImportAdditionalSettings>();
   onColumnMappingChange = input<(col: ColumnMapping) => void>();
 
-  badge(): string | undefined {
+  /** how many of the file's values have no mapping yet, undefined while nothing is configured */
+  readonly unmappedCount = computed<number | undefined>(() => {
     const additional = this.col()
       ?.additional as DiscreteColumnMappingAdditional;
     const valueMappings = additional?.values;
     if (!valueMappings) {
+      return undefined;
+    }
+    return Object.values(valueMappings).filter((v) => v === undefined).length;
+  });
+
+  readonly badge = computed(() => {
+    const unmapped = this.unmappedCount();
+    if (unmapped === undefined) {
       return "?";
     }
-    const unmappedCount = Object.values(valueMappings).filter(
-      (v) => v === undefined,
-    ).length;
-    return unmappedCount > 0 ? unmappedCount.toString() : undefined;
-  }
+    return unmapped > 0 ? unmapped.toString() : undefined;
+  });
+
+  readonly tooltip = computed(() => {
+    const unmapped = this.unmappedCount();
+    if (unmapped === undefined) {
+      return $localize`:import value mapping tooltip - not configured:The values of this column are not mapped yet. They are imported exactly as they are in the file, which can result in values the system does not recognise.`;
+    }
+    if (unmapped > 0) {
+      return $localize`:import value mapping tooltip - unmapped values:${unmapped}:count: of the values in this column have no mapping and are skipped during import.`;
+    }
+    return $localize`:import value mapping tooltip - configured:All values of this column are mapped. Open to review or change the mapping.`;
+  });
 
   async openConfig() {
     const updated = await this.configDialogs.openConfigDialog(

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
@@ -7,9 +7,7 @@ import {
 import { ColumnMapping } from "../../../import/column-mapping";
 import { EntityConstructor } from "../../../entity/model/entity";
 import { ImportAdditionalSettings } from "../../../import/import-additional-settings";
-import { MatDialog } from "@angular/material/dialog";
-import { MappingDialogData } from "../../../import/import-column-mapping/mapping-dialog-data";
-import { DiscreteImportDialogComponent } from "./discrete-import-dialog.component";
+import { ImportConfigDialogService } from "../../../import/import-column-mapping/import-config-dialog.service";
 import { DiscreteColumnMappingAdditional } from "../discrete.datatype";
 import { MatButtonModule } from "@angular/material/button";
 import { MatBadgeModule } from "@angular/material/badge";
@@ -27,7 +25,7 @@ import { DynamicComponent } from "../../../config/dynamic-components/dynamic-com
   imports: [MatButtonModule, MatBadgeModule],
 })
 export class DiscreteImportConfigComponent {
-  private readonly dialog = inject(MatDialog);
+  private readonly configDialogs = inject(ImportConfigDialogService);
 
   col = input<ColumnMapping>();
   rawData = input<any[]>([]);
@@ -49,28 +47,13 @@ export class DiscreteImportConfigComponent {
     return unmappedCount > 0 ? unmappedCount.toString() : undefined;
   }
 
-  openConfig() {
-    const col = this.col();
-    const uniqueValues = new Set<any>(
-      this.rawData().map((row) => row[col.column]),
+  async openConfig() {
+    const updated = await this.configDialogs.openConfigDialog(
+      this.col(),
+      this.rawData(),
+      this.entityType(),
+      this.additionalSettings(),
     );
-
-    this.dialog
-      .open<DiscreteImportDialogComponent, MappingDialogData>(
-        DiscreteImportDialogComponent,
-        {
-          data: {
-            col: col,
-            values: [...uniqueValues],
-            totalRowCount: this.rawData().length,
-            entityType: this.entityType(),
-            additionalSettings: this.additionalSettings(),
-          },
-          width: "80vw",
-          disableClose: true,
-        },
-      )
-      .afterClosed()
-      .subscribe(() => this.onColumnMappingChange()?.(col));
+    this.onColumnMappingChange()?.(updated);
   }
 }

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
@@ -197,8 +197,7 @@ export class DiscreteImportDialogComponent implements OnInit {
       }
       this.data.col.additional = discreteAdditional;
 
-      // the result marks the mapping as confirmed by the user, a cancelled dialog closes without it
-      this.dialog.close(true);
+      this.dialog.close();
     }
   }
 

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
@@ -197,7 +197,8 @@ export class DiscreteImportDialogComponent implements OnInit {
       }
       this.data.col.additional = discreteAdditional;
 
-      this.dialog.close();
+      // the result marks the mapping as confirmed by the user, a cancelled dialog closes without it
+      this.dialog.close(true);
     }
   }
 

--- a/src/app/core/basic-datatypes/discrete/discrete.datatype.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete.datatype.ts
@@ -12,6 +12,7 @@ export abstract class DiscreteDatatype<
   DBType,
 > extends DefaultDatatype<EntityType, DBType> {
   override importConfigComponent = "DiscreteImportConfig";
+  override importConfigDialog = "DiscreteImportDialog";
 
   abstract override transformToDatabaseFormat(
     value,

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -302,6 +302,16 @@ export class DefaultDatatype<EntityType = any, DBType = any> {
   importConfigComponent?: string;
 
   /**
+   * A dialog component in which the import transformation is configured
+   * (see {@link MappingDialogData} for the data it receives).
+   *
+   * Datatypes that require such a dialog get it opened automatically
+   * as soon as the user maps a column to one of their fields,
+   * so that the suggested settings are reviewed and confirmed rather than silently skipped.
+   */
+  importConfigDialog?: string;
+
+  /**
    * Return the (potentially adjusted) schema field for this datatype.
    *
    * Called when schema fields are set up (e.g. from config),

--- a/src/app/core/import/README.md
+++ b/src/app/core/import/README.md
@@ -1,0 +1,83 @@
+# Import Module
+
+UI workflow to import data from a spreadsheet (.csv / .xlsx) into records of an entity type.
+
+## Workflow
+
+`ImportComponent` holds the state of the whole import in one `importSettings` signal and guides the
+user through the steps of a stepper. Each step contributes one part of that state and is only
+completed once its part is valid.
+
+```mermaid
+---
+config:
+  theme: redux
+  layout: dagre
+---
+flowchart BT
+ subgraph s1["ImportComponent"]
+        n2["ImportFileComponent"]
+        n3["ImportEntityTypeComponent etc."]
+        n4["ImportColumnMappingComponent"]
+        n5["ImportReviewDataComponent"]
+  end
+    n2 --> n3
+    n3 --> n4
+    n4 --> n5
+```
+
+1. **ImportFileComponent** parses the file and produces the raw data together with the columns found
+   in it.
+2. **ImportEntityTypeComponent** (and the additional actions next to it) defines what the imported
+   records become in the system.
+3. **ImportColumnMappingComponent** maps each column of the file to a field of that entity type.
+4. **ImportReviewDataComponent** previews the resulting records before `ImportService` writes them.
+
+## Column mapping
+
+`ImportColumnMappingComponent` renders one row per column of the file and pre-selects fields whose
+name or label matches the column header (`ImportColumnMappingService`).
+
+```mermaid
+---
+config:
+  theme: redux
+  layout: dagre
+---
+flowchart BT
+ subgraph s3["EditImportColumnMapping (one per column)"]
+        m1["EntityFieldSelect"]
+        m2["Inline Component Config (for additional)"]
+  end
+ subgraph s2["ImportColumnMappingComponent"]
+        s3
+  end
+```
+
+A row consists of the field select and, for fields that need more than a plain copy of the value, an
+inline config component. Everything a single column needs is handled inside its own row component,
+the parent only keeps the list of mappings.
+
+### Transformation config (`additional`)
+
+Datatypes declare how their values are configured for an import:
+
+- `importConfigComponent`: the inline component shown next to the field select. Some are self
+  contained (a checkbox for location lookups, a select for the property an entity reference is
+  matched by), others only hold the button that opens a dialog.
+- `importConfigDialog`: the dialog for datatypes whose configuration does not fit into the row, i.e.
+  the value mapping of dropdowns and checkboxes, and the date format. `ImportConfigDialogService`
+  opens it and hands back the resulting mapping.
+
+Whatever the user confirms is stored in `ColumnMapping.additional` and used by the datatype's
+`importMapFunction` when the records are built. `additional` is therefore also the marker of whether
+a column has been configured: the dialogs only write it when the user confirms them, so a column that
+requires a dialog and has no `additional` was either never opened or cancelled. Such a column shows
+an error and blocks the step, so that the values of the file are never imported unchanged without the
+user knowing (see `ImportConfigDialogService.isConfigMissing`).
+
+## Re-using a previous import
+
+Every executed import stores its settings as an `ImportMetadata` record, listed in
+`ImportHistoryComponent`. Applying one of those copies its column mapping onto the columns of the
+current file, matched by column name.

--- a/src/app/core/import/column-mapping.ts
+++ b/src/app/core/import/column-mapping.ts
@@ -19,13 +19,4 @@ export interface ColumnMapping {
    * This is used to track if the coloumns are manually updated or not.
    */
   manuallyUpdated?: boolean;
-
-  /**
-   * How the user left the config dialog of this column, if its field requires one.
-   *
-   * `undefined` means the dialog was never opened, so the values are imported as they are
-   * in the file. "cancelled" means the user closed it without saving, which blocks the import
-   * until the mapping is confirmed.
-   */
-  configReview?: "confirmed" | "cancelled";
 }

--- a/src/app/core/import/column-mapping.ts
+++ b/src/app/core/import/column-mapping.ts
@@ -19,4 +19,13 @@ export interface ColumnMapping {
    * This is used to track if the coloumns are manually updated or not.
    */
   manuallyUpdated?: boolean;
+
+  /**
+   * How the user left the config dialog of this column, if its field requires one.
+   *
+   * `undefined` means the dialog was never opened, so the values are imported as they are
+   * in the file. "cancelled" means the user closed it without saving, which blocks the import
+   * until the mapping is confirmed.
+   */
+  configReview?: "confirmed" | "cancelled";
 }

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.html
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.html
@@ -13,3 +13,7 @@
     <ng-container [appDynamicComponent]="inlineComponentConfig()" />
   }
 </div>
+
+@if (configHint(); as hint) {
+  <mat-error class="config-hint">{{ hint }}</mat-error>
+}

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.html
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.html
@@ -14,6 +14,6 @@
   }
 </div>
 
-@if (configHint(); as hint) {
-  <mat-error class="config-hint">{{ hint }}</mat-error>
+@if (configError(); as error) {
+  <mat-error class="config-error">{{ error }}</mat-error>
 }

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.scss
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.scss
@@ -8,7 +8,7 @@ mat-form-field {
   max-width: 240px;
 }
 
-.config-hint {
+.config-error {
   // the form field keeps space below the input for its own errors, move the message into it
   // so that it reads as belonging to the field above rather than to the next column below
   margin-top: -18px;

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.scss
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.scss
@@ -8,6 +8,17 @@ mat-form-field {
   max-width: 240px;
 }
 
+.config-hint {
+  // the form field keeps space below the input for its own errors, move the message into it
+  // so that it reads as belonging to the field above rather than to the next column below
+  margin-top: -18px;
+
+  // mat-error keeps a spacer for the layout inside a form field, which is not needed out here
+  &::before {
+    display: none;
+  }
+}
+
 .lookup-warning-icon {
   color: #f57c00;
 }

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
@@ -65,11 +65,12 @@ describe("EditImportColumnMappingComponent", () => {
     expect(emitted.additional).toBeUndefined();
   });
 
-  it("should emit the newly selected field without any previous transformation config", () => {
+  it("should emit the newly selected field without the previous transformation config and its review", () => {
     fixture.componentRef.setInput("columnMapping", {
       column: "test",
       propertyName: "category",
       additional: { values: { male: "M" } },
+      configReview: "confirmed",
     });
     fixture.detectChanges();
 
@@ -80,9 +81,39 @@ describe("EditImportColumnMappingComponent", () => {
         column: "test",
         propertyName: "name",
         additional: undefined,
+        configReview: undefined,
         manuallyUpdated: true,
       }),
     );
+  });
+
+  it("should hint about the value mapping config until the user confirmed it", () => {
+    // mapped to an enum field, which is configured through a dialog
+    expect(component.configHint()).toContain("not configured");
+
+    fixture.componentRef.setInput("columnMapping", {
+      ...columnMapping,
+      configReview: "cancelled",
+    });
+    fixture.detectChanges();
+    expect(component.configHint()).toContain("was not saved");
+
+    fixture.componentRef.setInput("columnMapping", {
+      ...columnMapping,
+      configReview: "confirmed",
+    });
+    fixture.detectChanges();
+    expect(component.configHint()).toBeNull();
+  });
+
+  it("should not hint for fields that have no config dialog", () => {
+    fixture.componentRef.setInput("columnMapping", {
+      column: "test",
+      propertyName: "name",
+    });
+    fixture.detectChanges();
+
+    expect(component.configHint()).toBeNull();
   });
 
   it("should preserve additional when updateMapping is called with settingAdditional=true", () => {

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
@@ -3,10 +3,16 @@ import { EditImportColumnMappingComponent } from "./edit-import-column-mapping.c
 import { MockedTestingModule } from "../../../../utils/mocked-testing.module";
 import { ColumnMapping } from "../../column-mapping";
 import { TestEntity } from "../../../../utils/test-utils/TestEntity";
+import { ImportConfigDialogService } from "../import-config-dialog.service";
 
 describe("EditImportColumnMappingComponent", () => {
   let component: EditImportColumnMappingComponent;
   let fixture: ComponentFixture<EditImportColumnMappingComponent>;
+  let mockConfigDialogs: {
+    hasConfigDialog: ReturnType<typeof vi.fn>;
+    isConfigMissing: ReturnType<typeof vi.fn>;
+    openConfigDialog: ReturnType<typeof vi.fn>;
+  };
 
   const columnMapping: ColumnMapping = {
     column: "test",
@@ -20,8 +26,21 @@ describe("EditImportColumnMappingComponent", () => {
   ];
 
   beforeEach(async () => {
+    mockConfigDialogs = {
+      hasConfigDialog: vi.fn().mockReturnValue(true),
+      isConfigMissing: vi.fn().mockReturnValue(true),
+      openConfigDialog: vi
+        .fn()
+        .mockImplementation((col: ColumnMapping) =>
+          Promise.resolve({ ...col, additional: { values: { male: "M" } } }),
+        ),
+    };
+
     await TestBed.configureTestingModule({
       imports: [MockedTestingModule, EditImportColumnMappingComponent],
+      providers: [
+        { provide: ImportConfigDialogService, useValue: mockConfigDialogs },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditImportColumnMappingComponent);
@@ -65,55 +84,61 @@ describe("EditImportColumnMappingComponent", () => {
     expect(emitted.additional).toBeUndefined();
   });
 
-  it("should emit the newly selected field without the previous transformation config and its review", () => {
+  it("should emit the newly selected field without the previous transformation config", async () => {
+    mockConfigDialogs.hasConfigDialog.mockReturnValue(false);
     fixture.componentRef.setInput("columnMapping", {
       column: "test",
       propertyName: "category",
       additional: { values: { male: "M" } },
-      configReview: "confirmed",
     });
     fixture.detectChanges();
 
-    component.onFieldSelected("name");
+    await component.onFieldSelected("name");
 
     expect(component.columnMappingChange.emit).toHaveBeenCalledWith(
       expect.objectContaining({
         column: "test",
         propertyName: "name",
         additional: undefined,
-        configReview: undefined,
         manuallyUpdated: true,
       }),
     );
   });
 
-  it("should hint about the value mapping config until the user confirmed it", () => {
-    // mapped to an enum field, which is configured through a dialog
-    expect(component.configHint()).toContain("not configured");
+  it("should open the config dialog of a newly selected field and emit its result", async () => {
+    await component.onFieldSelected("category");
 
-    fixture.componentRef.setInput("columnMapping", {
-      ...columnMapping,
-      configReview: "cancelled",
-    });
-    fixture.detectChanges();
-    expect(component.configHint()).toContain("was not saved");
-
-    fixture.componentRef.setInput("columnMapping", {
-      ...columnMapping,
-      configReview: "confirmed",
-    });
-    fixture.detectChanges();
-    expect(component.configHint()).toBeNull();
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ propertyName: "category" }),
+      rawData,
+      TestEntity,
+      undefined,
+    );
+    expect(component.columnMappingChange.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ additional: { values: { male: "M" } } }),
+    );
   });
 
-  it("should not hint for fields that have no config dialog", () => {
+  it("should open only one dialog if the field select notifies twice for one selection", async () => {
+    await Promise.all([
+      component.onFieldSelected("category"),
+      component.onFieldSelected("category"),
+    ]);
+
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show an error while the value mapping config of the field is missing", () => {
+    mockConfigDialogs.isConfigMissing.mockReturnValue(true);
+    expect(component.configError()).toContain("not configured");
+
+    mockConfigDialogs.isConfigMissing.mockReturnValue(false);
     fixture.componentRef.setInput("columnMapping", {
-      column: "test",
-      propertyName: "name",
+      ...columnMapping,
+      additional: { values: { male: "M" } },
     });
     fixture.detectChanges();
-
-    expect(component.configHint()).toBeNull();
+    expect(component.configError()).toBeNull();
   });
 
   it("should preserve additional when updateMapping is called with settingAdditional=true", () => {

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.spec.ts
@@ -65,6 +65,26 @@ describe("EditImportColumnMappingComponent", () => {
     expect(emitted.additional).toBeUndefined();
   });
 
+  it("should emit the newly selected field without any previous transformation config", () => {
+    fixture.componentRef.setInput("columnMapping", {
+      column: "test",
+      propertyName: "category",
+      additional: { values: { male: "M" } },
+    });
+    fixture.detectChanges();
+
+    component.onFieldSelected("name");
+
+    expect(component.columnMappingChange.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        column: "test",
+        propertyName: "name",
+        additional: undefined,
+        manuallyUpdated: true,
+      }),
+    );
+  });
+
   it("should preserve additional when updateMapping is called with settingAdditional=true", () => {
     fixture.componentRef.setInput("columnMapping", {
       column: "test",

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
@@ -17,6 +17,7 @@ import { EntityFieldSelectComponent } from "../../../entity/entity-field-select/
 import { FormsModule } from "@angular/forms";
 import { DynamicComponentDirective } from "../../../config/dynamic-components/dynamic-component.directive";
 import { ImportAdditionalSettings } from "../../import-additional-settings";
+import { ImportConfigDialogService } from "../import-config-dialog.service";
 
 /**
  * Component to edit a single imported column's mapping to an entity field
@@ -36,6 +37,7 @@ import { ImportAdditionalSettings } from "../../import-additional-settings";
 })
 export class EditImportColumnMappingComponent {
   private readonly schemaService = inject(EntitySchemaService);
+  private readonly configDialogs = inject(ImportConfigDialogService);
 
   columnMapping = input.required<ColumnMapping>();
 
@@ -60,6 +62,14 @@ export class EditImportColumnMappingComponent {
 
   columnMappingChange = output<ColumnMapping>();
 
+  /**
+   * Whether this column's config dialog is currently open.
+   *
+   * The field select notifies twice for a single selection, this keeps the second notification
+   * from opening the same dialog again on top of the first one.
+   */
+  private configDialogOpen = false;
+
   currentlyMappedDatatype = computed<DefaultDatatype | null>(() => {
     const col = this.columnMapping();
     const schema = this.entityCtor()?.schema?.get(col?.propertyName);
@@ -69,23 +79,14 @@ export class EditImportColumnMappingComponent {
   });
 
   /**
-   * Message below the field about the state of its value mapping config,
-   * for fields that are configured through a dialog. `null` if nothing needs to be said.
+   * Error message below the field while the transformation of its values still has to be
+   * configured and confirmed by the user, `null` once it is configured or not needed at all.
    */
-  configHint = computed<string | null>(() => {
-    if (!this.currentlyMappedDatatype()?.importConfigDialog) {
-      return null;
-    }
-
-    switch (this.columnMapping()?.configReview) {
-      case "confirmed":
-        return null;
-      case "cancelled":
-        return $localize`:import column mapping - config not confirmed:Value mapping was not saved. Open it and confirm to continue.`;
-      default:
-        return $localize`:import column mapping - config not reviewed:Value mapping not configured, the values from the file are imported as they are.`;
-    }
-  });
+  configError = computed<string | null>(() =>
+    this.configDialogs.isConfigMissing(this.columnMapping(), this.entityCtor())
+      ? $localize`:import column mapping - config missing:Value mapping is not configured yet. Open it and confirm to continue.`
+      : null,
+  );
 
   inlineComponentConfig = computed<DynamicComponentConfig | null>(() => {
     const componentName = this.currentlyMappedDatatype()?.importConfigComponent;
@@ -117,16 +118,37 @@ export class EditImportColumnMappingComponent {
       .importAllowsMultiMapping &&
     option.id !== this.columnMapping()?.propertyName;
 
-  onFieldSelected(propertyName: string) {
-    const col = this.columnMapping();
-    this.columnMappingChange.emit({
-      ...col,
+  async onFieldSelected(propertyName: string) {
+    const col: ColumnMapping = {
+      ...this.columnMapping(),
       propertyName,
-      // the new field brings its own transformation config, which has not been reviewed yet
+      // the new field brings its own transformation, the previous config does not apply to it
       additional: undefined,
-      configReview: undefined,
       manuallyUpdated: true,
-    });
+    };
+    this.columnMappingChange.emit(col);
+
+    if (
+      this.configDialogOpen ||
+      !this.configDialogs.hasConfigDialog(col, this.entityCtor())
+    ) {
+      return;
+    }
+
+    // open the config right away, so that the user reviews and confirms the suggested value
+    // mappings of the field they just picked instead of importing the file's values unchanged
+    this.configDialogOpen = true;
+    try {
+      const configuredCol = await this.configDialogs.openConfigDialog(
+        col,
+        this.rawData(),
+        this.entityCtor(),
+        this.additionalSettings(),
+      );
+      this.columnMappingChange.emit(configuredCol);
+    } finally {
+      this.configDialogOpen = false;
+    }
   }
 
   updateMapping(settingAdditional = false) {

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
@@ -35,7 +35,7 @@ import { ImportAdditionalSettings } from "../../import-additional-settings";
   ],
 })
 export class EditImportColumnMappingComponent {
-  private schemaService = inject(EntitySchemaService);
+  private readonly schemaService = inject(EntitySchemaService);
 
   columnMapping = input.required<ColumnMapping>();
 

--- a/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/edit-import-column-mapping/edit-import-column-mapping.component.ts
@@ -68,6 +68,25 @@ export class EditImportColumnMappingComponent {
       : null;
   });
 
+  /**
+   * Message below the field about the state of its value mapping config,
+   * for fields that are configured through a dialog. `null` if nothing needs to be said.
+   */
+  configHint = computed<string | null>(() => {
+    if (!this.currentlyMappedDatatype()?.importConfigDialog) {
+      return null;
+    }
+
+    switch (this.columnMapping()?.configReview) {
+      case "confirmed":
+        return null;
+      case "cancelled":
+        return $localize`:import column mapping - config not confirmed:Value mapping was not saved. Open it and confirm to continue.`;
+      default:
+        return $localize`:import column mapping - config not reviewed:Value mapping not configured, the values from the file are imported as they are.`;
+    }
+  });
+
   inlineComponentConfig = computed<DynamicComponentConfig | null>(() => {
     const componentName = this.currentlyMappedDatatype()?.importConfigComponent;
     if (!componentName) return null;
@@ -103,7 +122,9 @@ export class EditImportColumnMappingComponent {
     this.columnMappingChange.emit({
       ...col,
       propertyName,
+      // the new field brings its own transformation config, which has not been reviewed yet
       additional: undefined,
+      configReview: undefined,
       manuallyUpdated: true,
     });
   }

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
@@ -2,38 +2,13 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ImportColumnMappingComponent } from "./import-column-mapping.component";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { ColumnMapping } from "../column-mapping";
-import { ImportConfigDialogService } from "./import-config-dialog.service";
-import { TestEntity } from "../../../utils/test-utils/TestEntity";
 
 describe("ImportColumnMappingComponent", () => {
   let component: ImportColumnMappingComponent;
   let fixture: ComponentFixture<ImportColumnMappingComponent>;
-  let mockConfigDialogs: {
-    hasConfigDialog: ReturnType<typeof vi.fn>;
-    openConfigDialog: ReturnType<typeof vi.fn>;
-  };
-
   beforeEach(async () => {
-    mockConfigDialogs = {
-      hasConfigDialog: vi
-        .fn()
-        .mockImplementation(
-          (col: ColumnMapping) => col.propertyName === "category",
-        ),
-      openConfigDialog: vi.fn().mockImplementation((col: ColumnMapping) =>
-        Promise.resolve({
-          ...col,
-          additional: { values: { male: "M" } },
-          configReview: "confirmed",
-        }),
-      ),
-    };
-
     await TestBed.configureTestingModule({
       imports: [MockedTestingModule, ImportColumnMappingComponent],
-      providers: [
-        { provide: ImportConfigDialogService, useValue: mockConfigDialogs },
-      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ImportColumnMappingComponent);
@@ -85,80 +60,5 @@ describe("ImportColumnMappingComponent", () => {
     expect(component.columnMapping()).toEqual([
       expect.objectContaining({ column: "Name", additional: "YYYY-MM-DD" }),
     ]);
-  });
-
-  it("should open the config dialog of each newly mapped column that needs one and apply the result", async () => {
-    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
-    fixture.componentRef.setInput("rawData", [{ gender: "male", name: "x" }]);
-    fixture.componentRef.setInput("columnMapping", [
-      { column: "name", propertyName: "name", manuallyUpdated: true },
-      { column: "gender", propertyName: "category", manuallyUpdated: true },
-      { column: "other", propertyName: "category", manuallyUpdated: true },
-    ]);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(2);
-    expect(component.columnMapping()).toEqual([
-      expect.objectContaining({ column: "name" }),
-      expect.objectContaining({
-        column: "gender",
-        additional: { values: { male: "M" } },
-      }),
-      expect.objectContaining({
-        column: "other",
-        additional: { values: { male: "M" } },
-      }),
-    ]);
-  });
-
-  it("should not open dialogs for columns that were mapped automatically", async () => {
-    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
-    // no manuallyUpdated flag: the column header matched the field, the user did not select it
-    fixture.componentRef.setInput("columnMapping", [
-      { column: "gender", propertyName: "category" },
-    ]);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(mockConfigDialogs.openConfigDialog).not.toHaveBeenCalled();
-  });
-
-  it("should not open the dialog again once its result was applied to the column", async () => {
-    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
-    fixture.componentRef.setInput("columnMapping", [
-      { column: "gender", propertyName: "category", manuallyUpdated: true },
-    ]);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    component.updateColumnMapping(component.columnMapping()[0], {
-      ...component.columnMapping()[0],
-      additional: undefined,
-    });
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(1);
-  });
-
-  it("should open the dialog again when the column is mapped to a different field", async () => {
-    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
-    fixture.componentRef.setInput("columnMapping", [
-      { column: "gender", propertyName: "category", manuallyUpdated: true },
-    ]);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    mockConfigDialogs.hasConfigDialog.mockReturnValue(true);
-    component.updateColumnMapping(component.columnMapping()[0], {
-      column: "gender",
-      propertyName: "dateOfBirth",
-      manuallyUpdated: true,
-    });
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
@@ -20,11 +20,13 @@ describe("ImportColumnMappingComponent", () => {
         .mockImplementation(
           (col: ColumnMapping) => col.propertyName === "category",
         ),
-      openConfigDialog: vi
-        .fn()
-        .mockImplementation((col: ColumnMapping) =>
-          Promise.resolve({ ...col, additional: { values: { male: "M" } } }),
-        ),
+      openConfigDialog: vi.fn().mockImplementation((col: ColumnMapping) =>
+        Promise.resolve({
+          ...col,
+          additional: { values: { male: "M" } },
+          configReview: "confirmed",
+        }),
+      ),
     };
 
     await TestBed.configureTestingModule({
@@ -85,13 +87,13 @@ describe("ImportColumnMappingComponent", () => {
     ]);
   });
 
-  it("should open the config dialog of each mapped column that needs one and apply the result", async () => {
+  it("should open the config dialog of each newly mapped column that needs one and apply the result", async () => {
     fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
     fixture.componentRef.setInput("rawData", [{ gender: "male", name: "x" }]);
     fixture.componentRef.setInput("columnMapping", [
-      { column: "name", propertyName: "name" },
-      { column: "gender", propertyName: "category" },
-      { column: "other", propertyName: "category" },
+      { column: "name", propertyName: "name", manuallyUpdated: true },
+      { column: "gender", propertyName: "category", manuallyUpdated: true },
+      { column: "other", propertyName: "category", manuallyUpdated: true },
     ]);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -110,18 +112,30 @@ describe("ImportColumnMappingComponent", () => {
     ]);
   });
 
-  it("should not open the dialog again for a column that was already offered for review", async () => {
+  it("should not open dialogs for columns that were mapped automatically", async () => {
     fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
+    // no manuallyUpdated flag: the column header matched the field, the user did not select it
     fixture.componentRef.setInput("columnMapping", [
       { column: "gender", propertyName: "category" },
     ]);
     fixture.detectChanges();
     await fixture.whenStable();
 
-    component.updateColumnMapping(
-      { column: "gender", propertyName: "category" },
-      { column: "gender", propertyName: "category", additional: undefined },
-    );
+    expect(mockConfigDialogs.openConfigDialog).not.toHaveBeenCalled();
+  });
+
+  it("should not open the dialog again once its result was applied to the column", async () => {
+    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
+    fixture.componentRef.setInput("columnMapping", [
+      { column: "gender", propertyName: "category", manuallyUpdated: true },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.updateColumnMapping(component.columnMapping()[0], {
+      ...component.columnMapping()[0],
+      additional: undefined,
+    });
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -131,16 +145,17 @@ describe("ImportColumnMappingComponent", () => {
   it("should open the dialog again when the column is mapped to a different field", async () => {
     fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
     fixture.componentRef.setInput("columnMapping", [
-      { column: "gender", propertyName: "category" },
+      { column: "gender", propertyName: "category", manuallyUpdated: true },
     ]);
     fixture.detectChanges();
     await fixture.whenStable();
 
     mockConfigDialogs.hasConfigDialog.mockReturnValue(true);
-    component.updateColumnMapping(
-      { column: "gender" },
-      { column: "gender", propertyName: "dateOfBirth" },
-    );
+    component.updateColumnMapping(component.columnMapping()[0], {
+      column: "gender",
+      propertyName: "dateOfBirth",
+      manuallyUpdated: true,
+    });
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.spec.ts
@@ -2,14 +2,36 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ImportColumnMappingComponent } from "./import-column-mapping.component";
 import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { ColumnMapping } from "../column-mapping";
+import { ImportConfigDialogService } from "./import-config-dialog.service";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
 
 describe("ImportColumnMappingComponent", () => {
   let component: ImportColumnMappingComponent;
   let fixture: ComponentFixture<ImportColumnMappingComponent>;
+  let mockConfigDialogs: {
+    hasConfigDialog: ReturnType<typeof vi.fn>;
+    openConfigDialog: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
+    mockConfigDialogs = {
+      hasConfigDialog: vi
+        .fn()
+        .mockImplementation(
+          (col: ColumnMapping) => col.propertyName === "category",
+        ),
+      openConfigDialog: vi
+        .fn()
+        .mockImplementation((col: ColumnMapping) =>
+          Promise.resolve({ ...col, additional: { values: { male: "M" } } }),
+        ),
+    };
+
     await TestBed.configureTestingModule({
       imports: [MockedTestingModule, ImportColumnMappingComponent],
+      providers: [
+        { provide: ImportConfigDialogService, useValue: mockConfigDialogs },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ImportColumnMappingComponent);
@@ -38,5 +60,90 @@ describe("ImportColumnMappingComponent", () => {
         propertyName: "Test2",
       }),
     ]);
+  });
+
+  it("should update the column mapping also if the row emitted an outdated object", () => {
+    // e.g. a config dialog that was opened for the previous object of that column emits after it was replaced
+    const outdatedColumnMapping: ColumnMapping = {
+      column: "Name",
+      propertyName: "test",
+    };
+
+    fixture.componentRef.setInput("columnMapping", [
+      { ...outdatedColumnMapping },
+    ]);
+    fixture.detectChanges();
+
+    component.updateColumnMapping(outdatedColumnMapping, {
+      column: "Name",
+      propertyName: "test",
+      additional: "YYYY-MM-DD",
+    });
+
+    expect(component.columnMapping()).toEqual([
+      expect.objectContaining({ column: "Name", additional: "YYYY-MM-DD" }),
+    ]);
+  });
+
+  it("should open the config dialog of each mapped column that needs one and apply the result", async () => {
+    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
+    fixture.componentRef.setInput("rawData", [{ gender: "male", name: "x" }]);
+    fixture.componentRef.setInput("columnMapping", [
+      { column: "name", propertyName: "name" },
+      { column: "gender", propertyName: "category" },
+      { column: "other", propertyName: "category" },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(2);
+    expect(component.columnMapping()).toEqual([
+      expect.objectContaining({ column: "name" }),
+      expect.objectContaining({
+        column: "gender",
+        additional: { values: { male: "M" } },
+      }),
+      expect.objectContaining({
+        column: "other",
+        additional: { values: { male: "M" } },
+      }),
+    ]);
+  });
+
+  it("should not open the dialog again for a column that was already offered for review", async () => {
+    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
+    fixture.componentRef.setInput("columnMapping", [
+      { column: "gender", propertyName: "category" },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.updateColumnMapping(
+      { column: "gender", propertyName: "category" },
+      { column: "gender", propertyName: "category", additional: undefined },
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("should open the dialog again when the column is mapped to a different field", async () => {
+    fixture.componentRef.setInput("entityType", TestEntity.ENTITY_TYPE);
+    fixture.componentRef.setInput("columnMapping", [
+      { column: "gender", propertyName: "category" },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    mockConfigDialogs.hasConfigDialog.mockReturnValue(true);
+    component.updateColumnMapping(
+      { column: "gender" },
+      { column: "gender", propertyName: "dateOfBirth" },
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockConfigDialogs.openConfigDialog).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
@@ -18,6 +18,7 @@ import { MatBadgeModule } from "@angular/material/badge";
 import { ImportColumnMappingService } from "./import-column-mapping.service";
 import { EditImportColumnMappingComponent } from "./edit-import-column-mapping/edit-import-column-mapping.component";
 import { ImportAdditionalSettings } from "../import-additional-settings";
+import { ImportConfigDialogService } from "./import-config-dialog.service";
 
 /**
  * Import sub-step: Let user map columns from import data to entity properties
@@ -38,8 +39,11 @@ import { ImportAdditionalSettings } from "../import-additional-settings";
   ],
 })
 export class ImportColumnMappingComponent {
-  private entities = inject(EntityRegistry);
-  private importColumnMappingService = inject(ImportColumnMappingService);
+  private readonly entities = inject(EntityRegistry);
+  private readonly importColumnMappingService = inject(
+    ImportColumnMappingService,
+  );
+  private readonly configDialogs = inject(ImportConfigDialogService);
 
   rawData = input<any[]>([]);
   columnMapping = model<ColumnMapping[]>([]);
@@ -49,6 +53,10 @@ export class ImportColumnMappingComponent {
   entityCtor = computed(() =>
     this.entityType() ? this.entities.get(this.entityType()) : undefined,
   );
+
+  /** for each column, the field whose config dialog was already shown to the user */
+  private readonly reviewedFields = new Map<string, string>();
+  private reviewingConfigs = false;
 
   constructor() {
     effect(() => {
@@ -63,7 +71,46 @@ export class ImportColumnMappingComponent {
       if (JSON.stringify(autoMappings) !== JSON.stringify(cm)) {
         untracked(() => this.columnMapping.set(autoMappings));
       }
+      untracked(() => this.reviewConfigsOfMappedColumns());
     });
+  }
+
+  /**
+   * Show the config dialog of every mapped column that requires one, one dialog after the other.
+   *
+   * Without this the suggested value mappings are never applied for columns the user did not
+   * touch (e.g. mapped automatically because the column header matches a field),
+   * and the raw values from the file are imported as they are.
+   */
+  private async reviewConfigsOfMappedColumns() {
+    if (this.reviewingConfigs) {
+      return;
+    }
+    this.reviewingConfigs = true;
+
+    try {
+      for (const column of this.columnMapping().map((c) => c.column)) {
+        const col = this.columnMapping().find((c) => c.column === column);
+        if (
+          !col?.propertyName ||
+          this.reviewedFields.get(column) === col.propertyName ||
+          !this.configDialogs.hasConfigDialog(col, this.entityCtor())
+        ) {
+          continue;
+        }
+
+        this.reviewedFields.set(column, col.propertyName);
+        const configuredCol = await this.configDialogs.openConfigDialog(
+          col,
+          this.rawData(),
+          this.entityCtor(),
+          this.additionalSettings(),
+        );
+        this.updateColumnMapping(col, configuredCol);
+      }
+    } finally {
+      this.reviewingConfigs = false;
+    }
   }
 
   updateColumnMapping(
@@ -72,7 +119,10 @@ export class ImportColumnMappingComponent {
   ) {
     this.columnMapping.update((cm) => {
       const next = [...cm];
-      const index = next.indexOf(originalColumnMapping);
+      // match by column rather than object identity, changes can be emitted after the array was replaced
+      const index = next.findIndex(
+        (c) => c.column === originalColumnMapping.column,
+      );
       if (index >= 0) {
         next[index] = { ...newColumnMapping };
       }

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
@@ -18,7 +18,6 @@ import { MatBadgeModule } from "@angular/material/badge";
 import { ImportColumnMappingService } from "./import-column-mapping.service";
 import { EditImportColumnMappingComponent } from "./edit-import-column-mapping/edit-import-column-mapping.component";
 import { ImportAdditionalSettings } from "../import-additional-settings";
-import { ImportConfigDialogService } from "./import-config-dialog.service";
 
 /**
  * Import sub-step: Let user map columns from import data to entity properties
@@ -43,7 +42,6 @@ export class ImportColumnMappingComponent {
   private readonly importColumnMappingService = inject(
     ImportColumnMappingService,
   );
-  private readonly configDialogs = inject(ImportConfigDialogService);
 
   rawData = input<any[]>([]);
   columnMapping = model<ColumnMapping[]>([]);
@@ -53,8 +51,6 @@ export class ImportColumnMappingComponent {
   entityCtor = computed(() =>
     this.entityType() ? this.entities.get(this.entityType()) : undefined,
   );
-
-  private reviewingConfigs = false;
 
   constructor() {
     effect(() => {
@@ -69,49 +65,7 @@ export class ImportColumnMappingComponent {
       if (JSON.stringify(autoMappings) !== JSON.stringify(cm)) {
         untracked(() => this.columnMapping.set(autoMappings));
       }
-      untracked(() => this.reviewConfigsOfMappedColumns());
     });
-  }
-
-  /**
-   * Show the config dialog of every column the user newly mapped, one dialog after the other,
-   * so that the suggested value mappings are reviewed instead of silently skipped.
-   *
-   * Columns that were mapped automatically because their header matches a field are left alone,
-   * opening their dialogs would bury the user in dialogs on entering the step. Those are marked
-   * as unconfigured in the UI instead.
-   */
-  private async reviewConfigsOfMappedColumns() {
-    if (this.reviewingConfigs) {
-      return;
-    }
-    this.reviewingConfigs = true;
-
-    try {
-      for (const column of this.columnMapping().map((c) => c.column)) {
-        const col = this.columnMapping().find((c) => c.column === column);
-        if (
-          !col?.propertyName ||
-          // only columns the user mapped themselves, and only until their dialog was shown once
-          // (selecting a field resets `configReview`, so a changed field is offered again)
-          !col.manuallyUpdated ||
-          col.configReview ||
-          !this.configDialogs.hasConfigDialog(col, this.entityCtor())
-        ) {
-          continue;
-        }
-
-        const configuredCol = await this.configDialogs.openConfigDialog(
-          col,
-          this.rawData(),
-          this.entityCtor(),
-          this.additionalSettings(),
-        );
-        this.updateColumnMapping(col, configuredCol);
-      }
-    } finally {
-      this.reviewingConfigs = false;
-    }
   }
 
   updateColumnMapping(

--- a/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
+++ b/src/app/core/import/import-column-mapping/import-column-mapping.component.ts
@@ -54,8 +54,6 @@ export class ImportColumnMappingComponent {
     this.entityType() ? this.entities.get(this.entityType()) : undefined,
   );
 
-  /** for each column, the field whose config dialog was already shown to the user */
-  private readonly reviewedFields = new Map<string, string>();
   private reviewingConfigs = false;
 
   constructor() {
@@ -76,11 +74,12 @@ export class ImportColumnMappingComponent {
   }
 
   /**
-   * Show the config dialog of every mapped column that requires one, one dialog after the other.
+   * Show the config dialog of every column the user newly mapped, one dialog after the other,
+   * so that the suggested value mappings are reviewed instead of silently skipped.
    *
-   * Without this the suggested value mappings are never applied for columns the user did not
-   * touch (e.g. mapped automatically because the column header matches a field),
-   * and the raw values from the file are imported as they are.
+   * Columns that were mapped automatically because their header matches a field are left alone,
+   * opening their dialogs would bury the user in dialogs on entering the step. Those are marked
+   * as unconfigured in the UI instead.
    */
   private async reviewConfigsOfMappedColumns() {
     if (this.reviewingConfigs) {
@@ -93,13 +92,15 @@ export class ImportColumnMappingComponent {
         const col = this.columnMapping().find((c) => c.column === column);
         if (
           !col?.propertyName ||
-          this.reviewedFields.get(column) === col.propertyName ||
+          // only columns the user mapped themselves, and only until their dialog was shown once
+          // (selecting a field resets `configReview`, so a changed field is offered again)
+          !col.manuallyUpdated ||
+          col.configReview ||
           !this.configDialogs.hasConfigDialog(col, this.entityCtor())
         ) {
           continue;
         }
 
-        this.reviewedFields.set(column, col.propertyName);
         const configuredCol = await this.configDialogs.openConfigDialog(
           col,
           this.rawData(),

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
@@ -44,7 +44,7 @@ describe("ImportConfigDialogService", () => {
   it("should open the dialog with the column's unique values and return the configured mapping", async () => {
     mockDialog.open.mockImplementation((_component, config) => {
       config.data.col.additional = { values: { male: "M" } };
-      return { afterClosed: () => of(undefined) };
+      return { afterClosed: () => of(true) };
     });
     const col: ColumnMapping = { column: "gender", propertyName: "category" };
 
@@ -58,8 +58,23 @@ describe("ImportConfigDialogService", () => {
     expect(dialogData.values).toEqual(["male", "female"]);
     expect(dialogData.totalRowCount).toBe(3);
     expect(result.additional).toEqual({ values: { male: "M" } });
+    expect(result.configReview).toBe("confirmed");
     // the given mapping is not modified, the dialog result is returned as a new object
     expect(col.additional).toBeUndefined();
+  });
+
+  it("should mark a cancelled config as unconfirmed, unless it was confirmed before", async () => {
+    const col: ColumnMapping = { column: "gender", propertyName: "category" };
+
+    const cancelled = await service.openConfigDialog(col, [], TestEntity);
+    expect(cancelled.configReview).toBe("cancelled");
+
+    const cancelledAfterConfirming = await service.openConfigDialog(
+      { ...col, configReview: "confirmed" },
+      [],
+      TestEntity,
+    );
+    expect(cancelledAfterConfirming.configReview).toBe("confirmed");
   });
 
   it("should not open a dialog for a field whose datatype does not define one", async () => {

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from "@angular/core/testing";
+import { MatDialog } from "@angular/material/dialog";
+import { of } from "rxjs";
+import { ImportConfigDialogService } from "./import-config-dialog.service";
+import { MockedTestingModule } from "../../../utils/mocked-testing.module";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { ColumnMapping } from "../column-mapping";
+
+describe("ImportConfigDialogService", () => {
+  let service: ImportConfigDialogService;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => of(undefined) }),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [MockedTestingModule.withState()],
+      providers: [{ provide: MatDialog, useValue: mockDialog }],
+    });
+
+    service = TestBed.inject(ImportConfigDialogService);
+  });
+
+  it("should detect which mapped fields have a config dialog", () => {
+    expect(
+      service.hasConfigDialog(
+        { column: "gender", propertyName: "category" },
+        TestEntity,
+      ),
+    ).toBe(true);
+    expect(
+      service.hasConfigDialog(
+        { column: "name", propertyName: "name" },
+        TestEntity,
+      ),
+    ).toBe(false);
+    expect(service.hasConfigDialog({ column: "gender" }, TestEntity)).toBe(
+      false,
+    );
+  });
+
+  it("should open the dialog with the column's unique values and return the configured mapping", async () => {
+    mockDialog.open.mockImplementation((_component, config) => {
+      config.data.col.additional = { values: { male: "M" } };
+      return { afterClosed: () => of(undefined) };
+    });
+    const col: ColumnMapping = { column: "gender", propertyName: "category" };
+
+    const result = await service.openConfigDialog(
+      col,
+      [{ gender: "male" }, { gender: "female" }, { gender: "male" }],
+      TestEntity,
+    );
+
+    const dialogData = mockDialog.open.mock.calls[0][1].data;
+    expect(dialogData.values).toEqual(["male", "female"]);
+    expect(dialogData.totalRowCount).toBe(3);
+    expect(result.additional).toEqual({ values: { male: "M" } });
+    // the given mapping is not modified, the dialog result is returned as a new object
+    expect(col.additional).toBeUndefined();
+  });
+
+  it("should not open a dialog for a field whose datatype does not define one", async () => {
+    const col: ColumnMapping = { column: "name", propertyName: "name" };
+
+    const result = await service.openConfigDialog(
+      col,
+      [{ name: "x" }],
+      TestEntity,
+    );
+
+    expect(mockDialog.open).not.toHaveBeenCalled();
+    expect(result).toBe(col);
+  });
+});

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.spec.ts
@@ -23,6 +23,33 @@ describe("ImportConfigDialogService", () => {
     service = TestBed.inject(ImportConfigDialogService);
   });
 
+  it("should report a missing config only for fields that need one and have no additional yet", () => {
+    const needsConfig: ColumnMapping = {
+      column: "gender",
+      propertyName: "category",
+    };
+    expect(service.isConfigMissing(needsConfig, TestEntity)).toBe(true);
+    expect(
+      service.isConfigMissing(
+        { ...needsConfig, additional: { values: {} } },
+        TestEntity,
+      ),
+    ).toBe(false);
+    // an empty date format is a valid, confirmed config
+    expect(
+      service.isConfigMissing(
+        { column: "date", propertyName: "dateOfBirth", additional: "" },
+        TestEntity,
+      ),
+    ).toBe(false);
+    expect(
+      service.isConfigMissing(
+        { column: "x", propertyName: "name" },
+        TestEntity,
+      ),
+    ).toBe(false);
+  });
+
   it("should detect which mapped fields have a config dialog", () => {
     expect(
       service.hasConfigDialog(
@@ -58,23 +85,17 @@ describe("ImportConfigDialogService", () => {
     expect(dialogData.values).toEqual(["male", "female"]);
     expect(dialogData.totalRowCount).toBe(3);
     expect(result.additional).toEqual({ values: { male: "M" } });
-    expect(result.configReview).toBe("confirmed");
     // the given mapping is not modified, the dialog result is returned as a new object
     expect(col.additional).toBeUndefined();
   });
 
-  it("should mark a cancelled config as unconfirmed, unless it was confirmed before", async () => {
+  it("should leave the mapping unconfigured when the user cancels the dialog", async () => {
     const col: ColumnMapping = { column: "gender", propertyName: "category" };
 
-    const cancelled = await service.openConfigDialog(col, [], TestEntity);
-    expect(cancelled.configReview).toBe("cancelled");
+    const result = await service.openConfigDialog(col, [], TestEntity);
 
-    const cancelledAfterConfirming = await service.openConfigDialog(
-      { ...col, configReview: "confirmed" },
-      [],
-      TestEntity,
-    );
-    expect(cancelledAfterConfirming.configReview).toBe("confirmed");
+    expect(result.additional).toBeUndefined();
+    expect(service.isConfigMissing(result, TestEntity)).toBe(true);
   });
 
   it("should not open a dialog for a field whose datatype does not define one", async () => {

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
@@ -27,11 +27,21 @@ export class ImportConfigDialogService {
   }
 
   /**
-   * Let the user configure how the column's values are imported
-   * and return the resulting column mapping, with `configReview` set to how the dialog was left.
+   * Whether the column still needs its transformation configured by the user.
    *
-   * A cancelled dialog does not discard a configuration that was confirmed before,
-   * the user is backing out of an edit rather than dropping their earlier decision.
+   * The dialogs only write `additional` when the user confirms them, so a column that requires
+   * a dialog and has no `additional` yet has either never been opened or been cancelled.
+   * In both cases the values of the file would be imported without any transformation.
+   */
+  isConfigMissing(col: ColumnMapping, entityType: EntityConstructor): boolean {
+    return this.hasConfigDialog(col, entityType) && col.additional == null;
+  }
+
+  /**
+   * Let the user configure how the column's values are imported
+   * and return the resulting column mapping.
+   *
+   * The returned mapping only differs from the given one if the user confirmed the dialog.
    */
   async openConfigDialog(
     col: ColumnMapping,
@@ -55,16 +65,13 @@ export class ImportConfigDialogService {
       additionalSettings: additionalSettings,
     };
 
-    const saved = await firstValueFrom(
+    await firstValueFrom(
       this.dialog
         .open(dialogComponent, { data, width: "80vw", disableClose: true })
         .afterClosed(),
     );
 
-    return {
-      ...data.col,
-      configReview: saved ? "confirmed" : (col.configReview ?? "cancelled"),
-    };
+    return data.col;
   }
 
   private getConfigDialogName(

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
@@ -1,0 +1,77 @@
+import { inject, Injectable } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
+import { firstValueFrom } from "rxjs";
+import { ColumnMapping } from "../column-mapping";
+import { EntityConstructor } from "../../entity/model/entity";
+import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
+import { ComponentRegistry } from "../../../dynamic-components";
+import { ImportAdditionalSettings } from "../import-additional-settings";
+import { MappingDialogData } from "./mapping-dialog-data";
+
+/**
+ * Open the dialog through which a column's import values are configured
+ * (e.g. value mappings for dropdowns or the format of dates),
+ * as defined by the datatype of the mapped field.
+ */
+@Injectable({ providedIn: "root" })
+export class ImportConfigDialogService {
+  private readonly dialog = inject(MatDialog);
+  private readonly components = inject(ComponentRegistry);
+  private readonly schemaService = inject(EntitySchemaService);
+
+  /**
+   * Whether the field the given column is mapped to requires configuration in a dialog.
+   */
+  hasConfigDialog(col: ColumnMapping, entityType: EntityConstructor): boolean {
+    return !!this.getConfigDialogName(col, entityType);
+  }
+
+  /**
+   * Let the user configure how the column's values are imported
+   * and return the resulting column mapping.
+   *
+   * The given mapping is left unchanged, if the user cancels or the datatype has no dialog.
+   */
+  async openConfigDialog(
+    col: ColumnMapping,
+    rawData: any[],
+    entityType: EntityConstructor,
+    additionalSettings?: ImportAdditionalSettings,
+  ): Promise<ColumnMapping> {
+    const dialogName = this.getConfigDialogName(col, entityType);
+    if (!dialogName) {
+      return col;
+    }
+
+    const dialogComponent = await this.components.get(dialogName)();
+    const uniqueValues = new Set<any>(rawData.map((row) => row[col.column]));
+    // the dialog writes the user's settings into the given mapping, so pass a copy of it
+    const data: MappingDialogData = {
+      col: { ...col },
+      values: [...uniqueValues],
+      totalRowCount: rawData.length,
+      entityType: entityType,
+      additionalSettings: additionalSettings,
+    };
+
+    await firstValueFrom(
+      this.dialog
+        .open(dialogComponent, { data, width: "80vw", disableClose: true })
+        .afterClosed(),
+    );
+
+    return data.col;
+  }
+
+  private getConfigDialogName(
+    col: ColumnMapping,
+    entityType: EntityConstructor,
+  ): string | undefined {
+    const schema = entityType?.schema?.get(col?.propertyName);
+    if (!schema) {
+      return undefined;
+    }
+    return this.schemaService.getDatatypeOrDefault(schema.dataType)
+      .importConfigDialog;
+  }
+}

--- a/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
+++ b/src/app/core/import/import-column-mapping/import-config-dialog.service.ts
@@ -28,9 +28,10 @@ export class ImportConfigDialogService {
 
   /**
    * Let the user configure how the column's values are imported
-   * and return the resulting column mapping.
+   * and return the resulting column mapping, with `configReview` set to how the dialog was left.
    *
-   * The given mapping is left unchanged, if the user cancels or the datatype has no dialog.
+   * A cancelled dialog does not discard a configuration that was confirmed before,
+   * the user is backing out of an edit rather than dropping their earlier decision.
    */
   async openConfigDialog(
     col: ColumnMapping,
@@ -54,13 +55,16 @@ export class ImportConfigDialogService {
       additionalSettings: additionalSettings,
     };
 
-    await firstValueFrom(
+    const saved = await firstValueFrom(
       this.dialog
         .open(dialogComponent, { data, width: "80vw", disableClose: true })
         .afterClosed(),
     );
 
-    return data.col;
+    return {
+      ...data.col,
+      configReview: saved ? "confirmed" : (col.configReview ?? "cancelled"),
+    };
   }
 
   private getConfigDialogName(

--- a/src/app/core/import/import.module.ts
+++ b/src/app/core/import/import.module.ts
@@ -73,10 +73,24 @@ const importComponents: ComponentTuple[] = [
       ),
   ],
   [
+    "DateImportDialog",
+    () =>
+      import("../basic-datatypes/date/date-import-config/date-import-dialog.component").then(
+        (c) => c.DateImportDialogComponent,
+      ),
+  ],
+  [
     "DiscreteImportConfig",
     () =>
       import("../basic-datatypes/discrete/discrete-import-config/discrete-import-config.component").then(
         (c) => c.DiscreteImportConfigComponent,
+      ),
+  ],
+  [
+    "DiscreteImportDialog",
+    () =>
+      import("../basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component").then(
+        (c) => c.DiscreteImportDialogComponent,
       ),
   ],
   [

--- a/src/app/core/import/import/import.component.html
+++ b/src/app/core/import/import/import.component.html
@@ -128,10 +128,7 @@
     </mat-step>
 
     <!-- STEP 3: MAP COLUMNS -->
-    <mat-step
-      [completed]="mappedColumnsCount() > 0 && !hasUnconfirmedColumnConfig()"
-      #step3
-    >
+    <mat-step [completed]="columnMappingComplete()" #step3>
       <ng-template matStepLabel>
         <div i18n="Import Step - map columns">Map Columns</div>
 

--- a/src/app/core/import/import/import.component.html
+++ b/src/app/core/import/import/import.component.html
@@ -132,7 +132,7 @@
       <ng-template matStepLabel>
         <div i18n="Import Step - map columns">Map Columns</div>
 
-        @if (mappedColumnsCount() > 0) {
+        @if (step3.completed) {
           <div
             class="step-label-extra"
             i18n="Import Step - map columns - sub-label"

--- a/src/app/core/import/import/import.component.html
+++ b/src/app/core/import/import/import.component.html
@@ -128,11 +128,14 @@
     </mat-step>
 
     <!-- STEP 3: MAP COLUMNS -->
-    <mat-step [completed]="mappedColumnsCount() > 0" #step3>
+    <mat-step
+      [completed]="mappedColumnsCount() > 0 && !hasUnconfirmedColumnConfig()"
+      #step3
+    >
       <ng-template matStepLabel>
         <div i18n="Import Step - map columns">Map Columns</div>
 
-        @if (step3.completed) {
+        @if (mappedColumnsCount() > 0) {
           <div
             class="step-label-extra"
             i18n="Import Step - map columns - sub-label"

--- a/src/app/core/import/import/import.component.spec.ts
+++ b/src/app/core/import/import/import.component.spec.ts
@@ -173,6 +173,33 @@ describe("ImportComponent", () => {
     await testApplyColumnMapping(loadedMapping, loadedMapping, 2);
   });
 
+  it("should apply historic column mapping - requiring a new review of its value mapping config", async () => {
+    component.importSettings.set({ columnMapping: [{ column: "x" }] });
+
+    // the file of this import can hold values the previous import did not have,
+    // so its config has to be reviewed for the new file rather than taken as confirmed
+    await testApplyColumnMapping(
+      [
+        {
+          column: "x",
+          propertyName: "gender",
+          additional: { values: { male: "M" } },
+          configReview: "confirmed",
+          manuallyUpdated: true,
+        },
+      ],
+      [
+        {
+          column: "x",
+          propertyName: "gender",
+          additional: { values: { male: "M" } },
+        },
+      ],
+      1,
+    );
+    expect(component.hasUnconfirmedColumnConfig()).toBe(false);
+  });
+
   it("should apply historic column mapping - overwriting existing mappings", async () => {
     component.importSettings.set({
       columnMapping: [

--- a/src/app/core/import/import/import.component.spec.ts
+++ b/src/app/core/import/import/import.component.spec.ts
@@ -122,22 +122,30 @@ describe("ImportComponent", () => {
     expect(component.mappedColumnsCount()).toBe(0);
   });
 
-  it("should flag a column whose config dialog was closed without confirming", () => {
+  it("should block the mapping step while a column still needs its values configured", () => {
     component.importSettings.set({
+      entityType: "Child",
       columnMapping: [
         { column: "x", propertyName: "name" },
-        { column: "y", propertyName: "gender", configReview: "confirmed" },
+        { column: "y", propertyName: "gender" },
       ],
     });
-    expect(component.hasUnconfirmedColumnConfig()).toBe(false);
+
+    expect(component.columnsMissingConfig()).toEqual([
+      { column: "y", propertyName: "gender" },
+    ]);
+    expect(component.columnMappingComplete()).toBe(false);
 
     component.importSettings.set({
+      entityType: "Child",
       columnMapping: [
         { column: "x", propertyName: "name" },
-        { column: "y", propertyName: "gender", configReview: "cancelled" },
+        { column: "y", propertyName: "gender", additional: { values: {} } },
       ],
     });
-    expect(component.hasUnconfirmedColumnConfig()).toBe(true);
+
+    expect(component.columnsMissingConfig()).toEqual([]);
+    expect(component.columnMappingComplete()).toBe(true);
   });
 
   async function testApplyColumnMapping(
@@ -171,33 +179,6 @@ describe("ImportComponent", () => {
     ];
 
     await testApplyColumnMapping(loadedMapping, loadedMapping, 2);
-  });
-
-  it("should apply historic column mapping - requiring a new review of its value mapping config", async () => {
-    component.importSettings.set({ columnMapping: [{ column: "x" }] });
-
-    // the file of this import can hold values the previous import did not have,
-    // so its config has to be reviewed for the new file rather than taken as confirmed
-    await testApplyColumnMapping(
-      [
-        {
-          column: "x",
-          propertyName: "gender",
-          additional: { values: { male: "M" } },
-          configReview: "confirmed",
-          manuallyUpdated: true,
-        },
-      ],
-      [
-        {
-          column: "x",
-          propertyName: "gender",
-          additional: { values: { male: "M" } },
-        },
-      ],
-      1,
-    );
-    expect(component.hasUnconfirmedColumnConfig()).toBe(false);
   });
 
   it("should apply historic column mapping - overwriting existing mappings", async () => {

--- a/src/app/core/import/import/import.component.spec.ts
+++ b/src/app/core/import/import/import.component.spec.ts
@@ -122,6 +122,24 @@ describe("ImportComponent", () => {
     expect(component.mappedColumnsCount()).toBe(0);
   });
 
+  it("should flag a column whose config dialog was closed without confirming", () => {
+    component.importSettings.set({
+      columnMapping: [
+        { column: "x", propertyName: "name" },
+        { column: "y", propertyName: "gender", configReview: "confirmed" },
+      ],
+    });
+    expect(component.hasUnconfirmedColumnConfig()).toBe(false);
+
+    component.importSettings.set({
+      columnMapping: [
+        { column: "x", propertyName: "name" },
+        { column: "y", propertyName: "gender", configReview: "cancelled" },
+      ],
+    });
+    expect(component.hasUnconfirmedColumnConfig()).toBe(true);
+  });
+
   async function testApplyColumnMapping(
     appliedMapping: ColumnMapping[],
     expectedMapping: ColumnMapping[],

--- a/src/app/core/import/import/import.component.ts
+++ b/src/app/core/import/import/import.component.ts
@@ -117,6 +117,17 @@ export class ImportComponent {
         .length ?? 0,
   );
 
+  /**
+   * Whether a column's config dialog was opened but closed without confirming the mapping.
+   * The user has to finish what they started before the import can continue.
+   */
+  hasUnconfirmedColumnConfig = computed(
+    () =>
+      this.importSettings().columnMapping?.some(
+        (m) => m.configReview === "cancelled",
+      ) ?? false,
+  );
+
   constructor() {
     this.route.queryParamMap.subscribe((params) => {
       if (params.has("entityType")) {

--- a/src/app/core/import/import/import.component.ts
+++ b/src/app/core/import/import/import.component.ts
@@ -208,12 +208,21 @@ export class ImportComponent {
       return;
     }
 
-    const adjustedMappings = currentColumnMapping.map(
-      ({ column }) =>
-        importMetadata.config.columnMapping.find(
-          (c) => column === c.column,
-        ) ?? { column },
-    );
+    const adjustedMappings = currentColumnMapping.map(({ column }) => {
+      const previous = importMetadata.config.columnMapping.find(
+        (c) => column === c.column,
+      );
+      if (!previous) {
+        return { column };
+      }
+
+      // The file of this import can hold values the previous import did not have, so the
+      // transformation config of the loaded mapping counts as unreviewed for this file.
+      // It is not marked as manually updated either, otherwise its dialog would open
+      // right away for every loaded column.
+      const { configReview, manuallyUpdated, ...reviewedAnew } = previous;
+      return reviewedAnew;
+    });
 
     // TODO: load additionalActions also
 

--- a/src/app/core/import/import/import.component.ts
+++ b/src/app/core/import/import/import.component.ts
@@ -30,6 +30,8 @@ import { ImportMatchExistingComponent } from "../update-existing/import-match-ex
 import { WarningNotOptimizedForSmallScreenComponent } from "#src/app/core/common-components/warning-not-optimized-for-small-screen/warning-not-optimized-for-small-screen.component";
 import { EntityAbility } from "../../permissions/ability/entity-ability";
 import { HintBoxComponent } from "../../common-components/hint-box/hint-box.component";
+import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { ImportConfigDialogService } from "../import-column-mapping/import-config-dialog.service";
 
 /**
  * View providing a full UI workflow to import data from an uploaded file.
@@ -65,6 +67,8 @@ export class ImportComponent {
   private router = inject(Router);
   private location = inject<Location>(LOCATION_TOKEN);
   private readonly ability = inject(EntityAbility);
+  private readonly entities = inject(EntityRegistry);
+  private readonly configDialogs = inject(ImportConfigDialogService);
 
   rawData: any[];
 
@@ -118,14 +122,24 @@ export class ImportComponent {
   );
 
   /**
-   * Whether a column's config dialog was opened but closed without confirming the mapping.
-   * The user has to finish what they started before the import can continue.
+   * Columns that are mapped to a field whose values have to be transformed,
+   * but whose transformation the user has not configured and confirmed yet.
    */
-  hasUnconfirmedColumnConfig = computed(
+  columnsMissingConfig = computed(() => {
+    const entityType = this.importSettings().entityType;
+    const entityCtor = entityType ? this.entities.get(entityType) : undefined;
+    if (!entityCtor) {
+      return [];
+    }
+    return (this.importSettings().columnMapping ?? []).filter((m) =>
+      this.configDialogs.isConfigMissing(m, entityCtor),
+    );
+  });
+
+  /** whether the user can continue from the column mapping step to the import preview */
+  columnMappingComplete = computed(
     () =>
-      this.importSettings().columnMapping?.some(
-        (m) => m.configReview === "cancelled",
-      ) ?? false,
+      this.mappedColumnsCount() > 0 && this.columnsMissingConfig().length === 0,
   );
 
   constructor() {
@@ -208,21 +222,12 @@ export class ImportComponent {
       return;
     }
 
-    const adjustedMappings = currentColumnMapping.map(({ column }) => {
-      const previous = importMetadata.config.columnMapping.find(
-        (c) => column === c.column,
-      );
-      if (!previous) {
-        return { column };
-      }
-
-      // The file of this import can hold values the previous import did not have, so the
-      // transformation config of the loaded mapping counts as unreviewed for this file.
-      // It is not marked as manually updated either, otherwise its dialog would open
-      // right away for every loaded column.
-      const { configReview, manuallyUpdated, ...reviewedAnew } = previous;
-      return reviewedAnew;
-    });
+    const adjustedMappings = currentColumnMapping.map(
+      ({ column }) =>
+        importMetadata.config.columnMapping.find(
+          (c) => column === c.column,
+        ) ?? { column },
+    );
 
     // TODO: load additionalActions also
 


### PR DESCRIPTION
- closes #4185

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## What this changes

Columns mapped to a field whose datatype needs extra import configuration (dropdown / checkbox value mapping, date format) could pass the column mapping step without that dialog ever being opened. The values from the file were then taken over as they are, which is what broke the stored checkbox values reported in #4165.

The column mapping step now makes that state visible and, where the user started configuring, mandatory:

| situation | what the user sees |
| --- | --- |
| user selects a field that needs configuration | its dialog opens right away, with the suggested mappings applied, to confirm or refine |
| column was mapped automatically (header matches a field) | no dialog, but a warning badge with tooltip on the button and a message below the field that the values are imported as they are |
| dialog closed with "Save & Close" | badge and message disappear, the mapping can still be reopened and changed |
| dialog closed with "Cancel" | message asks to open and confirm it, and "Continue" stays disabled until that happened |

Automatically mapped columns deliberately do not open their dialogs: a file whose headers match several fields would otherwise bury the user under dialogs before they even see the step.

### Implementation

- New `ImportConfigDialogService` owns opening a column's config dialog: it resolves the dialog component, collects the column's unique values, and returns the resulting `ColumnMapping`. The mapping passed in is no longer modified by the dialog, the result comes back as a new object.
- Datatypes declare their dialog through the new `importConfigDialog` property (`DiscreteImportDialog`, `DateImportDialog`), so nothing outside the datatype needs to know which dialog belongs to which field.
- Both dialogs now close with a result on save, which the service turns into `configReview` on the column mapping (`confirmed` / `cancelled`). Cancelling does not overwrite a configuration that was confirmed before.
- `ImportColumnMappingComponent` opens the dialogs of newly mapped columns one after the other and uses `configReview` to never show the same dialog twice.
- The message below the field uses `mat-error`, like other validation messages, pulled into the space the form field keeps for its own errors so that it belongs to the field above it.
- The date column now has the same badge and tooltip as value mappings, previously it gave no indication at all.
- The date and discrete inline config components delegate to the service, which removes their duplicated dialog setup code.

## Manual Testing Steps

### Automatically mapped columns are marked, not interrupted

1. Open the Import view and upload a CSV whose headers match existing fields:

```
name,gender,center,dropoutDate
Alice,female,Alpha,2024-01-05
Bob,male,Beta,
Carol,f,Alpha,2023-11-30
```

2. Continue, import as **Child**, Continue again.
3. "Map Columns" opens with **no dialog**. The rows for `gender`, `center` and `dropoutDate` show a red "?" badge on their "Configure value mapping" button and a red message below the field: "Value mapping not configured, the values from the file are imported as they are.". The `name` row has no button and no message.
4. Hover the badge / button of `gender` and of `dropoutDate`: each shows a tooltip explaining what is missing.
5. "Continue" is enabled, an unconfigured column does not block the import.

### A newly selected field opens its dialog

6. Map any column to a dropdown or date field yourself (e.g. reselect "Gender" on the `gender` row). Its dialog opens immediately, exactly once.
7. Press "Save & Close". The message and the "?" badge of that row disappear.

### Cancelling blocks the step

8. Reselect a field on the `center` row so its dialog opens, and press "Cancel" this time.
9. The row now says "Value mapping was not saved. Open it and confirm to continue." and "Continue" is **disabled**.
10. Open the same dialog again through its button and press "Save & Close": the message disappears and "Continue" is enabled again.
11. Reopen that dialog once more and press "Cancel": the column stays confirmed, cancelling an edit does not throw away what was already confirmed.

### Nothing repeats itself

12. Press "Back" and "Continue" again: no dialog opens a second time and the messages are unchanged.
13. Map a column to a plain text field: no button, no message, no dialog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added datatype-specific import configuration for date formats and discrete value mappings.
  * Added badges and tooltips showing configuration status.
  * Added validation errors for missing import configuration.
  * Import completion now requires all mapped fields to be fully configured.
  * Improved mapping updates when column data changes.

* **Bug Fixes**
  * Ensured empty date formats are saved consistently.
  * Prevented duplicate configuration dialogs.

* **Documentation**
  * Added import workflow and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->