### PR TITLE
chore(deps): enable Renovate for Dockerfile base image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     ":maintainLockFilesMonthly"
   ],
   "enabledManagers": [
-    "npm"
+    "npm",
+    "dockerfile"
   ],
   "timezone": "Etc/UTC",
   "schedule": [
@@ -64,6 +65,17 @@
         "patch"
       ],
       "groupName": "weekly-non-major-updates",
+      "automerge": false
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "docker-base-image",
       "automerge": false
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `dockerfile` to `enabledManagers` so Renovate tracks the `nginxinc/nginx-unprivileged:alpine` base image in `build/Dockerfile` (previously only npm deps were covered).
- Adds a `docker-base-image` package rule grouping minor/patch base-image bumps into their own PR, separate from the npm `weekly-non-major-updates` group. Major bumps already flow through the existing unrestricted major-update rule (draft PR).

## Test plan
- [ ] Confirm Renovate picks up the Dockerfile on next run (dependency dashboard / PR appears if an update is available)