### PR TITLE
fix(entity-block): don't crash change detection on a non-string entityId

### DIFF
--- a/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.spec.ts
@@ -119,9 +119,12 @@ describe("EntityBlockComponent", () => {
 
   it("renders the not-found fallback instead of throwing when entityId is not a string", async () => {
     // an Entity accidentally bound to [entityId] instead of [entity]: truthy, so it
-    // reaches the loader, but not a string, so extractTypeFromId() rejects it
+    // reaches the loader, but not a string, so extractTypeFromId() rejects it.
+    // typed as unknown rather than cast, so the boundary is explicit and the rest
+    // of the test keeps full type checking.
+    const runtimeInvalidEntityId: unknown = testEntity;
     mockEntityMapper.load.mockRejectedValue(new Error("not found"));
-    fixture.componentRef.setInput("entityId", testEntity as any);
+    fixture.componentRef.setInput("entityId", runtimeInvalidEntityId);
     fixture.detectChanges();
 
     await vi.waitFor(() => expect(component.notFound()).toBe(true));

--- a/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.spec.ts
@@ -117,6 +117,21 @@ describe("EntityBlockComponent", () => {
     expect(fixture.nativeElement.textContent).toContain("not available");
   });
 
+  it("renders the not-found fallback instead of throwing when entityId is not a string", async () => {
+    // an Entity accidentally bound to [entityId] instead of [entity]: truthy, so it
+    // reaches the loader, but not a string, so extractTypeFromId() rejects it
+    mockEntityMapper.load.mockRejectedValue(new Error("not found"));
+    fixture.componentRef.setInput("entityId", testEntity as any);
+    fixture.detectChanges();
+
+    await vi.waitFor(() => expect(component.notFound()).toBe(true));
+
+    expect(() => component.missingEntityType()).not.toThrow();
+    expect(component.missingEntityType()).toBeUndefined();
+    expect(component.notFoundIcon()).toBe("diamond");
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
   it("should display configured entity color on the icon", async () => {
     TestEntity.color = "#ff0000";
     try {

--- a/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.ts
+++ b/src/app/core/basic-datatypes/entity/entity-block/entity-block.component.ts
@@ -97,7 +97,17 @@ export class EntityBlockComponent {
     if (!this.notFound()) {
       return undefined;
     }
-    const type = Entity.extractTypeFromId(this.entityId());
+    const id = this.entityId();
+    if (typeof id !== "string") {
+      // `entityId` is typed as string, but nothing enforces that at runtime for a
+      // block that is rendered from user config. A non-string id makes the resource
+      // loader below fail and swallow the error, which in turn makes notFound() true
+      // and brings us here — so extractTypeFromId() would throw on every change
+      // detection pass, inside a computed the template reads. Degrade to the generic
+      // not-found display instead.
+      return undefined;
+    }
+    const type = Entity.extractTypeFromId(id);
     return type && this.registry.has(type)
       ? this.registry.get(type)
       : undefined;


### PR DESCRIPTION
Fixes [AAM-DIGITAL-754](https://aam-digital.sentry.io/issues/AAM-DIGITAL-754)

Found by the automated monitoring routine, 2026-08-05.

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — see "Verification" below; covered by a regression test that fails without the fix
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## The problem

[AAM-DIGITAL-754](https://aam-digital.sentry.io/issues/AAM-DIGITAL-754) appeared today: **11 events in ~2 seconds**, all from one page view on `codo-koordination.aam-digital.com` `/c/child`, substatus `escalating`, `ndb-core@3.87.2`.

```
Error: Invalid entity id provided: School:87611a62-7fa0-4923-96a7-5ab38d793355. Expected a non-empty string.
  at Entity.extractTypeFromId (src/app/core/entity/model/entity.ts:185)
  at missingEntityType         (entity-block.component.ts:100)
  at notFoundIcon              (entity-block.component.ts:112)
  at entity-block.component.html:18   [icon]="notFoundIcon()"
```

The message reads like a contradiction — it prints what looks like a perfectly good id while claiming it isn't a non-empty string. That is the tell. `extractTypeFromId` only throws when `!id || typeof id !== "string"`, and the message interpolates `${id}`, so the value is **not a string** but stringifies to `School:<uuid>`. Both of these reproduce the message exactly:

```js
String(["School:87611a62-…"])              // "School:87611a62-…"   ← entity-array field with one entry
String(entityInstance)                     // "School:87611a62-…"   ← Entity bound to [entityId]
```

Four distinct `School:` UUIDs appear in the same 2-second burst, which fits a list of school references being rendered.

## Why it fires 11 times instead of once

The throw is inside a `computed()` that the template reads through `notFoundIcon()`. Angular re-evaluates it on every change detection pass, so one bad reference produces a stream of unhandled errors, not a single one.

## Why the existing error handling made it reachable

`entityResource`'s loader already calls `extractTypeFromId` with the same value — inside a `try/catch` that logs at debug and returns `undefined`:

```ts
} catch (e) {
  Logging.debug("[DISPLAY_ENTITY] Could not find entity.", entityId, e);
  return undefined;
}
```

Returning `undefined` is exactly what makes `notFound()` true, and `notFound() === true` is the branch that calls `extractTypeFromId` **without** protection. So the tolerant path upstream is what guarantees the crash downstream — every invalid id is quietly routed into the one place that can't handle it.

## The change

One guard in `missingEntityType`, matching the tolerance the loader already has:

```ts
const id = this.entityId();
if (typeof id !== "string") {
  return undefined;
}
```

The block then renders its normal "not available" fallback with the generic `diamond` icon — the same thing it already shows for a registered-but-unknown type. No user-visible regression; the referenced record was unresolvable either way.

## Verification

```
ng test --include='…/entity-block.component.spec.ts'      →  9/9 passed
ng test --include='src/app/core/basic-datatypes/**/*.spec.ts'  →  234 passed, 10 skipped (48 files)
eslint src/app/core/basic-datatypes/entity/entity-block/       →  clean
prettier --check                                               →  clean
```

The regression test was confirmed to actually catch the bug — with the guard reverted it fails, reproducing the production error verbatim:

```
AssertionError: expected [Function] to not throw an error but
'Error: Invalid entity id provided: . Expected a non-empty string.' was thrown
```

(The interpolation is empty rather than `School:…` only because `TestEntity` has no `toStringAttributes`; the code path is identical.)

## Open question for reviewers

This fixes the crash, not the mis-binding that produces it. Something on `codo-koordination`'s `/c/child` view passes a non-string into `[entityId]` — most likely an entity-**array** field rendered through a single-value `EntityBlock`. Identifying that binding needs the tenant's config, which isn't visible from the monitoring side. If an entity-array reaching this input is considered legitimate, the better long-term fix is for the block to render one child block per entry rather than to degrade — happy to follow up either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPcokDDJaYitdTGrQW7yaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPcokDDJaYitdTGrQW7yaH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid, non-text entity identifiers could cause errors instead of displaying the not-found state.
  * Ensured missing entity types use the generic not-found display and default icon reliably.
  * Improved stability during repeated screen updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->