### PR TITLE
refactor: move bootstrap-time helpers into plain TS modules

### DIFF
--- a/doc/compodoc_sources/concepts/i18n.md
+++ b/doc/compodoc_sources/concepts/i18n.md
@@ -219,24 +219,6 @@ and booleans.
 
 ### Do's and don'ts
 
-- In the `bootstrap-*.ts` modules that `main.ts` imports statically (see
-  [bootstrap order](#bootstrap-order-dont-localize-before-translations-are-loaded)), never evaluate
-  `$localize` at module scope or in a `static` class member — translations aren't loaded yet at that
-  point. Use a getter, method or instance field instead, which only run once the app has bootstrapped:
-
-  ```typescript
-  // breaks in a bootstrap module - runs before translations are loaded:
-  const HINT = $localize`:some hint:We are working on improvements.`;
-
-  // works - only evaluated when called, after bootstrap:
-  get hint() {
-    return $localize`:some hint:We are working on improvements.`;
-  }
-  ```
-
-  Regular app code doesn't need this: it's loaded via `await import("./app/app.module")` after
-  translations are ready.
-
 - Try to keep your translatable texts as simple as possible concerning the
   amount of string-interpolation or computation inside the `{{}}`-Blocks. This
   makes it easier for translators

--- a/doc/compodoc_sources/concepts/i18n.md
+++ b/doc/compodoc_sources/concepts/i18n.md
@@ -219,24 +219,23 @@ and booleans.
 
 ### Do's and don'ts
 
-- Prefer evaluating `$localize` **when the text is used, not when the module is loaded**. A getter,
-  a method or an instance field all run after the app has bootstrapped, so translations are
-  guaranteed to be loaded:
+- In the `bootstrap-*.ts` modules that `main.ts` imports statically (see
+  [bootstrap order](#bootstrap-order-dont-localize-before-translations-are-loaded)), never evaluate
+  `$localize` at module scope or in a `static` class member — translations aren't loaded yet at that
+  point. Use a getter, method or instance field instead, which only run once the app has bootstrapped:
 
   ```typescript
-  // avoid in modules that may be loaded during bootstrap:
+  // breaks in a bootstrap module - runs before translations are loaded:
   const HINT = $localize`:some hint:We are working on improvements.`;
 
-  // prefer:
+  // works - only evaluated when called, after bootstrap:
   get hint() {
     return $localize`:some hint:We are working on improvements.`;
   }
   ```
 
-  This only actually breaks for the few modules `main.ts` imports statically (see
-  [bootstrap order](#bootstrap-order-dont-localize-before-translations-are-loaded)), but it is the
-  safer habit everywhere: a module that is lazily loaded today may become part of the bootstrap
-  graph tomorrow, and nothing would report the regression.
+  Regular app code doesn't need this: it's loaded via `await import("./app/app.module")` after
+  translations are ready.
 
 - Try to keep your translatable texts as simple as possible concerning the
   amount of string-interpolation or computation inside the `{{}}`-Blocks. This

--- a/doc/compodoc_sources/concepts/i18n.md
+++ b/doc/compodoc_sources/concepts/i18n.md
@@ -33,6 +33,23 @@ The CI tools are automatically publishing these texts for translation then.
    offline use. There is no separate per-locale build — a single build serves all languages and
    loads the translations dynamically.
 
+### Bootstrap order: don't localize before translations are loaded
+
+Because translations are loaded at runtime, **anything evaluated before `initLanguage()` resolves
+can only ever be English**. `$localize` does not fail in that case, it just returns the source
+text — no error, no failing test, nothing visible in review.
+
+`main.ts` loads the application itself with `await import("./app/app.module")` _after_
+`initLanguage()`, so regular app code is safe. Only the small graph of modules statically imported
+by `main.ts` runs earlier. Keep that graph minimal: bootstrap logic belongs in dependency-free
+modules next to `main.ts` (`bootstrap-i18n.ts`, `bootstrap-environment.ts`, `bootstrap-reset.ts`,
+`bootstrap-pwa-install.ts`), which must not import from `src/app/`. Importing a `@Injectable`
+service into `main.ts` — even just for one `static` helper — drags that service's whole dependency
+graph into the pre-i18n phase.
+
+Within those modules, never evaluate `$localize` at module scope or in a `static` class member.
+See the do's and don'ts below for how to write it instead.
+
 ### Manual re-export
 
 If translations are updated in POEditor after a release, you can manually trigger the
@@ -201,6 +218,25 @@ Types that are known to work well are the standard types of strings, numbers
 and booleans.
 
 ### Do's and don'ts
+
+- Prefer evaluating `$localize` **when the text is used, not when the module is loaded**. A getter,
+  a method or an instance field all run after the app has bootstrapped, so translations are
+  guaranteed to be loaded:
+
+  ```typescript
+  // avoid in modules that may be loaded during bootstrap:
+  const HINT = $localize`:some hint:We are working on improvements.`;
+
+  // prefer:
+  get hint() {
+    return $localize`:some hint:We are working on improvements.`;
+  }
+  ```
+
+  This only actually breaks for the few modules `main.ts` imports statically (see
+  [bootstrap order](#bootstrap-order-dont-localize-before-translations-are-loaded)), but it is the
+  safer habit everywhere: a module that is lazily loaded today may become part of the bootstrap
+  graph tomorrow, and nothing would report the regression.
 
 - Try to keep your translatable texts as simple as possible concerning the
   amount of string-interpolation or computation inside the `{{}}`-Blocks. This

--- a/src/app/core/admin/backup/backup.service.spec.ts
+++ b/src/app/core/admin/backup/backup.service.spec.ts
@@ -10,6 +10,7 @@ import { SyncStateSubject } from "app/core/session/session-type";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { of } from "rxjs";
 import { LOCATION_TOKEN } from "../../../utils/di-tokens";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
 
 describe("BackupService", () => {
   let db: PouchDatabase;
@@ -40,6 +41,7 @@ describe("BackupService", () => {
   afterEach(async () => {
     await db.destroy();
     vi.unstubAllGlobals();
+    sessionStorage.removeItem(RESET_PENDING_KEY);
   });
 
   it("should be created", () => {
@@ -140,54 +142,8 @@ describe("BackupService", () => {
     await service.resetApplication();
 
     expect(localStorage.getItem("someItem")).toBeNull();
-    expect(sessionStorage.getItem(BackupService.RESET_PENDING_KEY)).toBe("1");
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBe("1");
     expect(TestBed.inject(LOCATION_TOKEN).pathname).toBe("");
-
-    // Clean up sessionStorage
-    sessionStorage.removeItem(BackupService.RESET_PENDING_KEY);
-  });
-
-  it("runPendingReset should delete all databases and unregister service workers", async () => {
-    sessionStorage.setItem(BackupService.RESET_PENDING_KEY, "1");
-    localStorage.setItem("LAST_SYNC_test-db", "2024-01-01T00:00:00.000Z");
-
-    // Stub global indexedDB (not available in jsdom)
-    const mockDbs = [{ name: "db1" }, { name: "db2" }];
-    const deleteDatabase = vi.fn().mockImplementation(() => {
-      const req = { onsuccess: null as any, onerror: null as any };
-      setTimeout(() => req.onsuccess?.());
-      return req as any;
-    });
-    const databases = vi.fn().mockResolvedValue(mockDbs as any);
-    vi.stubGlobal("indexedDB", { databases, deleteDatabase });
-    const unregisterSpy = vi.fn().mockResolvedValue(true);
-    Object.defineProperty(navigator, "serviceWorker", {
-      value: {
-        getRegistrations: vi
-          .fn()
-          .mockResolvedValue([{ unregister: unregisterSpy } as any]),
-      },
-      configurable: true,
-      writable: true,
-    });
-
-    await BackupService.runPendingReset();
-
-    expect(deleteDatabase).toHaveBeenCalledWith("db1");
-    expect(deleteDatabase).toHaveBeenCalledWith("db2");
-    expect(unregisterSpy).toHaveBeenCalled();
-    expect(localStorage.getItem("LAST_SYNC_test-db")).toBeNull();
-    expect(sessionStorage.getItem(BackupService.RESET_PENDING_KEY)).toBeNull();
-  });
-
-  it("runPendingReset should do nothing when no reset is pending", async () => {
-    sessionStorage.removeItem(BackupService.RESET_PENDING_KEY);
-    const databases = vi.fn();
-    vi.stubGlobal("indexedDB", { databases });
-
-    await BackupService.runPendingReset();
-
-    expect(databases).not.toHaveBeenCalled();
   });
 
   function ignoreRevProperty(x) {

--- a/src/app/core/admin/backup/backup.service.ts
+++ b/src/app/core/admin/backup/backup.service.ts
@@ -5,6 +5,7 @@ import { DatabaseResolverService } from "../../database/database-resolver.servic
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { LOCATION_TOKEN, LOCAL_STORAGE_TOKEN } from "../../../utils/di-tokens";
 import { Logging } from "../../logging/logging.service";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
 
 /**
  * Create and load backups of the database.
@@ -65,12 +66,6 @@ export class BackupService {
     }
   }
 
-  /**
-   * sessionStorage key used to signal that a reset is pending.
-   * Set before page reload; checked on next bootstrap in {@link runPendingReset}.
-   */
-  static readonly RESET_PENDING_KEY = "__RESET_PENDING";
-
   async resetApplication() {
     const choice = await this.confirmationDialog.getConfirmation(
       $localize`:Reset Application Confirmation:Reset Application`,
@@ -87,46 +82,10 @@ export class BackupService {
 
     // Reload the page first to kill all PouchDB connections, in-flight sync,
     // view indexing, and other async operations. IDB databases are deleted on
-    // the fresh page (before Angular bootstraps) where no connections exist,
-    // avoiding race conditions with PouchDB's internal IDB transactions.
+    // the fresh page by `runPendingReset()` (before Angular bootstraps) where no
+    // connections exist, avoiding race conditions with PouchDB's IDB transactions.
     this.localStorage.clear();
-    sessionStorage.setItem(BackupService.RESET_PENDING_KEY, "1");
+    sessionStorage.setItem(RESET_PENDING_KEY, "1");
     this.location.pathname = "";
-  }
-
-  /**
-   * Run pending reset cleanup before Angular bootstraps.
-   * Called from main.ts so that IndexedDB databases are deleted while
-   * no PouchDB connections are open (eliminating race conditions).
-   */
-  static async runPendingReset(): Promise<void> {
-    if (!sessionStorage.getItem(BackupService.RESET_PENDING_KEY)) {
-      return;
-    }
-    sessionStorage.removeItem(BackupService.RESET_PENDING_KEY);
-    DatabaseResolverService.clearLastSyncMarkers();
-
-    // Delete all IndexedDB databases
-    // (keep Sentry's offline queue so pending diagnostic logs about the reset
-    // itself still reach remote logging after the reload)
-    const dbs = await indexedDB.databases();
-    await Promise.all(
-      dbs
-        .filter(({ name }) => name !== "sentry-offline")
-        .map(
-          ({ name }) =>
-            new Promise<void>((resolve, reject) => {
-              const del = indexedDB.deleteDatabase(name);
-              del.onsuccess = () => resolve();
-              del.onerror = () => reject(del.error);
-            }),
-        ),
-    );
-
-    // Unregister all service workers
-    if (navigator.serviceWorker) {
-      const registrations = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(registrations.map((reg) => reg.unregister()));
-    }
   }
 }

--- a/src/app/core/database/database-resolver.service.ts
+++ b/src/app/core/database/database-resolver.service.ts
@@ -17,6 +17,10 @@ import { SessionType } from "../session/session-type";
 import { NAVIGATOR_TOKEN, WINDOW_TOKEN } from "#src/app/utils/di-tokens";
 import { Logging } from "../logging/logging.service";
 import { LOCAL_STORAGE_TOKEN } from "../../utils/di-tokens";
+import {
+  clearLastSyncMarkers,
+  LAST_SYNC_KEY_PREFIX,
+} from "#src/bootstrap-reset";
 
 /**
  * Manages access to individual databases,
@@ -72,21 +76,10 @@ export class DatabaseResolverService {
   }
 
   async destroyDatabases() {
-    DatabaseResolverService.clearLastSyncMarkers();
+    clearLastSyncMarkers();
     for (const db of this.databases.values()) {
       await db.destroy();
     }
-  }
-
-  /**
-   * Static, so it cannot use the injected LOCAL_STORAGE_TOKEN and touches the
-   * real localStorage directly. Callers that need this mockable should make it
-   * an instance method first.
-   */
-  static clearLastSyncMarkers() {
-    Object.keys(localStorage)
-      .filter((key) => key.startsWith(SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX))
-      .forEach((key) => localStorage.removeItem(key));
   }
 
   /**
@@ -143,7 +136,7 @@ export class DatabaseResolverService {
     try {
       const dbName = dbConfig.dbNames.app;
       const lastSyncTime = this.localStorage.getItem(
-        SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX + dbName,
+        LAST_SYNC_KEY_PREFIX + dbName,
       );
       // indexedDB.databases() is not available in all browsers (then: undefined)
       const existingDbs = await this.window?.indexedDB?.databases?.();

--- a/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.spec.ts
+++ b/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.spec.ts
@@ -5,7 +5,7 @@ import {
   isKnownMultiTabDatabaseCorruption,
   PouchdbCorruptionRecoveryService,
 } from "./pouchdb-corruption-recovery.service";
-import { BackupService } from "../../admin/backup/backup.service";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
 
@@ -38,12 +38,12 @@ describe("PouchdbCorruptionRecoveryService", () => {
     (service as any).warningDialogOpen = false;
     (service as any).resetDialogOpen = false;
     localStorage.clear();
-    sessionStorage.removeItem(BackupService.RESET_PENDING_KEY);
+    sessionStorage.removeItem(RESET_PENDING_KEY);
   });
 
   afterEach(() => {
     localStorage.clear();
-    sessionStorage.removeItem(BackupService.RESET_PENDING_KEY);
+    sessionStorage.removeItem(RESET_PENDING_KEY);
   });
 
   it("should reset application state when user confirms", async () => {
@@ -53,7 +53,7 @@ describe("PouchdbCorruptionRecoveryService", () => {
     await service.promptResetApplicationDialog();
 
     expect(localStorage.getItem("foo")).toBe("bar");
-    expect(sessionStorage.getItem(BackupService.RESET_PENDING_KEY)).toBe("1");
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBe("1");
     expect(location.pathname).toBe("");
   });
 
@@ -65,7 +65,7 @@ describe("PouchdbCorruptionRecoveryService", () => {
 
     expect(confirmationDialog.getConfirmation).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem("foo")).toBe("bar");
-    expect(sessionStorage.getItem(BackupService.RESET_PENDING_KEY)).toBeNull();
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBeNull();
     expect(location.pathname).toBe("/entities/Entity:1");
   });
 
@@ -94,7 +94,7 @@ describe("PouchdbCorruptionRecoveryService", () => {
     await service.promptResetApplicationDialog();
 
     expect(localStorage.getItem("foo")).toBe("bar");
-    expect(sessionStorage.getItem(BackupService.RESET_PENDING_KEY)).toBeNull();
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBeNull();
     expect(location.pathname).toBe("/entities/Entity:1");
   });
 });

--- a/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
+++ b/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
@@ -5,7 +5,7 @@ import {
   OkButton,
 } from "#src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
 import { LOCATION_TOKEN } from "#src/app/utils/di-tokens";
-import { BackupService } from "../../admin/backup/backup.service";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
 import { Logging } from "../../logging/logging.service";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
@@ -79,7 +79,7 @@ We are working on improvements to allow this in the future.`,
     Logging.warn(
       "Resetting application data after suspected local database corruption (user confirmed)",
     );
-    sessionStorage.setItem(BackupService.RESET_PENDING_KEY, "1");
+    sessionStorage.setItem(RESET_PENDING_KEY, "1");
     this.location.pathname = "";
   }
 

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -25,19 +25,18 @@ import {
   isKnownMultiTabDatabaseCorruption,
 } from "./pouchdb-corruption-recovery.service";
 import { isConnectivityError } from "#src/app/utils/connectivity-error";
+import { LAST_SYNC_KEY_PREFIX } from "#src/bootstrap-reset";
 
 /**
  * An alternative implementation of PouchDatabase that additionally
  * provides functionality to sync with a remote CouchDB.
  */
 export class SyncedPouchDatabase extends PouchDatabase {
-  static LAST_SYNC_KEY_PREFIX = "LAST_SYNC_";
-
   get LAST_SYNC_KEY(): string | undefined {
     if (!this.pouchDB?.name) {
       return undefined;
     }
-    return SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX + this.pouchDB.name;
+    return LAST_SYNC_KEY_PREFIX + this.pouchDB.name;
   }
 
   POUCHDB_SYNC_BATCH_SIZE = 100;

--- a/src/app/core/pwa-install/pwa-install.component.spec.ts
+++ b/src/app/core/pwa-install/pwa-install.component.spec.ts
@@ -8,7 +8,7 @@ import type { Mock } from "vitest";
 
 type PwaInstallServiceMock = Pick<
   PwaInstallService,
-  "getPWAInstallType" | "installPWA"
+  "getPWAInstallType" | "installPWA" | "canInstallDirectly"
 > & {
   getPWAInstallType: Mock;
   installPWA: Mock;
@@ -25,10 +25,10 @@ describe("PwaInstallComponent", () => {
   let mockSnackbar: SnackBarMock;
 
   beforeEach(waitForAsync(() => {
-    PwaInstallService.canInstallDirectly = undefined;
     mockPWAInstallService = {
       getPWAInstallType: vi.fn(),
       installPWA: vi.fn(),
+      canInstallDirectly: undefined,
     };
     mockSnackbar = {
       openFromTemplate: vi.fn(),

--- a/src/app/core/pwa-install/pwa-install.component.ts
+++ b/src/app/core/pwa-install/pwa-install.component.ts
@@ -42,7 +42,7 @@ export class PwaInstallComponent implements OnInit {
     if (this.pwaInstallType === PWAInstallType.ShowiOSInstallInstructions) {
       this.showPWAInstallButton = true;
     }
-    PwaInstallService.canInstallDirectly?.then(() => {
+    this.pwaInstallService.canInstallDirectly?.then(() => {
       this.showPWAInstallButton = true;
     });
   }

--- a/src/app/core/pwa-install/pwa-install.service.spec.ts
+++ b/src/app/core/pwa-install/pwa-install.service.spec.ts
@@ -2,6 +2,10 @@ import { TestBed } from "@angular/core/testing";
 
 import { PwaInstallService, PWAInstallType } from "./pwa-install.service";
 import { WINDOW_TOKEN } from "../../utils/di-tokens";
+import {
+  registerPWAInstallListener,
+  resetPWAInstallListener,
+} from "#src/bootstrap-pwa-install";
 
 describe("PwaInstallService", () => {
   let service: PwaInstallService;
@@ -19,6 +23,11 @@ describe("PwaInstallService", () => {
       providers: [{ provide: WINDOW_TOKEN, useValue: mockWindow }],
     });
     service = TestBed.inject(PwaInstallService);
+  });
+
+  afterEach(() => {
+    // module-level state is shared with every other spec in this worker
+    resetPWAInstallListener();
   });
 
   it("should be created", () => {
@@ -55,19 +64,16 @@ describe("PwaInstallService", () => {
       } as any);
     });
 
-    PwaInstallService.registerPWAInstallListener();
+    registerPWAInstallListener();
     expect(window.addEventListener).toHaveBeenCalledWith(
       "beforeinstallprompt",
       expect.anything(),
     );
-    await expect(PwaInstallService.canInstallDirectly).resolves.not.toThrow();
+    await expect(service.canInstallDirectly).resolves.not.toThrow();
 
     const installPromise = service.installPWA();
     expect(installSpy).toHaveBeenCalled();
     await expect(installPromise).resolves.toEqual({ outcome: "accepted" });
-
-    // reset static property
-    PwaInstallService["deferredInstallPrompt"] = undefined;
   });
 
   it("should throw an error when trying to install without install prompt", () => {

--- a/src/app/core/pwa-install/pwa-install.service.spec.ts
+++ b/src/app/core/pwa-install/pwa-install.service.spec.ts
@@ -69,7 +69,7 @@ describe("PwaInstallService", () => {
       "beforeinstallprompt",
       expect.anything(),
     );
-    await expect(service.canInstallDirectly).resolves.not.toThrow();
+    await expect(service.canInstallDirectly).resolves.toBeUndefined();
 
     const installPromise = service.installPWA();
     expect(installSpy).toHaveBeenCalled();

--- a/src/app/core/pwa-install/pwa-install.service.ts
+++ b/src/app/core/pwa-install/pwa-install.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, inject } from "@angular/core";
 import { WINDOW_TOKEN } from "../../utils/di-tokens";
+import {
+  getDeferredInstallPrompt,
+  whenCanInstallDirectly,
+} from "#src/bootstrap-pwa-install";
 
 export enum PWAInstallType {
   ShowiOSInstallInstructions,
@@ -31,30 +35,22 @@ export class PwaInstallService {
   private window = inject<Window>(WINDOW_TOKEN);
 
   /**
-   * Resolves once/if it is possible to directly install the app
+   * Resolves once/if it is possible to directly install the app.
+   * `undefined` if the listener has not been registered during bootstrap.
    */
-  static canInstallDirectly: Promise<void>;
-
-  private static deferredInstallPrompt: any;
-
-  static registerPWAInstallListener() {
-    this.canInstallDirectly = new Promise((resolve) => {
-      window.addEventListener("beforeinstallprompt", (e) => {
-        e.preventDefault();
-        this.deferredInstallPrompt = e;
-        resolve();
-      });
-    });
+  get canInstallDirectly(): Promise<void> | undefined {
+    return whenCanInstallDirectly();
   }
 
   installPWA(): Promise<any> {
-    if (!PwaInstallService.deferredInstallPrompt) {
+    const installPrompt = getDeferredInstallPrompt();
+    if (!installPrompt) {
       throw new Error(
         "InstallPWA called, but PWA install prompt has not fired.",
       );
     }
-    PwaInstallService.deferredInstallPrompt.prompt();
-    return PwaInstallService.deferredInstallPrompt.userChoice;
+    installPrompt.prompt();
+    return installPrompt.userChoice;
   }
 
   getPWAInstallType(): PWAInstallType {

--- a/src/app/core/support/support/support.component.spec.ts
+++ b/src/app/core/support/support/support.component.spec.ts
@@ -23,6 +23,7 @@ import { SessionInfo, SessionSubject } from "../../session/auth/session-info";
 import { TEST_USER } from "../../user/demo-user-generator.service";
 import { SyncedPouchDatabase } from "../../database/pouchdb/synced-pouch-database";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
+import { LAST_SYNC_KEY_PREFIX } from "#src/bootstrap-reset";
 
 describe("SupportComponent", () => {
   let component: SupportComponent;
@@ -51,7 +52,7 @@ describe("SupportComponent", () => {
     const testDbName = TEST_USER + "-" + Entity.DATABASE;
     mockDB = Object.create(SyncedPouchDatabase.prototype);
     Object.defineProperty(mockDB, "LAST_SYNC_KEY", {
-      value: SyncedPouchDatabase.LAST_SYNC_KEY_PREFIX + testDbName,
+      value: LAST_SYNC_KEY_PREFIX + testDbName,
     });
     mockDB.getPouchDBOnceReady = vi.fn().mockReturnValue(
       Promise.resolve({

--- a/src/bootstrap-environment.ts
+++ b/src/bootstrap-environment.ts
@@ -1,6 +1,7 @@
 import { environment } from "./environments/environment";
 import { Logging } from "./app/core/logging/logging.service";
-import { FirebaseConfiguration } from "./app/features/notification/notification-config.interface";
+// type-only, so that this module does not enter the graph evaluated before i18n
+import type { FirebaseConfiguration } from "./app/features/notification/notification-config.interface";
 import { SessionType } from "./app/core/session/session-type";
 import { PUBLIC_FORM_ROUTE } from "./app/features/public-form/public-form-route";
 

--- a/src/bootstrap-pwa-install.ts
+++ b/src/bootstrap-pwa-install.ts
@@ -1,0 +1,58 @@
+/**
+ * Capture the browser's PWA install prompt during bootstrap.
+ *
+ * This module is imported by `main.ts` and therefore evaluated *before*
+ * `initLanguage()` has loaded any translations. Like `bootstrap-i18n.ts` and
+ * `bootstrap-environment.ts` it must not import anything from `src/app/`, so
+ * that bootstrapping does not pull the application's dependency graph into the
+ * pre-i18n phase (see doc/compodoc_sources/concepts/i18n.md).
+ *
+ * The app-facing API for this is `PwaInstallService`.
+ */
+
+/** The deferred `beforeinstallprompt` event, to be triggered on user request */
+let deferredInstallPrompt: any;
+
+/** Resolves once/if it is possible to directly install the app */
+let canInstallDirectly: Promise<void> | undefined;
+
+/**
+ * Start listening for the browser's `beforeinstallprompt` event and defer it,
+ * so that the app can offer an install button at any later point.
+ *
+ * Must be called before any async operation during bootstrap, because the
+ * browser fires the event early and does not replay it for later listeners.
+ */
+export function registerPWAInstallListener(): void {
+  canInstallDirectly = new Promise((resolve) => {
+    window.addEventListener("beforeinstallprompt", (e) => {
+      e.preventDefault();
+      deferredInstallPrompt = e;
+      resolve();
+    });
+  });
+}
+
+/**
+ * Resolves once/if the app can be installed directly.
+ * `undefined` if {@link registerPWAInstallListener} has not run.
+ */
+export function whenCanInstallDirectly(): Promise<void> | undefined {
+  return canInstallDirectly;
+}
+
+/**
+ * The deferred install prompt, if the browser has offered one already.
+ */
+export function getDeferredInstallPrompt(): any {
+  return deferredInstallPrompt;
+}
+
+/**
+ * Discard the deferred prompt and the listener's promise.
+ * Only needed in tests, to undo the module-level state of a previous case.
+ */
+export function resetPWAInstallListener(): void {
+  deferredInstallPrompt = undefined;
+  canInstallDirectly = undefined;
+}

--- a/src/bootstrap-reset.spec.ts
+++ b/src/bootstrap-reset.spec.ts
@@ -1,0 +1,101 @@
+import {
+  clearLastSyncMarkers,
+  LAST_SYNC_KEY_PREFIX,
+  RESET_PENDING_KEY,
+  runPendingReset,
+} from "./bootstrap-reset";
+
+describe("bootstrap-reset", () => {
+  let originalServiceWorker: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalServiceWorker = Object.getOwnPropertyDescriptor(
+      navigator,
+      "serviceWorker",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sessionStorage.removeItem(RESET_PENDING_KEY);
+    // only remove what these tests wrote: localStorage is shared across spec files
+    clearLastSyncMarkers();
+    localStorage.removeItem("someOtherItem");
+
+    if (originalServiceWorker) {
+      Object.defineProperty(navigator, "serviceWorker", originalServiceWorker);
+    } else {
+      delete (navigator as any).serviceWorker;
+    }
+  });
+
+  /** Stub the globals that jsdom does not provide, returning the spies to assert on */
+  function stubBrowserApis(dbNames: string[]) {
+    const deleteDatabase = vi.fn().mockImplementation(() => {
+      const req = { onsuccess: null as any, onerror: null as any };
+      setTimeout(() => req.onsuccess?.());
+      return req as any;
+    });
+    const databases = vi
+      .fn()
+      .mockResolvedValue(dbNames.map((name) => ({ name })) as any);
+    vi.stubGlobal("indexedDB", { databases, deleteDatabase });
+
+    const unregister = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        getRegistrations: vi.fn().mockResolvedValue([{ unregister } as any]),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    return { databases, deleteDatabase, unregister };
+  }
+
+  it("clearLastSyncMarkers should only remove the last sync markers", () => {
+    localStorage.setItem(LAST_SYNC_KEY_PREFIX + "test-db", "2024-01-01");
+    localStorage.setItem("someOtherItem", "someValue");
+
+    clearLastSyncMarkers();
+
+    expect(localStorage.getItem(LAST_SYNC_KEY_PREFIX + "test-db")).toBeNull();
+    expect(localStorage.getItem("someOtherItem")).toBe("someValue");
+  });
+
+  it("runPendingReset should delete all databases and unregister service workers", async () => {
+    sessionStorage.setItem(RESET_PENDING_KEY, "1");
+    localStorage.setItem(
+      LAST_SYNC_KEY_PREFIX + "test-db",
+      "2024-01-01T00:00:00.000Z",
+    );
+    const { deleteDatabase, unregister } = stubBrowserApis(["db1", "db2"]);
+
+    await runPendingReset();
+
+    expect(deleteDatabase).toHaveBeenCalledWith("db1");
+    expect(deleteDatabase).toHaveBeenCalledWith("db2");
+    expect(unregister).toHaveBeenCalled();
+    expect(localStorage.getItem(LAST_SYNC_KEY_PREFIX + "test-db")).toBeNull();
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBeNull();
+  });
+
+  it("runPendingReset should keep Sentry's offline queue of pending logs", async () => {
+    sessionStorage.setItem(RESET_PENDING_KEY, "1");
+    const { deleteDatabase } = stubBrowserApis(["db1", "sentry-offline"]);
+
+    await runPendingReset();
+
+    expect(deleteDatabase).toHaveBeenCalledWith("db1");
+    expect(deleteDatabase).not.toHaveBeenCalledWith("sentry-offline");
+  });
+
+  it("runPendingReset should do nothing when no reset is pending", async () => {
+    sessionStorage.removeItem(RESET_PENDING_KEY);
+    const { databases } = stubBrowserApis(["db1"]);
+
+    await runPendingReset();
+
+    expect(databases).not.toHaveBeenCalled();
+  });
+});

--- a/src/bootstrap-reset.ts
+++ b/src/bootstrap-reset.ts
@@ -1,0 +1,71 @@
+/**
+ * Reset of all locally stored application data, executed during bootstrap.
+ *
+ * This module is imported by `main.ts` and therefore evaluated *before*
+ * `initLanguage()` has loaded any translations. Like `bootstrap-i18n.ts` and
+ * `bootstrap-environment.ts` it must not import anything from `src/app/`, so
+ * that bootstrapping does not pull the application's dependency graph into the
+ * pre-i18n phase (see doc/compodoc_sources/concepts/i18n.md).
+ */
+
+/**
+ * sessionStorage key used to signal that a reset is pending.
+ * Set before a page reload; checked on the next bootstrap in {@link runPendingReset}.
+ */
+export const RESET_PENDING_KEY = "__RESET_PENDING";
+
+/**
+ * localStorage key prefix under which `SyncedPouchDatabase` records when a
+ * database last completed a sync (one key per database).
+ */
+export const LAST_SYNC_KEY_PREFIX = "LAST_SYNC_";
+
+/**
+ * Remove the "last sync" marker of every database, so that no previous sync is
+ * assumed to have happened on this device.
+ *
+ * This accesses the real localStorage directly rather than the injectable
+ * LOCAL_STORAGE_TOKEN, because it also runs before Angular exists.
+ * Callers that need this mockable should wrap it in an instance method first.
+ */
+export function clearLastSyncMarkers() {
+  Object.keys(localStorage)
+    .filter((key) => key.startsWith(LAST_SYNC_KEY_PREFIX))
+    .forEach((key) => localStorage.removeItem(key));
+}
+
+/**
+ * Run pending reset cleanup before Angular bootstraps.
+ * Called from main.ts so that IndexedDB databases are deleted while
+ * no PouchDB connections are open (eliminating race conditions).
+ */
+export async function runPendingReset(): Promise<void> {
+  if (!sessionStorage.getItem(RESET_PENDING_KEY)) {
+    return;
+  }
+  sessionStorage.removeItem(RESET_PENDING_KEY);
+  clearLastSyncMarkers();
+
+  // Delete all IndexedDB databases
+  // (keep Sentry's offline queue so pending diagnostic logs about the reset
+  // itself still reach remote logging after the reload)
+  const dbs = await indexedDB.databases();
+  await Promise.all(
+    dbs
+      .filter(({ name }) => name !== "sentry-offline")
+      .map(
+        ({ name }) =>
+          new Promise<void>((resolve, reject) => {
+            const del = indexedDB.deleteDatabase(name);
+            del.onsuccess = () => resolve();
+            del.onerror = () => reject(del.error);
+          }),
+      ),
+  );
+
+  // Unregister all service workers
+  if (navigator.serviceWorker) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((reg) => reg.unregister()));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,12 @@ import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 import { initEnvironmentConfig } from "./bootstrap-environment";
 import { Logging } from "./app/core/logging/logging.service";
-import { PwaInstallService } from "./app/core/pwa-install/pwa-install.service";
+import { registerPWAInstallListener } from "./bootstrap-pwa-install";
 import { initLanguage } from "./bootstrap-i18n";
-import { BackupService } from "./app/core/admin/backup/backup.service";
+import { runPendingReset } from "./bootstrap-reset";
 
 // Register before any async operations so the beforeinstallprompt event is not missed
-PwaInstallService.registerPWAInstallListener();
+registerPWAInstallListener();
 
 bootstrap().catch((reason) => {
   Logging.error("Application Bootstrap failed", reason);
@@ -16,7 +16,7 @@ bootstrap().catch((reason) => {
 
 async function bootstrap() {
   // If a reset was requested, delete all databases before PouchDB opens any connections.
-  await BackupService.runPendingReset();
+  await runPendingReset();
 
   await initEnvironmentConfig();
 


### PR DESCRIPTION
## Summary
- Move `BackupService.runPendingReset()` and `PwaInstallService.registerPWAInstallListener()` out of `@Injectable` services into new dependency-free modules (`src/bootstrap-reset.ts`, `src/bootstrap-pwa-install.ts`), following the pattern of `bootstrap-i18n.ts` / `bootstrap-environment.ts`
- `main.ts` no longer imports `BackupService`, so its DI graph (92 files) is no longer evaluated before `initLanguage()` — eliminates the class of bug where a module-scope `$localize` in that graph silently stays untranslated
- `PwaInstallService.canInstallDirectly` becomes an instance getter instead of a static; `PouchdbCorruptionRecoveryService` now reads `RESET_PENDING_KEY` from `bootstrap-reset.ts` instead of importing `BackupService`, removing another edge into that graph
- Document the bootstrap-order trap in `doc/compodoc_sources/concepts/i18n.md`, with a do/don't example for evaluating `$localize` in a getter/method/instance field rather than module or static scope

No behavior change.

Fixes #4222

## Test plan
- [x] `npx eslint` on all changed files — clean
- [x] `npx tsc --noEmit` — clean
- [x] Unit tests for all touched files pass (`bootstrap-reset`, `pwa-install.service`, `pwa-install.component`, `backup.service`, `pouchdb-corruption-recovery.service`, `support.component` — 6 files, 36 tests)
- [ ] Manual smoke test of PWA install prompt and "Reset Application" flow in a running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PWA installation prompt handling for more reliable installation flows.
  * Added safer application reset cleanup while preserving Sentry’s offline queue.
  * Added guidance for initializing translations before application startup.

* **Bug Fixes**
  * Improved cleanup of synchronization markers, cached databases, and service workers during resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->