### PR TITLE
fix(dropdown): keep multi-select dropdown open while selecting options

### DIFF
--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.html
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.html
@@ -79,6 +79,7 @@
     matInput
     style="text-overflow: ellipsis"
     [matAutocomplete]="autoSuggestions"
+    [appKeepPanelOpenOnSelect]="!!multi()"
     [matAutocompleteConnectedTo]="autocompleteOrigin"
     (focusout)="onFocusOut($event)"
     [placeholder]="placeholder"
@@ -92,6 +93,7 @@ Autocomplete
   [disableRipple]="true"
   #autoSuggestions="matAutocomplete"
   (optionSelected)="select($event.option.value)"
+  (closed)="onDropdownClosed()"
   autoActiveFirstOption
   [hideSingleSelectionIndicator]="true"
   [panelWidth]="panelWidth()"
@@ -110,6 +112,7 @@ Autocomplete
       >
         <mat-option
           [value]="item"
+          (onSelectionChange)="onOptionSelectionChange($event)"
           *cdkVirtualFor="
             let item of autocompleteOptions();
             trackBy: trackByOptionValueFn
@@ -123,7 +126,11 @@ Autocomplete
       </cdk-virtual-scroll-viewport>
     } @else {
       @for (item of autocompleteOptions(); track item.asValue) {
-        <mat-option [value]="item" class="option-with-wrap">
+        <mat-option
+          [value]="item"
+          class="option-with-wrap"
+          (onSelectionChange)="onOptionSelectionChange($event)"
+        >
           <ng-container
             [ngTemplateOutlet]="optionContent"
             [ngTemplateOutletContext]="{ $implicit: item, truncate: false }"
@@ -155,7 +162,7 @@ Autocomplete
       class="option-content flex-row disable-autocomplete-active-color align-center"
     >
       @if (multi()) {
-        <mat-checkbox [checked]="item.selected"></mat-checkbox>
+        <mat-checkbox [checked]="isSelected(item)"></mat-checkbox>
       }
       @if (!templateRef()) {
         <span
@@ -186,6 +193,7 @@ Autocomplete
       <mat-option
         [value]="toCreateOptionValue(option, inputElement.value)"
         [attr.aria-label]="createOptionAriaLabel(option, inputElement.value)"
+        (onSelectionChange)="onOptionSelectionChange($event)"
       >
         <em
           i18n="

--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.spec.ts
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.spec.ts
@@ -24,6 +24,12 @@ describe("BasicAutocompleteComponent", () => {
   let loader: HarnessLoader;
   let testControl: FormControl;
   const entityToId = (e: Entity) => e?.getId();
+  const checkedOptionStates = () =>
+    Array.from(
+      document.querySelectorAll<HTMLInputElement>(
+        ".mat-mdc-autocomplete-panel mat-checkbox input",
+      ),
+    ).map((checkbox) => checkbox.checked);
 
   beforeEach(async () => {
     testControl = new FormControl("");
@@ -147,7 +153,7 @@ describe("BasicAutocompleteComponent", () => {
     expect(component.autocompleteForm.disabled).toBe(true);
   });
 
-  it("should initialize the options in multi select mode", async () => {
+  it("should initialize the options in multi select mode and keep the panel open while selecting", async () => {
     const autocomplete = await loader.getHarness(MatAutocompleteHarness);
     fixture.componentRef.setInput("options", [0, 1, 2]);
     fixture.componentRef.setInput("multi", true);
@@ -164,12 +170,118 @@ describe("BasicAutocompleteComponent", () => {
     );
 
     await options[2].click();
-    // When browser is not in foreground, this doesn't happen automatically
-    component.autocomplete()!.openPanel();
+    expect(component.autocomplete()!.panelOpen).toBe(true);
     fixture.detectChanges();
     await options[1].click();
 
     expect(component.value).toEqual([0, 2]);
+    expect(component.autocomplete()!.panelOpen).toBe(true);
+  });
+
+  it("should keep the keyboard navigation on the selected option in multi select mode", async () => {
+    const autocomplete = await loader.getHarness(MatAutocompleteHarness);
+    fixture.componentRef.setInput("options", ["one", "two", "three"]);
+    fixture.componentRef.setInput("multi", true);
+    fixture.detectChanges();
+
+    component.showAutocomplete();
+    component.autocomplete()!.openPanel();
+    const options = await autocomplete.getOptions();
+    await options[1].click();
+    await fixture.whenStable();
+
+    const keyManager = component.autocomplete()!.autocomplete._keyManager;
+    expect(keyManager.activeItem?.value).toEqual(
+      expect.objectContaining({ asValue: "two" }),
+    );
+  });
+
+  it("should close the panel after selecting an option in single select mode", async () => {
+    const autocomplete = await loader.getHarness(MatAutocompleteHarness);
+    fixture.componentRef.setInput("options", ["one", "two"]);
+    fixture.detectChanges();
+
+    component.showAutocomplete();
+    component.autocomplete()!.openPanel();
+    const options = await autocomplete.getOptions();
+    await options[1].click();
+
+    expect(component.value).toBe("two");
+    expect(component.autocomplete()!.panelOpen).toBe(false);
+  });
+
+  it("should keep the typed filter and update the checkboxes while selecting multiple options", async () => {
+    const autocomplete = await loader.getHarness(MatAutocompleteHarness);
+    fixture.componentRef.setInput("options", ["apple", "apricot", "banana"]);
+    fixture.componentRef.setInput("multi", true);
+    fixture.detectChanges();
+
+    component.showAutocomplete();
+    component.autocomplete()!.openPanel();
+    component.autocompleteForm.setValue("ap");
+    fixture.detectChanges();
+
+    const options = await autocomplete.getOptions();
+    await options[0].click();
+    fixture.detectChanges();
+
+    expect(component.value).toEqual(["apple"]);
+    expect(component.autocompleteForm.value).toBe("ap");
+    expect(checkedOptionStates()).toEqual([true, false]);
+
+    // selecting takes the focus out of the search input, which must not end the search mode
+    component.onFocusOut({ relatedTarget: null } as FocusEvent);
+    expect(component.isInSearchMode()).toBe(true);
+
+    await options[1].click();
+    fixture.detectChanges();
+
+    expect(component.value).toEqual(["apple", "apricot"]);
+    expect(checkedOptionStates()).toEqual([true, true]);
+  });
+
+  it("should offer the displayed selection for overwriting when typing a filter after selecting", async () => {
+    const autocomplete = await loader.getHarness(MatAutocompleteHarness);
+    fixture.componentRef.setInput("options", ["one", "two"]);
+    fixture.componentRef.setInput("multi", true);
+    fixture.detectChanges();
+
+    component.showAutocomplete();
+    component.autocomplete()!.openPanel();
+    const options = await autocomplete.getOptions();
+    await options[0].click();
+    await fixture.whenStable();
+
+    // the search input doubles as the display of the selection, so it has to be updated ...
+    const searchInput = component.inputElement()!._elementRef
+      .nativeElement as HTMLInputElement;
+    expect(component.autocompleteForm.value).toBe("one");
+    // ... and its text selected, so the user can type a filter without deleting it first
+    expect(searchInput.selectionStart).toBe(0);
+    expect(searchInput.selectionEnd).toBe("one".length);
+  });
+
+  it("should close the panel and clear the filter when creating a new option in multi select mode", async () => {
+    const createOptionMock = vi.fn().mockResolvedValue("new option");
+    fixture.componentRef.setInput("createOption", createOptionMock);
+    fixture.componentRef.setInput("options", ["existing"]);
+    fixture.componentRef.setInput("multi", true);
+    fixture.componentRef.setInput("display", "chips");
+    fixture.detectChanges();
+
+    component.showAutocomplete();
+    component.autocomplete()!.openPanel();
+    const closePanelSpy = vi.spyOn(component.autocomplete(), "closePanel");
+    component.autocompleteForm.setValue("new option");
+
+    component.select("new option");
+    await fixture.whenStable();
+
+    expect(closePanelSpy).toHaveBeenCalled();
+    expect(component.value).toEqual(["new option"]);
+    // dropdown is open again to continue selecting, with all options available
+    expect(component.autocomplete()!.panelOpen).toBe(true);
+    expect(component.autocompleteForm.value).toBe("");
   });
 
   it("should switch the input when focusing in multi select mode", () => {

--- a/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.ts
+++ b/src/app/core/common-components/basic-autocomplete/basic-autocomplete.component.ts
@@ -54,10 +54,14 @@ import {
   ViewportRuler,
 } from "@angular/cdk/scrolling";
 import { EMPTY, fromEvent, merge } from "rxjs";
+import { MatOptionSelectionChange } from "@angular/material/core";
 import { FaDynamicIconComponent } from "../fa-dynamic-icon/fa-dynamic-icon.component";
+import { KeepPanelOpenOnSelectDirective } from "./keep-panel-open-on-select.directive";
 
 // re-export FaDynamicIconComponent to avoid forcing users of BasicAutocompleteComponent to import separately
 export { FaDynamicIconComponent } from "../fa-dynamic-icon/fa-dynamic-icon.component";
+// re-export for subclasses that reuse BASIC_AUTOCOMPLETE_COMPONENT_IMPORTS
+export { KeepPanelOpenOnSelectDirective } from "./keep-panel-open-on-select.directive";
 
 /**
  * Configuration for a single "Add new [label]" entry in the autocomplete dropdown.
@@ -101,6 +105,7 @@ export const BASIC_AUTOCOMPLETE_COMPONENT_IMPORTS = [
   CdkVirtualScrollViewport,
   CdkVirtualForOf,
   CdkFixedSizeVirtualScroll,
+  KeepPanelOpenOnSelectDirective,
 ];
 
 /**
@@ -643,6 +648,10 @@ export class BasicAutocompleteComponent<O, V = O>
   }
 
   async createFromConfig(marker: CreateOptionMarker<O>) {
+    // creating an option opens a form of its own, so the dropdown has to give way
+    // (it is kept open when selecting one of the existing options in multi-select mode)
+    this.autocomplete()?.closePanel();
+
     const createdOption = await marker.__createOptionConfig.create(
       marker.__input,
     );
@@ -650,6 +659,13 @@ export class BasicAutocompleteComponent<O, V = O>
       const newOption = this.toSelectableOption(createdOption);
       this._options.push(newOption);
       this.select(newOption);
+
+      if (this.multi()) {
+        // continue selecting further options, with all of them available again
+        this.retainSearchValue = "";
+        this.showAutocomplete();
+        this.autocomplete()?.openPanel();
+      }
     } else {
       this.showAutocomplete();
       this.autocompleteForm.setValue(marker.__input);
@@ -661,13 +677,72 @@ export class BasicAutocompleteComponent<O, V = O>
       option.selected = !option.selected;
       this._selectedOptions.set(this._options.filter((o) => o.selected));
       this.value = this._selectedOptions().map((o) => o.asValue);
-      // re-open autocomplete to select next option
-      setTimeout(() => this.showAutocomplete());
+      this.afterMultiSelectToggle();
     } else {
       this._selectedOptions.set([option]);
       this.value = option.asValue;
       this.isInSearchMode.set(false);
     }
+  }
+
+  /**
+   * The dropdown stays open while selecting several options, so update everything that
+   * Material would otherwise take care of when the panel closes and is opened again.
+   */
+  private afterMultiSelectToggle() {
+    // selecting an option takes the browser focus off the search input, so typing to filter
+    // further would be lost without giving the focus back
+    const inputEl = this.inputElement();
+    inputEl?.focus();
+
+    if (this.effectiveDisplay() === "text" && !this.retainSearchValue) {
+      // the search input doubles as the display of the current selection here, as long as the
+      // user has not typed a filter text. No event, so the visible options are not re-filtered.
+      this.autocompleteForm.setValue(this.displayText, { emitEvent: false });
+      // the autocomplete writes the new value to the input element in a microtask of its own,
+      // which resets any text selection. Select all text after that, so that typing a filter
+      // overwrites the displayed selection instead of being appended to it.
+      queueMicrotask(() =>
+        (inputEl?._elementRef.nativeElement as HTMLInputElement)?.select(),
+      );
+    }
+
+    // the field can grow with the selection (e.g. an additional row of chips)
+    this.updateOpenPanelPosition();
+  }
+
+  /**
+   * Whether the given option is part of the current selection.
+   * Reads the {@link _selectedOptions} signal, so that options rendered in the open dropdown
+   * are updated as soon as the selection changes.
+   */
+  protected isSelected(option: SelectableOption<O, V>): boolean {
+    return this._selectedOptions().includes(option);
+  }
+
+  /**
+   * Apply a selection the user made while the dropdown is kept open for a multi-select field.
+   *
+   * Material only emits its own `optionSelected` output when the panel closes, which is
+   * suppressed for multi-select (see {@link KeepPanelOpenOnSelectDirective}).
+   */
+  protected onOptionSelectionChange(event: MatOptionSelectionChange) {
+    if (!event.isUserInput || !this.multi()) {
+      return;
+    }
+
+    // Material marks the clicked option as selected internally. With the panel staying open
+    // that state would be applied to rows the virtual scroll recycles for other options,
+    // so the selection displayed by the checkboxes is derived from the value only.
+    event.source.deselect(false);
+
+    this.select(event.source.value);
+
+    // Material moves the keyboard navigation back to the first option after each selection.
+    // Keep it on the selected option instead, so the user can continue from there
+    // (this runs after the reset, which is synchronous within Material's keydown handling).
+    const keyManager = this.autocomplete()?.autocomplete?._keyManager;
+    queueMicrotask(() => keyManager?.setActiveItem(event.source));
   }
 
   private toSelectableOption(opt: O): SelectableOption<O, V> {
@@ -683,16 +758,37 @@ export class BasicAutocompleteComponent<O, V = O>
   }
 
   onFocusOut(event: FocusEvent) {
+    if (this.autocomplete()?.panelOpen) {
+      // clicking an option takes the focus out of the search input, but the user is still
+      // selecting as long as the dropdown is open (see {@link onDropdownClosed})
+      return;
+    }
+
     if (
       !this.elementRef.nativeElement.contains(event.relatedTarget as Element)
     ) {
-      if (!this.multi() && this.autocompleteForm.value === "") {
-        this.select(undefined);
-      }
-      this.isInSearchMode.set(false);
-      this.retainSearchValue = "";
+      this.endSearchMode();
     }
   }
+
+  /**
+   * The dropdown closed, which ends the selection unless the field still has the focus
+   * (e.g. after closing the dropdown with the Escape key).
+   */
+  protected onDropdownClosed() {
+    if (!this.focused) {
+      this.endSearchMode();
+    }
+  }
+
+  private endSearchMode() {
+    if (!this.multi() && this.autocompleteForm.value === "") {
+      this.select(undefined);
+    }
+    this.isInSearchMode.set(false);
+    this.retainSearchValue = "";
+  }
+
   override onContainerClick(event: MouseEvent) {
     const target = event.target;
     const clickedOption =

--- a/src/app/core/common-components/basic-autocomplete/keep-panel-open-on-select.directive.ts
+++ b/src/app/core/common-components/basic-autocomplete/keep-panel-open-on-select.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, inject, input } from "@angular/core";
+import { MatAutocompleteTrigger } from "@angular/material/autocomplete";
+import { MatOptionSelectionChange } from "@angular/material/core";
+import { filter, Observable } from "rxjs";
+
+/**
+ * Keep an autocomplete dropdown open when the user selects one of its options,
+ * so that several options can be selected without reopening the dropdown for each of them.
+ *
+ * Selecting an option is one of the "panel closing actions" of Angular Material's autocomplete
+ * and there is no input to opt out of it. The trigger's stream of option selections (the only
+ * closing action caused by a selection) is therefore replaced with a filtered one before
+ * Material reads it through `panelClosingActions`.
+ *
+ * While the panel is kept open, Material does not run its own selection handling anymore,
+ * which means the `optionSelected` output of the `mat-autocomplete` does not emit.
+ * Listen to `onSelectionChange` of the individual `mat-option`s instead.
+ */
+@Directive({
+  selector: "input[appKeepPanelOpenOnSelect]",
+})
+export class KeepPanelOpenOnSelectDirective {
+  private readonly trigger = inject(MatAutocompleteTrigger, { self: true });
+
+  /** whether the dropdown should stay open when the user selects an option */
+  readonly keepPanelOpen = input(false, { alias: "appKeepPanelOpenOnSelect" });
+
+  constructor() {
+    // `optionSelections` is public but declared readonly, as replacing it is not a documented
+    // use case. The dropdown specs assert the resulting behaviour to catch changes to this
+    // internal in future Material versions.
+    const trigger = this.trigger as {
+      optionSelections: Observable<MatOptionSelectionChange>;
+    };
+
+    trigger.optionSelections = trigger.optionSelections.pipe(
+      filter(() => !this.keepPanelOpen()),
+    );
+  }
+}


### PR DESCRIPTION
- closes #4177

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

Selecting an option is one of the "panel closing actions" of Angular Material's autocomplete, and there is no input to opt out of it. Multi-select fields therefore closed their list of options after every single item.

The new `KeepPanelOpenOnSelectDirective` filters the option selections out of the trigger's closing actions while the field is a multi-select, so the dropdown stays open. Material then no longer runs its own selection handling (its `optionSelected` output does not emit), so the selections are applied through `onSelectionChange` of the individual options instead. The panel is no longer torn down and rebuilt per selection, which keeps the typed filter text, the scroll position within a long list and the keyboard navigation in place.

Further details of the behaviour with the dropdown staying open:

- the focus goes back to the search input after each selection, so the user can keep typing to narrow the options
- for fields showing their selection as text, the search input keeps displaying the updated selection and its text is selected, so typing a filter overwrites it instead of being appended
- the panel is repositioned after each selection, because the field can grow (e.g. an additional row of chips)
- the checkbox state is derived from the value via a signal, so it also updates for "Select All" / "Clear" while the dropdown is open
- creating a new option still closes the dropdown while its form is open, and afterwards reopens it with the filter cleared, so further options can be selected
- single-select fields are unchanged and still close on selection

Note: replacing the trigger's stream of option selections relies on a Material internal. The specs assert the resulting behaviour (panel open for multi-select, closed for single-select), so a change in a future Material version fails CI rather than passing silently.

## Manual Testing Steps

Multi-select of dropdown (configurable-enum) and entity fields:

1. Open a record with a multi-select dropdown field (e.g. the "Team involved" field of a note) and click into the field.
2. Select several options in a row: the list of options stays open, each checkbox is ticked immediately and the chips are added, without having to click the field again.
3. Click an already selected option: it is unselected and the list still stays open.
4. Type a few letters to filter, then select two of the remaining options: the filter text stays in place, so no retyping is needed.
5. Click outside the field (or press Tab / Escape): the dropdown closes and the selection is applied to the record.
6. Save and reopen the record: the selected options are stored correctly.

Long lists and list filters:

7. Open a multi-select field with more than 100 options, scroll down and select an option: the list keeps its scroll position instead of jumping back to the top.
8. Open a list view with a multi-select filter (e.g. "Center" on the Children list), select several values, and use the "Select All" and "Clear" buttons in the dropdown: all checkboxes and the filtered table update while the dropdown stays open.

Creating a new option:

9. In a multi-select entity field, type a name that does not exist yet and select "Add new ...": the dropdown closes while the form for the new record is open. After saving it, the new entry is selected and the dropdown is open again with all options available.

Single select (unchanged):

10. Open a single-select dropdown field and select an option: the dropdown closes immediately as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Multi-select autocomplete panels now remain open after selecting options.
  - Selected options retain keyboard focus and display accurate checkbox states.
  - Creating a new option reopens the panel for continued selection.

- **Bug Fixes**
  - Improved filtered selection, displayed selection text, focus handling, and panel positioning.
  - Single-select autocomplete behavior remains unchanged, with the panel closing after selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->