### PR TITLE
fix(import): skip additional import actions with unregistered entity types

### DIFF
--- a/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.spec.ts
+++ b/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.spec.ts
@@ -113,4 +113,39 @@ describe("EntityActionsMenuService", () => {
     expect(actions.map((action) => action.action)).toEqual(["healthy-action"]);
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it("should not break the whole menu when an action factory throws", async () => {
+    const entity = TestEntity.create("Record A");
+    const warnSpy = vi.spyOn(Logging, "warn").mockImplementation(() => {});
+
+    service.registerActions([
+      {
+        action: "static-action",
+        label: "Static",
+        icon: "check",
+        execute: async () => true,
+      },
+    ]);
+    service.registerActionsFactories([
+      () => {
+        throw new Error("Requested item is not registered in EntityRegistry.");
+      },
+      () => [
+        {
+          action: "healthy-factory-action",
+          label: "Healthy Factory",
+          icon: "check",
+          execute: async () => true,
+        },
+      ],
+    ]);
+
+    const actions = await service.getActionsForSingle(entity);
+
+    expect(actions.map((action) => action.action)).toEqual([
+      "static-action",
+      "healthy-factory-action",
+    ]);
+    expect(warnSpy).toHaveBeenCalled();
+  });
 });

--- a/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.spec.ts
+++ b/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.spec.ts
@@ -146,6 +146,9 @@ describe("EntityActionsMenuService", () => {
       "static-action",
       "healthy-factory-action",
     ]);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("action factory failed"),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
   });
 });

--- a/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.ts
+++ b/src/app/core/entity-details/entity-actions-menu/entity-actions-menu.service.ts
@@ -21,10 +21,20 @@ export class EntityActionsMenuService {
   private readonly ability = inject(EntityAbility, { optional: true });
 
   getActions(entity?: Entity): EntityAction[] {
-    return [
-      ...this.actions,
-      ...this.actionsFactories.flatMap((factory) => factory(entity)),
-    ];
+    const factoryActions = this.actionsFactories.flatMap((factory) => {
+      try {
+        return factory(entity);
+      } catch (err) {
+        // a single misbehaving factory must not break the whole context menu
+        Logging.warn(
+          "EntityActionsMenu: action factory failed; skipping its actions.",
+          { error: err },
+        );
+        return [];
+      }
+    });
+
+    return [...this.actions, ...factoryActions];
   }
 
   /**

--- a/src/app/core/import/additional-actions/import-additional.service.spec.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.spec.ts
@@ -354,7 +354,10 @@ describe("ImportAdditionalService", () => {
     expect(
       actions.some((a) => a["targetType"] === "RemovedEntity"),
     ).toBeFalsy();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("not registered"),
+      expect.objectContaining({ unregisteredType: "RemovedEntity" }),
+    );
     // building labels for the remaining actions must not hit an unregistered type
     expect(() =>
       actions.map((a) => service.createActionLabel(a)),

--- a/src/app/core/import/additional-actions/import-additional.service.spec.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.spec.ts
@@ -10,9 +10,13 @@ import {
   expectEntitiesToMatch,
 } from "../../../utils/expect-entity-data.spec";
 import { CoreTestingModule } from "../../../utils/core-testing.module";
-import { DatabaseEntity } from "../../entity/database-entity.decorator";
+import {
+  DatabaseEntity,
+  EntityRegistry,
+} from "../../entity/database-entity.decorator";
 import { DatabaseField } from "../../entity/database-field.decorator";
 import { AttendanceItem } from "../../../features/attendance/model/attendance-item";
+import { Logging } from "../../logging/logging.service";
 
 describe("ImportAdditionalService", () => {
   let service: ImportAdditionalService;
@@ -42,6 +46,9 @@ describe("ImportAdditionalService", () => {
     participants: AttendanceItem[];
   }
 
+  @DatabaseEntity("GroupEntity")
+  class GroupEntity extends Entity {}
+
   @DatabaseEntity("RelationshipEntity")
   class RelationshipEntity extends Entity {
     @DatabaseField({
@@ -51,8 +58,12 @@ describe("ImportAdditionalService", () => {
     })
     participant: string;
 
-    @DatabaseField({ dataType: "entity", additional: "Other" })
+    @DatabaseField({ dataType: "entity", additional: GroupEntity.ENTITY_TYPE })
     group: string;
+
+    // a config where the referenced type was renamed or removed leaves such a dangling reference behind
+    @DatabaseField({ dataType: "entity", additional: "RemovedEntity" })
+    removedGroup: string;
   }
 
   beforeEach(async () => {
@@ -92,9 +103,10 @@ describe("ImportAdditionalService", () => {
         relationshipEntityType: RelationshipEntity.ENTITY_TYPE,
         relationshipProperty: "participant",
         relationshipTargetProperty: "group",
-        targetType: "Other",
+        targetType: GroupEntity.ENTITY_TYPE,
         expertOnly: false,
       },
+      // the action for RelationshipEntity.removedGroup is omitted because "RemovedEntity" is not registered
     ]);
   });
 
@@ -112,7 +124,7 @@ describe("ImportAdditionalService", () => {
   });
 
   it("should  get actions linking imported data to the given type for indirectly linked", async () => {
-    const actual = service.getActionsLinkingTo("Other");
+    const actual = service.getActionsLinkingTo(GroupEntity.ENTITY_TYPE);
     expect(actual).toEqual([
       expect.objectContaining({
         sourceType: ImportedEntity.ENTITY_TYPE,
@@ -120,7 +132,7 @@ describe("ImportAdditionalService", () => {
         relationshipEntityType: RelationshipEntity.ENTITY_TYPE,
         relationshipProperty: "participant",
         relationshipTargetProperty: "group",
-        targetType: "Other",
+        targetType: GroupEntity.ENTITY_TYPE,
       }),
     ]);
   });
@@ -331,5 +343,21 @@ describe("ImportAdditionalService", () => {
     };
     const label = service.createActionLabel(multiTypeAction);
     expect(label).toContain("ImportedEntity / DirectlyLinkingEntity");
+  });
+
+  it("should skip actions referencing an unregistered entity type instead of throwing on their label", () => {
+    const warnSpy = vi.spyOn(Logging, "warn").mockImplementation(() => {});
+    expect(TestBed.inject(EntityRegistry).has("RemovedEntity")).toBe(false);
+
+    const actions = service.getActionsLinkingFor(ImportedEntity.ENTITY_TYPE);
+
+    expect(
+      actions.some((a) => a["targetType"] === "RemovedEntity"),
+    ).toBeFalsy();
+    expect(warnSpy).toHaveBeenCalled();
+    // building labels for the remaining actions must not hit an unregistered type
+    expect(() =>
+      actions.map((a) => service.createActionLabel(a)),
+    ).not.toThrow();
   });
 });

--- a/src/app/core/import/additional-actions/import-additional.service.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.ts
@@ -18,6 +18,7 @@ import { AttendanceDatatype } from "../../../features/attendance/model/attendanc
 import { EntityRelationsService } from "../../entity/entity-mapper/entity-relations.service";
 import { asArray } from "../../../utils/asArray";
 import { EntityConfigReadyService } from "../../entity/entity-config-ready.service";
+import { Logging } from "../../logging/logging.service";
 
 /**
  * Service to handle additional import actions
@@ -131,7 +132,9 @@ export class ImportAdditionalService {
    * @param entityType
    */
   getActionsLinkingFor(entityType: string): AdditionalImportAction[] {
-    return this.linkableEntities.get(entityType) ?? [];
+    return (this.linkableEntities.get(entityType) ?? []).filter((a) =>
+      this.hasAllReferencedTypes(a),
+    );
   }
 
   /**
@@ -143,13 +146,41 @@ export class ImportAdditionalService {
     const linkingTypes: AdditionalImportAction[] = [];
 
     for (const entityType of this.linkableEntities.keys()) {
-      const matchingActions = (
-        this.linkableEntities.get(entityType) ?? []
-      ).filter((a) => a.targetType === targetEntityType);
+      const matchingActions = (this.linkableEntities.get(entityType) ?? [])
+        .filter((a) => a.targetType === targetEntityType)
+        .filter((a) => this.hasAllReferencedTypes(a));
       linkingTypes.push(...matchingActions);
     }
 
     return linkingTypes;
+  }
+
+  /**
+   * Check that every entity type an action refers to is actually registered.
+   *
+   * The types come from the entity config (e.g. a relationship field's `additional`),
+   * where a renamed or removed type can leave a dangling reference behind.
+   * Looking such a type up throws, so an action referencing one must not be offered at all.
+   */
+  private hasAllReferencedTypes(action: AdditionalImportAction): boolean {
+    const referencedTypes = [
+      action.sourceType,
+      ...asArray(action["targetType"] ?? []),
+      ...asArray(action["relationshipEntityType"] ?? []),
+    ];
+
+    const unregisteredType = referencedTypes.find(
+      (type) => !this.entityRegistry.has(type),
+    );
+    if (unregisteredType) {
+      Logging.warn(
+        "ImportAdditional: skipping action referencing an entity type that is not registered.",
+        { unregisteredType, action },
+      );
+      return false;
+    }
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
- closes #4183

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Notes on the two issues

**The reachable one is the import wizard, not the context menu.**

An entity-datatype field's `additional` is a raw config value, so a renamed or removed entity type leaves a dangling reference behind. `findIndirectLinkActionsForField` copies that value straight into an action's `targetType`, and `createActionLabel` then looks it up in the `EntityRegistry`, which throws.

`getActionsLinkingFor` (used by the import wizard's "Advanced Import Actions" section) never filtered `targetType` against a live type, so the throw escaped through the option list and the "Link all imported records to" selector rendered **completely empty**. Every valid action was lost, not just the one with the stale reference.

The context-menu path (`getActionsLinkingTo`) turned out to be much harder to hit: it filters `a.targetType === entity.getType()`, which is always a registered type, and both `sourceType` and `relationshipEntityType` come from live registry iteration. I could not construct a config that breaks it. The guard is applied there too, for the config-reload race described in the issue.

**The factory isolation is hardening, not a live bug.** Only two action factories exist (`ImportModule`, `AttendanceModule`) and neither can currently throw, which is likely why the original CI trace could not be reproduced. The `try`/`catch` means the next factory anyone registers does not inherit the hole.

## Fix

- `ImportAdditionalService.hasAllReferencedTypes()` checks `entityRegistry.has()` for `sourceType`, every `targetType`, and `relationshipEntityType`; applied in both `getActionsLinkingFor` and `getActionsLinkingTo`, logging a warning and skipping the action.
- `EntityActionsMenuService.getActions()` wraps each factory in `try`/`catch`, mirroring the existing `visible()` isolation.

## Manual Testing Steps

The dangling reference has to be created first, since a config produced through the Admin UI cannot normally contain one.

1. Open the deployed app for this PR and create a demo system with the **[All Features]** use case.
2. Go to **Admin > Edit Application Configuration (JSON)**.
3. Find `entity:Note` > `attributes` > `schools` and change `"additional": "School"` to `"additional": "SchoolArchived"`. Save.
4. Go to **Import** and upload any small `.csv` (e.g. a `name` column with two rows).
5. On step 2 **Select Import Type(s)**, choose **Child**.
6. Expand **Advanced Import Actions [optional]** and open the **"Link all imported records to:"** dropdown.

Expected: the dropdown lists four options (School through School Enrollment, Event, Class Session, Recurring Activity). The dangling `SchoolArchived` action is absent, and the browser console shows a single `[warn] ImportAdditional: skipping action referencing an entity type that is not registered.`

Before this change the same dropdown opened **empty**, with `RegistryLookupError: Requested item is not registered in EntityRegistry. Key: SchoolArchived` in the console.

7. Undo the config change (the JSON editor offers an undo, or restore `"School"` manually) and confirm the dropdown still lists the same four options with no warning.

Also worth a quick check that the entity context menu is unaffected: open any Child record and confirm the "⋮" menu still shows its usual actions.

## Follow-up spotted while tracing (not fixed here)

`getActionsLinkingTo` filters with `a.targetType === targetEntityType`, but `targetType` can be an array (`field2.additional` allows one, and `createActionLabel` handles arrays via `asArray`). The strict equality never matches an array, so multi-target indirect actions silently never appear in the context menu. Happy to file this separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action menus now remain available when an individual action provider fails; other valid actions continue to appear.
  * Import actions referencing unavailable entity types are skipped instead of causing errors.
  * Improved logging identifies failed action providers and invalid import references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->