### PR TITLE
refactor: unify drag & drop in the admin editors

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
@@ -2,7 +2,7 @@
   <!-- FORM PREVIEW -->
   <div
     cdkDropList
-    (cdkDropListDropped)="dropfieldGroups($event, fieldGroups())"
+    (cdkDropListDropped)="dropFieldGroups($event)"
     cdkDropListOrientation="mixed"
     class="flex-grow padding-right-regular drop-list"
     [class.admin-grid-layout]="!fieldsOnlyMode()"
@@ -30,7 +30,7 @@
         <div
           cdkDropList
           [id]="uniqueAreaId() + '-group' + i"
-          [cdkDropListData]="group.fields"
+          [cdkDropListData]="i"
           (cdkDropListDropped)="drop($event)"
           [cdkDropListConnectedTo]="connectedGroups()"
           [cdkDropListDisabled]="isDisabled()"
@@ -42,6 +42,7 @@
             <div
               class="admin-form-field flex-row align-center"
               cdkDrag
+              [cdkDragData]="field"
               cdkDragBoundary=".overall-container"
             >
               <fa-icon
@@ -114,7 +115,7 @@
       <div
         cdkDropList
         (cdkDropListDropped)="drop($event)"
-        [cdkDropListData]="filteredFields()"
+        [cdkDropListData]="availableFieldsTarget"
         [cdkDropListConnectedTo]="connectedGroups()"
         class="drop-list"
       >
@@ -162,6 +163,7 @@
               field === createNewTextPlaceholder
             "
             cdkDrag
+            [cdkDragData]="field"
             cdkDragBoundary="mat-drawer-container"
           >
             <fa-icon

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
@@ -39,11 +39,16 @@
         >
           <!-- FIELD [start] -->
           @for (field of group.fields; track field) {
+            <!--
+              No cdkDragBoundary here: it clamps the pointer to
+              `boundary.right - (previewWidth - grabOffset)`, which for a field-wide preview
+              grabbed at its handle stops short of the toolbar, making it impossible to drag
+              a field out of the form again.
+            -->
             <div
               class="admin-form-field flex-row align-center"
               cdkDrag
               [cdkDragData]="field"
-              cdkDragBoundary=".overall-container"
             >
               <fa-icon
                 icon="grip-vertical"
@@ -114,9 +119,11 @@
     <mat-card-content>
       <div
         cdkDropList
+        [id]="availableFieldsDropListId()"
         (cdkDropListDropped)="drop($event)"
         [cdkDropListData]="availableFieldsTarget"
         [cdkDropListConnectedTo]="connectedGroups()"
+        [cdkDropListDisabled]="isDisabled()"
         class="drop-list"
       >
         <div class="drop-area-hint">

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EntityForm } from "#src/app/core/common-components/entity-form/entity-form";
-import { CdkDragDrop } from "@angular/cdk/drag-drop";
+import { CdkDrag, CdkDragDrop, CdkDropList } from "@angular/cdk/drag-drop";
 import { FormGroup } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { By } from "@angular/platform-browser";
@@ -19,7 +19,16 @@ import { DefaultValueService } from "../../../default-values/default-value-servi
 import { FormConfig } from "../../../entity-details/form/form.component";
 import { AdminEntityService } from "../../admin-entity.service";
 import { AdminModule } from "../../admin.module";
-import { AdminEntityFormComponent } from "./admin-entity-form.component";
+import {
+  AdminEntityFormComponent,
+  FieldDropTarget,
+} from "./admin-entity-form.component";
+
+type FieldDropEvent = CdkDragDrop<
+  FieldDropTarget,
+  FieldDropTarget,
+  ColumnConfig
+>;
 
 describe("AdminEntityFormComponent", () => {
   let component: AdminEntityFormComponent;
@@ -124,23 +133,24 @@ describe("AdminEntityFormComponent", () => {
     ]);
   });
 
-  function mockDropNewFieldEvent(
-    targetContainer: ColumnConfig[],
-    previousContainer?: ColumnConfig[],
-    previousIndex?: number,
+  /**
+   * Simulate dropping `field` into the drop list `to` (a field group's index or the toolbar).
+   * Drags start from the toolbar unless `from` says otherwise.
+   */
+  function mockDropEvent(
+    field: ColumnConfig,
+    to: FieldDropTarget,
+    currentIndex = 1,
+    from: FieldDropTarget = "available",
+    previousIndex = 0,
   ) {
-    previousContainer = previousContainer ?? component.availableFields();
-    previousIndex = previousIndex ?? 0; // "new field" placeholder is always first
-
     return {
-      container: { data: targetContainer },
-      currentIndex: 1,
-      previousContainer: { data: previousContainer },
-      previousIndex: previousIndex,
-    } as Partial<CdkDragDrop<ColumnConfig[], ColumnConfig[]>> as CdkDragDrop<
-      ColumnConfig[],
-      ColumnConfig[]
-    >;
+      item: { data: field },
+      container: { data: to },
+      currentIndex,
+      previousContainer: { data: from },
+      previousIndex,
+    } as Partial<FieldDropEvent> as FieldDropEvent;
   }
 
   it("should add new field in view if field config dialog succeeds", async () => {
@@ -154,15 +164,20 @@ describe("AdminEntityFormComponent", () => {
         afterClosed: () => of(newField),
       } as any);
 
-      const targetContainer = component.config().fieldGroups[0].fields;
-      component.drop(mockDropNewFieldEvent(targetContainer));
+      component.drop(mockDropEvent(component.createNewFieldPlaceholder, 0));
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mockDialog.open).toHaveBeenCalled();
-      expect(targetContainer).toEqual(["name", newField.id, "other"]);
+      expect(component.fieldGroups()[0].fields).toEqual([
+        "name",
+        newField.id,
+        "other",
+      ]);
       expect(component.availableFields()).toContain(
         component.createNewFieldPlaceholder,
       );
+      // the new field is in the form now, so it is no longer offered in the toolbar
+      expect(component.availableFields()).not.toContain(newField.id);
     } finally {
       vi.useRealTimers();
     }
@@ -173,11 +188,10 @@ describe("AdminEntityFormComponent", () => {
     try {
       mockDialog.open.mockReturnValue({ afterClosed: () => of("") } as any);
 
-      const targetContainer = component.config().fieldGroups[0].fields;
-      component.drop(mockDropNewFieldEvent(targetContainer));
+      component.drop(mockDropEvent(component.createNewFieldPlaceholder, 0));
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(targetContainer).toEqual(["name", "other"]);
+      expect(component.fieldGroups()[0].fields).toEqual(["name", "other"]);
       expect(mockDialog.open).toHaveBeenCalled();
       expect(component.availableFields()).toContain(
         component.createNewFieldPlaceholder,
@@ -190,7 +204,9 @@ describe("AdminEntityFormComponent", () => {
   it("should not create field (show dialog) if new field is dropped on toolbar (available fields)", async () => {
     vi.useFakeTimers();
     try {
-      component.drop(mockDropNewFieldEvent(component.availableFields()));
+      component.drop(
+        mockDropEvent(component.createNewFieldPlaceholder, "available"),
+      );
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mockDialog.open).not.toHaveBeenCalled();
@@ -202,19 +218,84 @@ describe("AdminEntityFormComponent", () => {
   it("should create a new fieldGroup in config on dropping field in new-group drop area", async () => {
     vi.useFakeTimers();
     try {
-      const field = component.config().fieldGroups[0].fields[0];
-      const dropEvent = mockDropNewFieldEvent(
-        null,
-        component.config().fieldGroups[0].fields,
-        0,
-      );
-      component.dropNewGroup(dropEvent);
+      const field = component.fieldGroups()[0].fields[0];
+      component.dropNewGroup(mockDropEvent(field, undefined, 0, 0, 0));
       await vi.advanceTimersByTimeAsync(0);
 
       expect(component.fieldGroups()[2]).toEqual({ fields: [field] });
+      // the field has moved, so it is gone from the group it was dragged out of
+      expect(component.fieldGroups()[0].fields).toEqual(["other"]);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("should move a field from one group into another", async () => {
+    await component.drop(mockDropEvent("name", 1, 0, 0, 0));
+
+    expect(component.fieldGroups()).toEqual([
+      { header: "Group 1", fields: ["other"] },
+      { fields: ["name", "category"] },
+    ]);
+  });
+
+  it("should reorder fields within a group", async () => {
+    await component.drop(mockDropEvent("name", 0, 1, 0, 0));
+
+    expect(component.fieldGroups()[0].fields).toEqual(["other", "name"]);
+  });
+
+  it("should remove a field from the form when dropped back into the toolbar", async () => {
+    await component.drop(mockDropEvent("name", "available", 0, 0, 0));
+
+    expect(component.fieldGroups()[0].fields).toEqual(["other"]);
+    expect(component.availableFields()).toContain("name");
+  });
+
+  it("should not mutate the config input when fields are moved", async () => {
+    const configBefore = JSON.stringify(testConfig);
+
+    await component.drop(mockDropEvent("name", 1, 0, 0, 0));
+
+    expect(JSON.stringify(testConfig)).toBe(configBefore);
+  });
+
+  it("should reorder the field groups", () => {
+    component.dropFieldGroups({
+      previousIndex: 0,
+      currentIndex: 1,
+    } as CdkDragDrop<unknown>);
+
+    expect(component.fieldGroups()).toEqual([
+      { fields: ["category"] },
+      { header: "Group 1", fields: ["name", "other"] },
+    ]);
+  });
+
+  it("should identify each fields drop list by the target a drop applies to", () => {
+    const dropListData = fixture.debugElement
+      .queryAll(By.directive(CdkDropList))
+      .map((el) => el.injector.get(CdkDropList).data);
+
+    // the outer list only reorders the groups themselves and needs no target;
+    // the two group lists and the toolbar identify where a dropped field goes
+    expect(dropListData).toEqual([undefined, 0, 1, undefined, "available"]);
+  });
+
+  it("should attach each field to its drag, so a drop knows what was moved", () => {
+    const draggedFields = fixture.debugElement
+      .queryAll(By.css(".admin-form-field"))
+      .map((el) => el.injector.get(CdkDrag).data);
+
+    expect(draggedFields).toEqual(
+      expect.arrayContaining([
+        "name",
+        "other",
+        "category",
+        component.createNewFieldPlaceholder,
+        component.createNewTextPlaceholder,
+      ]),
+    );
   });
 
   it("should move all fields from removed group to availableFields toolbar", async () => {

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -150,7 +150,7 @@ describe("AdminEntityFormComponent", () => {
       currentIndex,
       previousContainer: { data: from },
       previousIndex,
-    } as Partial<FieldDropEvent> as FieldDropEvent;
+    } as FieldDropEvent;
   }
 
   it("should add new field in view if field config dialog succeeds", async () => {
@@ -280,6 +280,21 @@ describe("AdminEntityFormComponent", () => {
     // the outer list only reorders the groups themselves and needs no target;
     // the two group lists and the toolbar identify where a dropped field goes
     expect(dropListData).toEqual([undefined, 0, 1, undefined, "available"]);
+  });
+
+  it("should connect the toolbar, so fields can be dragged out of the form again", () => {
+    const dropLists = fixture.debugElement
+      .queryAll(By.directive(CdkDropList))
+      .map((el) => el.injector.get(CdkDropList));
+    const toolbar = dropLists.find((list) => list.data === "available");
+    const fieldGroups = dropLists.filter(
+      (list) => typeof list.data === "number",
+    );
+
+    expect(toolbar.id).toBe(component.availableFieldsDropListId());
+    for (const group of fieldGroups) {
+      expect(group.connectedTo).toContain(toolbar.id);
+    }
   });
 
   it("should attach each field to its drag, so a drop knows what was moved", () => {

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -3,7 +3,6 @@ import {
   CdkDragDrop,
   DragDropModule,
   moveItemInArray,
-  transferArrayItem,
 } from "@angular/cdk/drag-drop";
 import {
   ChangeDetectionStrategy,
@@ -49,6 +48,19 @@ import {
   AdminEntityFieldComponent,
   AdminEntityFieldData,
 } from "../admin-entity-field/admin-entity-field.component";
+
+/**
+ * Identifies one of the drop lists a field can be dragged between:
+ * the index of a field group in the form, or the toolbar of fields not used in the form.
+ */
+export type FieldDropTarget = number | "available";
+
+/** A field dragged between the form's field groups and the toolbar of unused fields. */
+type FieldDragDropEvent = CdkDragDrop<
+  FieldDropTarget,
+  FieldDropTarget,
+  ColumnConfig
+>;
 
 @UntilDestroy()
 @Component({
@@ -147,6 +159,9 @@ export class AdminEntityFormComponent {
     id: null,
     label: $localize`:Label drag and drop item:Create Text Block`,
   };
+
+  /** `cdkDropListData` marking the toolbar as the drop target for fields removed from the form */
+  readonly availableFieldsTarget: FieldDropTarget = "available";
 
   searchFilter = new FormControl("");
 
@@ -327,41 +342,44 @@ export class AdminEntityFormComponent {
     return result;
   }
 
-  drop(event: CdkDragDrop<ColumnConfig[], ColumnConfig[]>) {
-    const prevFieldsArray = event.previousContainer.data;
-    const newFieldsArray = event.container.data;
-
-    if (
-      prevFieldsArray[event.previousIndex] === this.createNewFieldPlaceholder
-    ) {
-      this.dropNewField(event);
+  /**
+   * Move a field that was dragged into a field group or back into the toolbar.
+   *
+   * Each drop list carries its identity (a field group's index or "available") as
+   * `cdkDropListData` and each field carries itself as `cdkDragData`, so that the new
+   * `fieldGroups` can be built immutably instead of splicing the arrays CDK hands over.
+   */
+  async drop(event: FieldDragDropEvent) {
+    const target = event.container.data;
+    if (target === "available" && this.isNewFieldPlaceholder(event.item.data)) {
+      // the "create new" placeholders live in the toolbar already
       return;
     }
 
-    if (
-      prevFieldsArray[event.previousIndex] === this.createNewTextPlaceholder
-    ) {
-      this.dropNewText(event);
+    const field = await this.resolveDroppedField(event.item.data);
+    if (!field) {
       return;
     }
 
-    if (event.previousContainer === event.container) {
-      moveItemInArray(newFieldsArray, event.previousIndex, event.currentIndex);
-    } else {
-      transferArrayItem(
-        prevFieldsArray,
-        newFieldsArray,
+    this.fieldGroups.update((groups) =>
+      moveFieldBetweenGroups(
+        groups,
+        field,
+        event.previousContainer.data,
         event.previousIndex,
+        target,
         event.currentIndex,
-      );
-    }
-
-    this.fieldGroups.update((g) => [...g]);
+      ),
+    );
   }
 
-  dropfieldGroups<E>(event: CdkDragDrop<E[], any>, fieldGroupsArray: E[]) {
-    moveItemInArray(fieldGroupsArray, event.previousIndex, event.currentIndex);
-    this.fieldGroups.update((g) => [...g]);
+  /** Reorder the field groups (the form's columns). */
+  dropFieldGroups(event: CdkDragDrop<unknown>) {
+    this.fieldGroups.update((groups) => {
+      const reordered = [...groups];
+      moveItemInArray(reordered, event.previousIndex, event.currentIndex);
+      return reordered;
+    });
   }
 
   /**
@@ -430,25 +448,38 @@ export class AdminEntityFormComponent {
     );
   }
 
-  /**
-   * drop handler specifically for the "create new field" item
-   * @param event
-   * @private
-   */
-  private async dropNewField(
-    event: CdkDragDrop<ColumnConfig[], ColumnConfig[]>,
-  ) {
-    if (event.container.data === this.availableFields()) {
-      // don't add new field to the available fields that are not in the form yet
-      return;
-    }
+  private isNewFieldPlaceholder(field: ColumnConfig): boolean {
+    return (
+      field === this.createNewFieldPlaceholder ||
+      field === this.createNewTextPlaceholder
+    );
+  }
 
+  /**
+   * The field a drop actually adds to the form: the "create new" placeholders open their config
+   * dialog first (returning undefined if the user cancels), any other field is moved as it is.
+   */
+  private async resolveDroppedField(
+    dragged: ColumnConfig,
+  ): Promise<ColumnConfig | undefined> {
+    if (dragged === this.createNewFieldPlaceholder) {
+      return this.createNewField();
+    }
+    if (dragged === this.createNewTextPlaceholder) {
+      return this.createNewTextBlock();
+    }
+    return dragged;
+  }
+
+  /**
+   * Define a new field through its config dialog and add it to the entity type's schema.
+   * @returns the new field's id, or undefined if the dialog was cancelled
+   */
+  private async createNewField(): Promise<string | undefined> {
     const newField = await this.openFieldConfig({ id: null });
     if (!newField) {
-      return;
+      return undefined;
     }
-
-    const newFieldId = newField.id;
 
     if (this.updateEntitySchema()) {
       this.adminEntityService.updateSchemaField(
@@ -456,65 +487,57 @@ export class AdminEntityFormComponent {
         newField.id,
         newField,
       );
-      // the schema update has added the new field to the available fields already, remove it from there
-      const updatedFields = [...this.availableFields()];
-      updatedFields.splice(updatedFields.indexOf(newFieldId), 1);
-      this.availableFields.set(updatedFields);
     } else {
       // For local-only updates (e.g., public forms), manually update schema
       this.entityType().schema.set(newField.id, newField);
-      const updatedFields = [...this.availableFields()];
-      const fieldIndex = updatedFields.indexOf(newFieldId);
-      if (fieldIndex !== -1) {
-        updatedFields.splice(fieldIndex, 1);
-        this.availableFields.set(updatedFields);
-      }
     }
+    this.addFieldToPreview(newField.id);
 
-    this.dummyForm().formGroup.addControl(newFieldId, new FormControl());
-    this.dummyForm().formGroup.disable();
-    event.container.data.splice(event.currentIndex, 0, newFieldId);
-    this.fieldGroups.update((g) => [...g]); // notify signal of in-place mutation
+    return newField.id;
   }
 
   /**
-   * drop handler specifically for the "create new Text field" item
-   * @param event
-   * @private
+   * Define a new text block through its config dialog.
+   * @returns the new text block, or undefined if the dialog was cancelled
    */
-  private async dropNewText(
-    event: CdkDragDrop<ColumnConfig[], ColumnConfig[]>,
-  ) {
-    if (event.container.data === this.availableFields()) {
-      // don't add new Text field to the available fields that are not in the form yet
-      return;
-    }
-
+  private async createNewTextBlock(): Promise<FormFieldConfig | undefined> {
     const newTextField = await this.openTextConfig({ id: null });
     if (!newTextField) {
+      return undefined;
+    }
+    this.addFieldToPreview(newTextField.id);
+
+    return newTextField;
+  }
+
+  /** register a newly created field with the preview form, so that it can be rendered */
+  private addFieldToPreview(fieldId: string) {
+    const previewForm = this.dummyForm();
+    if (!previewForm) {
+      return;
+    }
+    previewForm.formGroup.addControl(fieldId, new FormControl());
+    previewForm.formGroup.disable();
+  }
+
+  /** Move the dragged field into a new field group appended to the form. */
+  async dropNewGroup(event: FieldDragDropEvent) {
+    const field = await this.resolveDroppedField(event.item.data);
+    if (!field) {
       return;
     }
 
-    this.dummyForm().formGroup.addControl(newTextField.id, new FormControl());
-    this.dummyForm().formGroup.disable();
-    event.container.data.splice(event.currentIndex, 0, newTextField);
-    this.fieldGroups.update((g) => [...g]);
-
-    // the schema update has added the new Text field to the available fields already, remove it from there
-    this.availableFields.update((fields) =>
-      fields.filter((f) =>
-        typeof f === "string"
-          ? f !== newTextField.id
-          : f.id !== newTextField.id,
-      ),
-    );
-  }
-
-  dropNewGroup(event: CdkDragDrop<any, any>) {
-    const newCol: FieldGroup = { fields: [] };
-    this.fieldGroups.update((groups) => [...groups, newCol]);
-    event.container.data = newCol.fields;
-    this.drop(event);
+    this.fieldGroups.update((groups) => {
+      const withNewGroup: FieldGroup[] = [...groups, { fields: [] }];
+      return moveFieldBetweenGroups(
+        withNewGroup,
+        field,
+        event.previousContainer.data,
+        event.previousIndex,
+        withNewGroup.length - 1,
+        0,
+      );
+    });
   }
 
   removeGroup(i: number) {
@@ -568,4 +591,37 @@ export class AdminEntityFormComponent {
   clearSearch() {
     this.searchFilter.setValue("");
   }
+}
+
+/**
+ * Move `field` from one drop target to another, returning new group objects for the groups that
+ * changed (all others are kept as they are).
+ *
+ * A target of "available" is the toolbar of fields not used in the form: it holds no state of its
+ * own (it is derived from the form's groups), so a field moved there is simply removed from the
+ * form and a field moved from there is simply added.
+ */
+function moveFieldBetweenGroups(
+  groups: FieldGroup[],
+  field: ColumnConfig,
+  from: FieldDropTarget,
+  fromIndex: number,
+  to: FieldDropTarget,
+  toIndex: number,
+): FieldGroup[] {
+  return groups.map((group, index) => {
+    if (index !== from && index !== to) {
+      return group;
+    }
+
+    let fields = group.fields ?? [];
+    if (index === from) {
+      fields = [...fields.slice(0, fromIndex), ...fields.slice(fromIndex + 1)];
+    }
+    if (index === to) {
+      // within the same group, `toIndex` refers to the list without the dragged field
+      fields = [...fields.slice(0, toIndex), field, ...fields.slice(toIndex)];
+    }
+    return { ...group, fields };
+  });
 }

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -242,15 +242,21 @@ export class AdminEntityFormComponent {
     return (fieldGroups ?? []).reduce((p, c) => p.concat(c.fields ?? []), []);
   }
 
+  /** id of the toolbar's drop list, so that fields can be dragged out of the form again */
+  readonly availableFieldsDropListId = computed(
+    () => `availableFields-${this.uniqueAreaId()}`,
+  );
+
   /**
-   * List of group IDs that are connected to the drag&drop area.
+   * Ids of all drop lists a field can be dragged into: every field group, the area creating a
+   * new group, and the toolbar of fields not used in the form.
    */
   readonly connectedGroups = computed(() => {
     const config = this.config();
     const areaId = this.uniqueAreaId();
 
     if (!config) {
-      return [`newGroupDropArea-${areaId}`];
+      return [`newGroupDropArea-${areaId}`, this.availableFieldsDropListId()];
     }
 
     return [
@@ -258,6 +264,7 @@ export class AdminEntityFormComponent {
         (_, groupIndex) => `${areaId}-group${groupIndex}`,
       ),
       `newGroupDropArea-${areaId}`,
+      this.availableFieldsDropListId(),
     ];
   });
 

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.html
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.html
@@ -1,16 +1,7 @@
-<mat-nav-list class="drop-list flex-column gap-regular limit-width">
+<mat-nav-list class="limit-width">
   @if (item()) {
-    <div
-      class="flex-row menu-item-container drop-item"
-      cdkDrag
-      [cdkDragData]="item()"
-      cdkDropList
-      [id]="item().uniqueId"
-      [cdkDropListData]="item().subMenu"
-      [cdkDropListConnectedTo]="connectedTo()"
-      (cdkDropListDropped)="onDragDrop($event)"
-    >
-      <div class="flex-row" cdkDragHandle>
+    <div class="flex-row menu-item-container">
+      <div class="flex-row">
         <fa-icon icon="grip-vertical" class="drag-handle"></fa-icon>
 
         <app-menu-item
@@ -49,23 +40,6 @@
           </button>
         </div>
       </div>
-
-      @if (allowSubMenu() && item().subMenu && item().subMenu.length > 0) {
-        <div class="submenu">
-          @for (subItem of item().subMenu; track subItem.uniqueId) {
-            <app-admin-menu-item
-              [item]="subItem"
-              [connectedTo]="connectedTo()"
-              [allowEntityLinks]="allowEntityLinks()"
-              [allowSubMenu]="allowSubMenu()"
-              (itemDrop)="onDragDrop($event)"
-              (deleteItem)="removeSubItem(subItem)"
-              (itemChange)="onSubItemChange($event)"
-              class="submenu-list"
-            ></app-admin-menu-item>
-          }
-        </div>
-      }
     </div>
   }
 </mat-nav-list>

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.scss
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.scss
@@ -16,11 +16,6 @@
   margin-left: auto; /* Push actions to far right */
 }
 
-.drop-item:has(.remove-icon:hover) {
-  color: rgb(255, 0, 0);
-  background-color: rgba(255, 0, 0, 0.1);
-}
-
 /* Drag handle (left) */
 .drag-handle {
   cursor: move;
@@ -45,42 +40,10 @@ app-menu-item {
   overflow: hidden; /* Prevent overflow from child elements */
 }
 
-/* Submenu indentation: only indent the visible content, not the actions */
-.submenu-list > .menu-item-container,
-.submenu .menu-item-container {
-  padding-left: 32px;
-}
-
 .limit-width {
   max-width: 400px;
 
   @media (max-width: 600px) {
     max-width: 100%;
   }
-}
-
-
-.cdk-drag-preview {
-  box-sizing: border-box;
-  border-radius: 4px;
-  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
-  0 8px 10px 1px rgba(0, 0, 0, 0.14),
-  0 3px 14px 2px rgba(0, 0, 0, 0.12);
-}
-
-.cdk-drag-placeholder {
-  opacity: 0;
-}
-
-.cdk-drag-animating {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-.drop-list.cdk-drop-list-dragging .drop-item:not(.cdk-drag-placeholder) {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-.cdk-drop-list-receiving {
-  background-color: rgba(0, 0, 0, 0.03);
-  border: 2px dashed #ccc;
 }

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.spec.ts
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.spec.ts
@@ -61,19 +61,14 @@ describe("AdminMenuItemComponent", () => {
     } as MenuItemForAdminUi);
     expect(component.hasNoLinkWarning()).toBe(false);
 
-    const child = {
-      uniqueId: "2",
-      label: "Child",
-      icon: "user",
-      link: "/child",
-      subMenu: [],
-    } as MenuItemForAdminUi;
+    // sub-items are rendered as rows of their own, the editor reports them via `hasSubItems`
     fixture.componentRef.setInput("item", {
       uniqueId: "1",
       label: "Section",
       icon: "folder",
-      subMenu: [child],
+      subMenu: [],
     } as MenuItemForAdminUi);
+    fixture.componentRef.setInput("hasSubItems", true);
     expect(component.hasNoLinkWarning()).toBe(false);
   });
 });

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.spec.ts
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.spec.ts
@@ -5,12 +5,19 @@ import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testi
 import { MenuItemForAdminUi } from "../menu-item-for-admin-ui";
 import { provideRouter } from "@angular/router";
 import { Angulartics2Module } from "angulartics2";
+import { MatDialog } from "@angular/material/dialog";
+import { of } from "rxjs";
+import type { Mock } from "vitest";
 
 describe("AdminMenuItemComponent", () => {
   let component: AdminMenuItemComponent;
   let fixture: ComponentFixture<AdminMenuItemComponent>;
+  let mockDialog: { open: Mock };
 
   beforeEach(async () => {
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => of(undefined) }),
+    };
     await TestBed.configureTestingModule({
       imports: [
         AdminMenuItemComponent,
@@ -22,6 +29,7 @@ describe("AdminMenuItemComponent", () => {
           provide: MenuService,
           useValue: { generateMenuItemForEntityType: () => [] },
         },
+        { provide: MatDialog, useValue: mockDialog },
         provideRouter([]),
       ],
     }).compileComponents();
@@ -70,5 +78,18 @@ describe("AdminMenuItemComponent", () => {
     } as MenuItemForAdminUi);
     fixture.componentRef.setInput("hasSubItems", true);
     expect(component.hasNoLinkWarning()).toBe(false);
+  });
+
+  it("should pass the allowEntityLinks value, not the input signal, to the edit dialog", async () => {
+    fixture.componentRef.setInput("allowEntityLinks", false);
+
+    await component.editMenuItem(component.item());
+
+    expect(mockDialog.open).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({ allowEntityLinks: false }),
+      }),
+    );
   });
 });

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.ts
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.ts
@@ -10,7 +10,6 @@ import {
 import { EntityMenuItem, MenuItem } from "app/core/ui/navigation/menu-item";
 import { MenuItemComponent } from "app/core/ui/navigation/menu-item/menu-item.component";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
-import { CdkDragDrop, DragDropModule } from "@angular/cdk/drag-drop";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { FormsModule } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
@@ -18,7 +17,7 @@ import { MenuService } from "app/core/ui/navigation/menu.service";
 import { firstValueFrom } from "rxjs";
 import { AdminMenuItemDetailsComponent } from "../admin-menu-item-details/admin-menu-item-details.component";
 import {
-  hasNoLinkAndNoSubItems,
+  isManualItemWithoutLink,
   MenuItemForAdminUi,
 } from "../menu-item-for-admin-ui";
 import { MatNavList } from "@angular/material/list";
@@ -26,18 +25,18 @@ import { MatIconButton } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 
 /**
- * Display and edit a menu item in the admin interface,
- * including recursively editing and drag&drop of subMenu items.
+ * Display and edit a single menu item in the admin interface.
+ *
+ * Nesting and drag & drop are handled by the surrounding
+ * {@link MenuItemListEditorComponent}, which renders the whole (nested) menu as one flat list.
  */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "app-admin-menu-item",
-  standalone: true,
   imports: [
     MatNavList,
     MenuItemComponent,
     FaIconComponent,
-    DragDropModule,
     MatFormFieldModule,
     FormsModule,
     MatIconButton,
@@ -54,6 +53,9 @@ export class AdminMenuItemComponent {
   private readonly menuService = inject(MenuService);
 
   item = model.required<MenuItemForAdminUi>();
+
+  /** whether this item has nested sub-items (which are rows of their own in the editor) */
+  hasSubItems = input<boolean>(false);
 
   itemToDisplay = computed<MenuItem>(() => {
     const item = this.item();
@@ -72,42 +74,16 @@ export class AdminMenuItemComponent {
    */
   hasNoLinkWarning = computed(() => {
     const item = this.item();
-    return item ? hasNoLinkAndNoSubItems(item) : false;
+    return item ? isManualItemWithoutLink(item) && !this.hasSubItems() : false;
   });
-
-  connectedTo = input<string[]>([]);
 
   /** Whether entity type links are allowed (false for shortcuts, true for admin menu) */
   allowEntityLinks = input<boolean>(true);
 
-  /** Whether sub-menus are allowed for this item type */
-  allowSubMenu = input<boolean>(true);
-
-  itemDrop = output<CdkDragDrop<MenuItemForAdminUi[]>>();
   deleteItem = output<MenuItemForAdminUi>();
-
-  removeSubItem(subItem: MenuItemForAdminUi): void {
-    this.item.set({
-      ...this.item(),
-      subMenu: [...this.item().subMenu.filter((i) => i !== subItem)],
-    });
-  }
-
-  onSubItemChange(updatedSubItem: MenuItemForAdminUi) {
-    this.item.set({
-      ...this.item(),
-      subMenu: this.item().subMenu.map((sub) =>
-        sub.uniqueId === updatedSubItem.uniqueId ? updatedSubItem : sub,
-      ),
-    });
-  }
 
   onDelete(item: MenuItemForAdminUi): void {
     this.deleteItem.emit(item);
-  }
-
-  onDragDrop(event: CdkDragDrop<MenuItemForAdminUi[]>) {
-    this.itemDrop.emit(event);
   }
 
   async editMenuItem(item: MenuItemForAdminUi) {
@@ -134,7 +110,7 @@ export class AdminMenuItemComponent {
       width: "600px",
       data: {
         item: item ? { ...item } : {},
-        allowEntityLinks: this.allowEntityLinks,
+        allowEntityLinks: this.allowEntityLinks(),
       },
     });
     return firstValueFrom(dialogRef.afterClosed());

--- a/src/app/core/admin/admin-menu/admin-menu.component.html
+++ b/src/app/core/admin/admin-menu/admin-menu.component.html
@@ -27,6 +27,5 @@
 <app-menu-item-list-editor
   class="margin-top-large"
   [items]="menuItems()"
-  containerId="navigation-container"
   (itemsChange)="onMenuItemsChange($event)"
 ></app-menu-item-list-editor>

--- a/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
+++ b/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
@@ -1,3 +1,4 @@
+import { FlatTreeAdapter } from "#src/app/utils/flat-tree/flat-tree";
 import { EntityMenuItem, MenuItem } from "../../ui/navigation/menu-item";
 
 /**
@@ -8,6 +9,16 @@ export interface MenuItemForAdminUi extends MenuItem {
   uniqueId: string;
   subMenu: MenuItemForAdminUi[];
 }
+
+/**
+ * Edit the menu as a flat, indented list (see `flat-tree`):
+ * every menu item can hold nested sub-items.
+ */
+export const menuItemTree: FlatTreeAdapter<MenuItemForAdminUi> = {
+  id: (item) => item.uniqueId,
+  children: (item) => item.subMenu ?? [],
+  withChildren: (item, subMenu) => ({ ...item, subMenu }),
+};
 
 export class MenuItemForAdminUiNew implements MenuItemForAdminUi {
   constructor(public uniqueId: string) {}
@@ -27,14 +38,4 @@ export function isManualItemWithoutLink(
   item: MenuItem | EntityMenuItem,
 ): boolean {
   return !item.link?.trim() && !(item as EntityMenuItem).entityType?.trim();
-}
-
-/**
- * True when an item has no destination link and also no nested sub-items.
- */
-export function hasNoLinkAndNoSubItems(item: MenuItemForAdminUi): boolean {
-  return (
-    isManualItemWithoutLink(item) &&
-    (!item.subMenu || item.subMenu.length === 0)
-  );
 }

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.html
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.html
@@ -25,7 +25,7 @@
     >
       <app-admin-menu-item
         [item]="row.data"
-        [hasSubItems]="hasSubItems(i)"
+        [hasSubItems]="row.hasSubItems"
         [allowEntityLinks]="allowEntityLinks()"
         (deleteItem)="removeItem(i)"
         (itemChange)="onItemChange($event, i)"

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.html
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.html
@@ -1,4 +1,4 @@
-@if (showAddButton) {
+@if (showAddButton()) {
   <div class="margin-bottom-regular">
     <app-icon-button
       icon="plus-circle"
@@ -12,21 +12,24 @@
 }
 
 <div
+  class="drop-list flex-column gap-regular"
   cdkDropList
-  [id]="containerId"
-  [cdkDropListData]="items()"
-  [cdkDropListConnectedTo]="connectedDropLists"
-  (cdkDropListDropped)="onDragDrop($event)"
+  (cdkDropListDropped)="onDrop($event)"
 >
-  @for (item of items(); track item.uniqueId; let i = $index) {
-    <app-admin-menu-item
-      [item]="item"
-      [connectedTo]="connectedDropLists"
-      [allowEntityLinks]="allowEntityLinks"
-      [allowSubMenu]="allowSubMenu"
-      (itemDrop)="onDragDrop($event)"
-      (deleteItem)="removeItem(item)"
-      (itemChange)="onItemChange($event, i)"
-    ></app-admin-menu-item>
+  @for (row of rows(); track row.id; let i = $index) {
+    <div
+      class="drop-item"
+      [style.margin-left.px]="row.level * indentPerLevel"
+      cdkDrag
+      [cdkDragData]="row"
+    >
+      <app-admin-menu-item
+        [item]="row.data"
+        [hasSubItems]="hasSubItems(i)"
+        [allowEntityLinks]="allowEntityLinks()"
+        (deleteItem)="removeItem(i)"
+        (itemChange)="onItemChange($event, i)"
+      ></app-admin-menu-item>
+    </div>
   }
 </div>

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.scss
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.scss
@@ -1,3 +1,25 @@
 .margin-bottom-regular {
   margin-bottom: 16px;
 }
+
+// CDK drag & drop feedback
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow:
+    0 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0 8px 10px 1px rgba(0, 0, 0, 0.14),
+    0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.drop-list.cdk-drop-list-dragging .drop-item:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.spec.ts
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.spec.ts
@@ -40,6 +40,24 @@ describe("MenuItemListEditorComponent", () => {
     fixture.detectChanges();
   });
 
+  /** a menu item with the given id and (optional) sub-items */
+  const menuItem = (
+    uniqueId: string,
+    subMenu: MenuItemForAdminUi[] = [],
+  ): MenuItemForAdminUi => ({ uniqueId, label: uniqueId, subMenu });
+
+  /** simulate a drop, `draggedLevels` being how far the item was dragged sideways */
+  const drop = (
+    previousIndex: number,
+    currentIndex: number,
+    draggedLevels = 0,
+  ) =>
+    component.onDrop({
+      previousIndex,
+      currentIndex,
+      distance: { x: draggedLevels * component.indentPerLevel, y: 0 },
+    } as CdkDragDrop<unknown>);
+
   it("should create", () => {
     expect(component).toBeTruthy();
   });
@@ -118,103 +136,83 @@ describe("MenuItemListEditorComponent", () => {
     expect(emittedValues).toEqual([[secondItem]]);
   });
 
-  describe("drag & drop of the flat, indented list", () => {
-    /** a menu item with the given id and (optional) sub-items */
-    const menuItem = (
-      uniqueId: string,
-      subMenu: MenuItemForAdminUi[] = [],
-    ): MenuItemForAdminUi => ({ uniqueId, label: uniqueId, subMenu });
+  it("flattens nested items into indented rows", () => {
+    component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
 
-    /** simulate a drop, `draggedLevels` being how far the item was dragged sideways */
-    const drop = (
-      previousIndex: number,
-      currentIndex: number,
-      draggedLevels = 0,
-    ) =>
-      component.onDrop({
-        previousIndex,
-        currentIndex,
-        distance: { x: draggedLevels * component.indentPerLevel, y: 0 },
-      } as CdkDragDrop<unknown>);
+    expect(component.rows().map((r) => [r.id, r.level, r.hasSubItems])).toEqual(
+      [
+        ["a", 0, true],
+        ["a1", 1, false],
+        ["b", 0, false],
+      ],
+    );
+  });
 
-    it("flattens nested items into indented rows", () => {
-      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+  it("moves an item together with its sub-items", () => {
+    component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
 
-      expect(component.rows().map((r) => [r.id, r.level])).toEqual([
-        ["a", 0],
-        ["a1", 1],
-        ["b", 0],
-      ]);
-      expect(component.hasSubItems(0)).toBe(true);
-      expect(component.hasSubItems(1)).toBe(false);
-    });
+    drop(0, 2); // drag "a" to the end; cdk counts the dragged row only
 
-    it("moves an item together with its sub-items", () => {
-      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+    expect(component.items()).toEqual([
+      menuItem("b"),
+      menuItem("a", [menuItem("a1")]),
+    ]);
+  });
 
-      drop(0, 2); // drag "a" to the end; cdk counts the dragged row only
+  it("nests an item into the item above when dragged to the right", () => {
+    component.items.set([menuItem("a"), menuItem("b")]);
 
-      expect(component.items()).toEqual([
-        menuItem("b"),
-        menuItem("a", [menuItem("a1")]),
-      ]);
-    });
+    drop(1, 1, 1);
 
-    it("nests an item into the item above when dragged to the right", () => {
-      component.items.set([menuItem("a"), menuItem("b")]);
+    expect(component.items()).toEqual([menuItem("a", [menuItem("b")])]);
+  });
 
-      drop(1, 1, 1);
+  it("does not re-nest on slight sideways drift while dragging", () => {
+    component.items.set([menuItem("a"), menuItem("b")]);
 
-      expect(component.items()).toEqual([menuItem("a", [menuItem("b")])]);
-    });
+    component.onDrop({
+      previousIndex: 1,
+      currentIndex: 1,
+      distance: { x: component.indentPerLevel / 2, y: 0 },
+    } as CdkDragDrop<unknown>);
 
-    it("does not re-nest on slight sideways drift while dragging", () => {
-      component.items.set([menuItem("a"), menuItem("b")]);
+    expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
+  });
 
-      component.onDrop({
-        previousIndex: 1,
-        currentIndex: 1,
-        distance: { x: component.indentPerLevel / 2, y: 0 },
-      } as CdkDragDrop<unknown>);
+  it("lifts a sub-item out of its parent when dragged to the left", () => {
+    component.items.set([menuItem("a", [menuItem("a1")])]);
 
-      expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
-    });
+    drop(1, 1, -1);
 
-    it("lifts a sub-item out of its parent when dragged to the left", () => {
-      component.items.set([menuItem("a", [menuItem("a1")])]);
+    expect(component.items()).toEqual([menuItem("a"), menuItem("a1")]);
+  });
 
-      drop(1, 1, -1);
+  it("does not nest items when sub-menus are not allowed", () => {
+    fixture.componentRef.setInput("allowSubMenu", false);
+    component.items.set([menuItem("a"), menuItem("b")]);
 
-      expect(component.items()).toEqual([menuItem("a"), menuItem("a1")]);
-    });
+    drop(1, 1, 1);
 
-    it("does not nest items when sub-menus are not allowed", () => {
-      fixture.componentRef.setInput("allowSubMenu", false);
-      component.items.set([menuItem("a"), menuItem("b")]);
+    expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
+  });
 
-      drop(1, 1, 1);
+  it("removes an item together with its sub-items", () => {
+    component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
 
-      expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
-    });
+    component.removeItem(0);
 
-    it("removes an item together with its sub-items", () => {
-      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+    expect(component.items()).toEqual([menuItem("b")]);
+  });
 
-      component.removeItem(0);
+  it("keeps the sub-items when an item itself is edited", () => {
+    component.items.set([menuItem("a", [menuItem("a1")])]);
 
-      expect(component.items()).toEqual([menuItem("b")]);
-    });
+    // the edit dialog returns the item without its (separately rendered) sub-items
+    component.onItemChange({ ...menuItem("a"), label: "renamed" }, 0);
 
-    it("keeps the sub-items when an item itself is edited", () => {
-      component.items.set([menuItem("a", [menuItem("a1")])]);
-
-      // the edit dialog returns the item without its (separately rendered) sub-items
-      component.onItemChange({ ...menuItem("a"), label: "renamed" }, 0);
-
-      expect(component.items()).toEqual([
-        { ...menuItem("a", [menuItem("a1")]), label: "renamed" },
-      ]);
-    });
+    expect(component.items()).toEqual([
+      { ...menuItem("a", [menuItem("a1")]), label: "renamed" },
+    ]);
   });
 
   it("should convert entity menu item to plain format with toPlainMenuItem", () => {

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.spec.ts
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { CdkDragDrop } from "@angular/cdk/drag-drop";
 import { MenuItemListEditorComponent } from "./menu-item-list-editor.component";
 import { MatDialog } from "@angular/material/dialog";
 import { MenuItemForAdminUi } from "../../admin/admin-menu/menu-item-for-admin-ui";
@@ -110,13 +111,110 @@ describe("MenuItemListEditorComponent", () => {
     component.items.subscribe((val) => emittedValues.push(val));
 
     // Act
-    component.removeItem(item);
+    component.removeItem(0);
 
     // Assert
-    const items = component.items();
-    expect(items.length).toBe(1);
-    expect(items[0]).toBe(secondItem);
+    expect(component.items()).toEqual([secondItem]);
     expect(emittedValues).toEqual([[secondItem]]);
+  });
+
+  describe("drag & drop of the flat, indented list", () => {
+    /** a menu item with the given id and (optional) sub-items */
+    const menuItem = (
+      uniqueId: string,
+      subMenu: MenuItemForAdminUi[] = [],
+    ): MenuItemForAdminUi => ({ uniqueId, label: uniqueId, subMenu });
+
+    /** simulate a drop, `draggedLevels` being how far the item was dragged sideways */
+    const drop = (
+      previousIndex: number,
+      currentIndex: number,
+      draggedLevels = 0,
+    ) =>
+      component.onDrop({
+        previousIndex,
+        currentIndex,
+        distance: { x: draggedLevels * component.indentPerLevel, y: 0 },
+      } as CdkDragDrop<unknown>);
+
+    it("flattens nested items into indented rows", () => {
+      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+
+      expect(component.rows().map((r) => [r.id, r.level])).toEqual([
+        ["a", 0],
+        ["a1", 1],
+        ["b", 0],
+      ]);
+      expect(component.hasSubItems(0)).toBe(true);
+      expect(component.hasSubItems(1)).toBe(false);
+    });
+
+    it("moves an item together with its sub-items", () => {
+      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+
+      drop(0, 2); // drag "a" to the end; cdk counts the dragged row only
+
+      expect(component.items()).toEqual([
+        menuItem("b"),
+        menuItem("a", [menuItem("a1")]),
+      ]);
+    });
+
+    it("nests an item into the item above when dragged to the right", () => {
+      component.items.set([menuItem("a"), menuItem("b")]);
+
+      drop(1, 1, 1);
+
+      expect(component.items()).toEqual([menuItem("a", [menuItem("b")])]);
+    });
+
+    it("does not re-nest on slight sideways drift while dragging", () => {
+      component.items.set([menuItem("a"), menuItem("b")]);
+
+      component.onDrop({
+        previousIndex: 1,
+        currentIndex: 1,
+        distance: { x: component.indentPerLevel / 2, y: 0 },
+      } as CdkDragDrop<unknown>);
+
+      expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
+    });
+
+    it("lifts a sub-item out of its parent when dragged to the left", () => {
+      component.items.set([menuItem("a", [menuItem("a1")])]);
+
+      drop(1, 1, -1);
+
+      expect(component.items()).toEqual([menuItem("a"), menuItem("a1")]);
+    });
+
+    it("does not nest items when sub-menus are not allowed", () => {
+      fixture.componentRef.setInput("allowSubMenu", false);
+      component.items.set([menuItem("a"), menuItem("b")]);
+
+      drop(1, 1, 1);
+
+      expect(component.items()).toEqual([menuItem("a"), menuItem("b")]);
+    });
+
+    it("removes an item together with its sub-items", () => {
+      component.items.set([menuItem("a", [menuItem("a1")]), menuItem("b")]);
+
+      component.removeItem(0);
+
+      expect(component.items()).toEqual([menuItem("b")]);
+    });
+
+    it("keeps the sub-items when an item itself is edited", () => {
+      component.items.set([menuItem("a", [menuItem("a1")])]);
+
+      // the edit dialog returns the item without its (separately rendered) sub-items
+      component.onItemChange({ ...menuItem("a"), label: "renamed" }, 0);
+
+      expect(component.items()).toEqual([
+        { ...menuItem("a", [menuItem("a1")]), label: "renamed" },
+      ]);
+    });
   });
 
   it("should convert entity menu item to plain format with toPlainMenuItem", () => {

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
@@ -60,20 +60,21 @@ export class MenuItemListEditorComponent {
   /** pixels of indentation per nesting level */
   readonly indentPerLevel = 32;
 
-  /** the menu as a flat, indented list of rows */
-  readonly rows = computed<FlatTreeRow<MenuItemForAdminUi>[]>(() =>
-    flattenTree(this.items(), menuItemTree),
-  );
+  /**
+   * The menu as a flat, indented list of rows, each with the display flags the template needs:
+   * an item has sub-items when the row below it is deeper.
+   */
+  readonly rows = computed(() => {
+    const rows = flattenTree(this.items(), menuItemTree);
+    return rows.map((row, index) => ({
+      ...row,
+      hasSubItems: rows[index + 1]?.level > row.level,
+    }));
+  });
 
   private readonly nesting = computed<FlatTreeOptions>(() => ({
     maxLevel: this.allowSubMenu() ? undefined : 0,
   }));
-
-  /** whether the item at `index` has nested sub-items, i.e. the row below it is deeper */
-  hasSubItems(index: number): boolean {
-    const rows = this.rows();
-    return rows[index + 1]?.level > rows[index].level;
-  }
 
   onDrop(event: CdkDragDrop<unknown>): void {
     // how far the item was dragged sideways determines how deep it is nested;

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
@@ -1,22 +1,27 @@
 import {
   Component,
-  Input,
+  computed,
   inject,
+  input,
   model,
   ChangeDetectionStrategy,
 } from "@angular/core";
-import {
-  CdkDragDrop,
-  DragDropModule,
-  moveItemInArray,
-  transferArrayItem,
-} from "@angular/cdk/drag-drop";
+import { CdkDragDrop, DragDropModule } from "@angular/cdk/drag-drop";
 import { v4 as uuid } from "uuid";
 import { MatDialog } from "@angular/material/dialog";
-import { Logging } from "../../logging/logging.service";
+import {
+  FlatTreeOptions,
+  FlatTreeRow,
+  flattenTree,
+  moveSubtree,
+  rebuildTree,
+  removeSubtree,
+  updateRow,
+} from "#src/app/utils/flat-tree/flat-tree";
 import { MenuItem } from "../navigation/menu-item";
 import { AdminMenuItemComponent } from "../../admin/admin-menu/admin-menu-item/admin-menu-item.component";
 import {
+  menuItemTree,
   MenuItemForAdminUi,
   MenuItemForAdminUiNew,
 } from "../../admin/admin-menu/menu-item-for-admin-ui";
@@ -27,11 +32,14 @@ import { IconButtonComponent } from "../../common-components/icon-button/icon-bu
  * A reusable component for editing lists of menu items with drag & drop,
  * add/remove functionality. Used by both AdminMenuComponent and
  * ShortcutDashboardSettingsComponent.
+ *
+ * The (possibly nested) menu is edited as a single flat, indented list (see `flat-tree`):
+ * dragging an item sideways nests it into the item above or lifts it back out, and dragging
+ * an item with sub-items carries its whole subtree.
  */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "app-menu-item-list-editor",
-  standalone: true,
   imports: [AdminMenuItemComponent, DragDropModule, IconButtonComponent],
   templateUrl: "./menu-item-list-editor.component.html",
   styleUrl: "./menu-item-list-editor.component.scss",
@@ -40,71 +48,61 @@ export class MenuItemListEditorComponent {
   private readonly dialog = inject(MatDialog);
 
   items = model<MenuItemForAdminUi[]>([]);
-  @Input() showAddButton: boolean = true;
 
-  /** Unique identifier for the drag-drop container */
-  @Input() containerId: string = "menu-item-list-container";
+  showAddButton = input<boolean>(true);
 
   /** Whether entity type links are allowed (false for shortcuts, true for admin menu) */
-  @Input() allowEntityLinks: boolean = true;
+  allowEntityLinks = input<boolean>(true);
 
-  @Input() allowSubMenu: boolean = true;
+  /** Whether items may be nested into sub-menus (false for shortcuts) */
+  allowSubMenu = input<boolean>(true);
 
-  public get connectedDropLists(): string[] {
-    if (!this.allowSubMenu) {
-      // For shortcuts, only allow drops in the main container
-      return [this.containerId];
-    }
-    return [this.containerId, ...this.getIdsRecursive(this.items())].reverse();
+  /** pixels of indentation per nesting level */
+  readonly indentPerLevel = 32;
+
+  /** the menu as a flat, indented list of rows */
+  readonly rows = computed<FlatTreeRow<MenuItemForAdminUi>[]>(() =>
+    flattenTree(this.items(), menuItemTree),
+  );
+
+  private readonly nesting = computed<FlatTreeOptions>(() => ({
+    maxLevel: this.allowSubMenu() ? undefined : 0,
+  }));
+
+  /** whether the item at `index` has nested sub-items, i.e. the row below it is deeper */
+  hasSubItems(index: number): boolean {
+    const rows = this.rows();
+    return rows[index + 1]?.level > rows[index].level;
   }
 
-  private getIdsRecursive(items: MenuItemForAdminUi[]): string[] {
-    let ids: string[] = [];
-    items?.forEach((item) => {
-      ids.push(item.uniqueId);
-      if (this.allowSubMenu && item.subMenu) {
-        ids = ids.concat(this.getIdsRecursive(item.subMenu));
-      }
-    });
-    return ids;
+  onDrop(event: CdkDragDrop<unknown>): void {
+    // how far the item was dragged sideways determines how deep it is nested;
+    // truncated, so that only a full indentation step re-nests (and not slight drift)
+    const levelDelta = Math.trunc(event.distance.x / this.indentPerLevel);
+    this.setRows(
+      moveSubtree(
+        this.rows(),
+        event.previousIndex,
+        event.currentIndex,
+        menuItemTree,
+        { ...this.nesting(), levelDelta },
+      ),
+    );
   }
 
-  onDragDrop(event: CdkDragDrop<MenuItem[]>) {
-    try {
-      if (event.previousContainer === event.container) {
-        // Same container - always allow reordering
-        moveItemInArray(
-          event.container.data,
-          event.previousIndex,
-          event.currentIndex,
-        );
-      } else {
-        // Cross-container transfer - only allow if submenus are enabled
-        if (!this.allowSubMenu) {
-          // For shortcuts, prevent cross-container drops (no submenus allowed)
-          return;
-        }
+  /** remove the item at `index` and, with it, its sub-items */
+  removeItem(index: number): void {
+    this.setRows(
+      removeSubtree(this.rows(), index, menuItemTree, this.nesting()),
+    );
+  }
 
-        transferArrayItem(
-          event.previousContainer.data,
-          event.container.data,
-          event.previousIndex,
-          event.currentIndex,
-        );
+  onItemChange(newItem: MenuItemForAdminUi, index: number): void {
+    this.setRows(updateRow(this.rows(), index, newItem));
+  }
 
-        // Ensure the moved item has a subMenu array to allow nesting
-        const targetData = event.container.data as MenuItemForAdminUi[];
-        const movedItem = targetData[event.currentIndex];
-        if (movedItem && !movedItem.subMenu) {
-          movedItem.subMenu = [];
-        }
-      }
-      // Deep clone to ensure new references for all items (including nested subMenus),
-      // so child model() signals detect the mutation done by transferArrayItem/moveItemInArray.
-      this.items.set(structuredClone(this.items()));
-    } catch (error) {
-      Logging.debug("Drag drop error:", error);
-    }
+  private setRows(rows: FlatTreeRow<MenuItemForAdminUi>[]): void {
+    this.items.set(rebuildTree(rows, menuItemTree));
   }
 
   async addNewMenuItem() {
@@ -114,7 +112,7 @@ export class MenuItemListEditorComponent {
       data: {
         item: { ...newItem },
         isNew: true,
-        allowEntityLinks: this.allowEntityLinks,
+        allowEntityLinks: this.allowEntityLinks(),
       },
     });
 
@@ -124,25 +122,13 @@ export class MenuItemListEditorComponent {
           ...result,
           uniqueId: uuid(),
           subMenu:
-            this.allowSubMenu && result.subMenu
+            this.allowSubMenu() && result.subMenu
               ? MenuItemListEditorComponent.addUniqueIds(result.subMenu)
               : [],
         };
         this.items.update((curr) => [normalizedItem, ...curr]);
       }
     });
-  }
-
-  removeItem(item: MenuItemForAdminUi): void {
-    this.items.update((curr) => curr.filter((i) => i !== item));
-  }
-
-  onItemChange(newItem: MenuItemForAdminUi, index: number) {
-    this.items.update((curr) => [
-      ...curr.slice(0, index),
-      newItem,
-      ...curr.slice(index + 1),
-    ]);
   }
 
   /**

--- a/src/app/features/dashboard-widgets/shortcut-dashboard-widget/shortcut-dashboard-settings.component/shortcut-dashboard-settings.component.html
+++ b/src/app/features/dashboard-widgets/shortcut-dashboard-widget/shortcut-dashboard-settings.component/shortcut-dashboard-settings.component.html
@@ -8,7 +8,6 @@
       [items]="menuItems()"
       [allowEntityLinks]="false"
       [allowSubMenu]="false"
-      containerId="shortcuts-container"
       (itemsChange)="onMenuItemsChange($event)"
     ></app-menu-item-list-editor>
   </div>

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.html
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.html
@@ -11,7 +11,7 @@
       @for (row of rows(); track row.id; let i = $index) {
         <div
           class="report-row"
-          [class.group-row]="isGroup(row.data)"
+          [class.group-row]="row.isGroup"
           [style.margin-left.px]="row.level * indentPerLevel"
           cdkDrag
           [cdkDragData]="row"
@@ -25,7 +25,7 @@
               ></fa-icon>
             }
 
-            @if (isGroup(row.data)) {
+            @if (row.isGroup) {
               <fa-icon icon="layer-group" class="row-icon"></fa-icon>
               <input
                 class="group-title-input"
@@ -48,7 +48,7 @@
             }
 
             @if (enabled()) {
-              @if (isGroup(row.data)) {
+              @if (row.isGroup) {
                 <button
                   mat-icon-button
                   type="button"
@@ -77,15 +77,11 @@
                 type="button"
                 (click)="remove(i)"
                 [matTooltip]="
-                  isGroup(row.data)
-                    ? 'Remove group and its contents'
-                    : 'Remove query'
+                  row.isGroup ? 'Remove group and its contents' : 'Remove query'
                 "
                 i18n-matTooltip
                 [attr.aria-label]="
-                  isGroup(row.data)
-                    ? 'Remove group and its contents'
-                    : 'Remove query'
+                  row.isGroup ? 'Remove group and its contents' : 'Remove query'
                 "
               >
                 <fa-icon icon="trash"></fa-icon>

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.html
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.html
@@ -8,10 +8,10 @@
       cdkDropList
       (cdkDropListDropped)="onDrop($event)"
     >
-      @for (row of rows(); track row.uniqueId; let i = $index) {
+      @for (row of rows(); track row.id; let i = $index) {
         <div
           class="report-row"
-          [class.group-row]="row.isGroup"
+          [class.group-row]="isGroup(row.data)"
           [style.margin-left.px]="row.level * indentPerLevel"
           cdkDrag
           [cdkDragData]="row"
@@ -25,12 +25,12 @@
               ></fa-icon>
             }
 
-            @if (row.isGroup) {
+            @if (isGroup(row.data)) {
               <fa-icon icon="layer-group" class="row-icon"></fa-icon>
               <input
                 class="group-title-input"
                 type="text"
-                [value]="row.groupTitle ?? ''"
+                [value]="row.data.groupTitle ?? ''"
                 [disabled]="!enabled()"
                 placeholder="Group title"
                 i18n-placeholder
@@ -41,14 +41,14 @@
             } @else {
               <app-edit-sql-query
                 class="query-editor"
-                [value]="row.query ?? ''"
+                [value]="row.data.query ?? ''"
                 [disabled]="!enabled()"
                 (valueChange)="setQuery(i, $event)"
               ></app-edit-sql-query>
             }
 
             @if (enabled()) {
-              @if (row.isGroup) {
+              @if (isGroup(row.data)) {
                 <button
                   mat-icon-button
                   type="button"
@@ -77,11 +77,15 @@
                 type="button"
                 (click)="remove(i)"
                 [matTooltip]="
-                  row.isGroup ? 'Remove group and its contents' : 'Remove query'
+                  isGroup(row.data)
+                    ? 'Remove group and its contents'
+                    : 'Remove query'
                 "
                 i18n-matTooltip
                 [attr.aria-label]="
-                  row.isGroup ? 'Remove group and its contents' : 'Remove query'
+                  isGroup(row.data)
+                    ? 'Remove group and its contents'
+                    : 'Remove query'
                 "
               >
                 <fa-icon icon="trash"></fa-icon>

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.spec.ts
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.spec.ts
@@ -9,7 +9,6 @@ import {
 import { CdkDragDrop } from "@angular/cdk/drag-drop";
 import { setupCustomFormControlEditComponent } from "#src/app/core/entity/entity-field-edit/dynamic-edit/edit-component-test-utils";
 import { EditReportDefinitionComponent } from "./edit-report-definition.component";
-import { isGroupNode } from "./report-definition-ui-node";
 
 /** wire the component to a `reportDefinition` control sitting next to a `mode` control */
 function createWithMode(mode: string): EditReportDefinitionComponent {
@@ -84,13 +83,11 @@ describe("EditReportDefinitionComponent", () => {
       ]);
     fixture.detectChanges();
 
-    expect(component.rows().map((r) => [isGroupNode(r.data), r.level])).toEqual(
-      [
-        [false, 0],
-        [true, 0],
-        [false, 1],
-      ],
-    );
+    expect(component.rows().map((r) => [r.isGroup, r.level])).toEqual([
+      [false, 0],
+      [true, 0],
+      [false, 1],
+    ]);
   });
 
   it("adds a query and a group at the root and persists to the bound control", () => {

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.spec.ts
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { CdkDragDrop } from "@angular/cdk/drag-drop";
 import { setupCustomFormControlEditComponent } from "#src/app/core/entity/entity-field-edit/dynamic-edit/edit-component-test-utils";
 import { EditReportDefinitionComponent } from "./edit-report-definition.component";
-import { FlatReportRow } from "./report-definition-ui-node";
+import { isGroupNode } from "./report-definition-ui-node";
 
 /** wire the component to a `reportDefinition` control sitting next to a `mode` control */
 function createWithMode(mode: string): EditReportDefinitionComponent {
@@ -31,10 +31,17 @@ describe("EditReportDefinitionComponent", () => {
   let formGroup: UntypedFormGroup;
 
   const definition = () => formGroup.get("reportDefinition").value;
-  const drop = (previousIndex: number, currentIndex: number) =>
-    component.onDrop({ previousIndex, currentIndex } as CdkDragDrop<
-      FlatReportRow[]
-    >);
+  /** simulate a drop, `draggedLevels` being how far the row was dragged sideways */
+  const drop = (
+    previousIndex: number,
+    currentIndex: number,
+    draggedLevels = 0,
+  ) =>
+    component.onDrop({
+      previousIndex,
+      currentIndex,
+      distance: { x: draggedLevels * component.indentPerLevel, y: 0 },
+    } as CdkDragDrop<unknown>);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -77,11 +84,13 @@ describe("EditReportDefinitionComponent", () => {
       ]);
     fixture.detectChanges();
 
-    expect(component.rows().map((r) => [r.isGroup, r.level])).toEqual([
-      [false, 0],
-      [true, 0],
-      [false, 1],
-    ]);
+    expect(component.rows().map((r) => [isGroupNode(r.data), r.level])).toEqual(
+      [
+        [false, 0],
+        [true, 0],
+        [false, 1],
+      ],
+    );
   });
 
   it("adds a query and a group at the root and persists to the bound control", () => {
@@ -172,5 +181,43 @@ describe("EditReportDefinitionComponent", () => {
     drop(0, 1);
 
     expect(definition()).toEqual([{ query: "b" }, { query: "a" }]);
+  });
+
+  it("nests a query into the group above it when dragged to the right", () => {
+    formGroup
+      .get("reportDefinition")
+      .setValue([{ groupTitle: "G", items: [] }, { query: "a" }]);
+    fixture.detectChanges();
+
+    drop(1, 1, 1); // dragged one indentation step to the right
+
+    expect(definition()).toEqual([
+      { groupTitle: "G", items: [{ query: "a" }] },
+    ]);
+  });
+
+  it("lifts a query out of its group when dragged to the left", () => {
+    formGroup
+      .get("reportDefinition")
+      .setValue([{ groupTitle: "G", items: [{ query: "a" }] }]);
+    fixture.detectChanges();
+
+    drop(1, 1, -1);
+
+    expect(definition()).toEqual([
+      { groupTitle: "G", items: [] },
+      { query: "a" },
+    ]);
+  });
+
+  it("does not nest a query below another query, however far it is dragged", () => {
+    formGroup
+      .get("reportDefinition")
+      .setValue([{ query: "a" }, { query: "b" }]);
+    fixture.detectChanges();
+
+    drop(1, 1, 3);
+
+    expect(definition()).toEqual([{ query: "a" }, { query: "b" }]);
   });
 });

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.ts
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.ts
@@ -11,61 +11,46 @@ import {
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import {
-  CdkDragDrop,
-  DragDropModule,
-  moveItemInArray,
-} from "@angular/cdk/drag-drop";
+import { CdkDragDrop, DragDropModule } from "@angular/cdk/drag-drop";
 import { MatFormFieldControl } from "@angular/material/form-field";
 import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
-import { v4 as uuid } from "uuid";
 import { CustomFormControlDirective } from "#src/app/core/common-components/basic-autocomplete/custom-form-control.directive";
 import { FormFieldConfig } from "#src/app/core/common-components/entity-form/FormConfig";
 import { DynamicComponent } from "#src/app/core/config/dynamic-components/dynamic-component.decorator";
 import { EditComponent } from "#src/app/core/entity/entity-field-edit/dynamic-edit/edit-component.interface";
+import {
+  FlatTreeRow,
+  flattenTree,
+  insertChild,
+  moveSubtree,
+  rebuildTree,
+  removeSubtree,
+  updateRow,
+} from "#src/app/utils/flat-tree/flat-tree";
 import { ReportDefinitionDto } from "../report-config";
 import { JsonEditorComponent } from "#src/app/core/admin/json-editor/json-editor.component";
 import { SqlCodeEditorComponent } from "../edit-sql-query/sql-code-editor.component";
 import {
-  FlatReportRow,
-  flattenTree,
-  normalizeLevels,
-  rebuildTree,
-  subtreeLength,
+  isGroupNode,
+  newGroupNode,
+  newQueryNode,
+  ReportDefinitionUiNode,
+  reportDefinitionTree,
   toReportDefinition,
   toUiNodes,
 } from "./report-definition-ui-node";
-
-/** a fresh (empty) query row, without a nesting level */
-function newQueryRow(): Omit<FlatReportRow, "level"> {
-  return { uniqueId: uuid(), query: "", isGroup: false };
-}
-
-/** a fresh (empty) group row, without a nesting level */
-function newGroupRow(): Omit<FlatReportRow, "level"> {
-  return {
-    uniqueId: uuid(),
-    groupTitle: $localize`:ReportConfig:New group`,
-    isGroup: true,
-  };
-}
-
-/** the nesting level a row dropped directly below `above` should take (child of a group, else sibling) */
-function nestingLevelBelow(above: FlatReportRow | undefined): number {
-  if (!above) {
-    return 0;
-  }
-  return above.isGroup ? above.level + 1 : above.level;
-}
 
 /**
  * Structured editor for a SQL report's `reportDefinition` tree
  * (`{ query?, groupTitle?, items? }[]`, see {@link ReportDefinitionDto}).
  *
- * The editor offers SQL syntax highlighting.
- * Non-SQL reports can be edited in a JSON editor.
+ * The tree is edited as a single flat, indented list (see `flat-tree`): each query is a
+ * syntax-highlighted editor and each group a heading. Queries/groups are added directly into a
+ * group via its "+" buttons, and any row can be dragged to a new position — dragging it sideways
+ * nests it into the group above or lifts it back out, and dragging a group carries its whole
+ * subtree. For non-"sql" modes the definition is edited as raw JSON.
  */
 @DynamicComponent("EditReportDefinition")
 @Component({
@@ -105,9 +90,11 @@ export class EditReportDefinitionComponent
   readonly indentPerLevel = 24;
 
   /** the definition as a flat, indented list of rows (working copy) */
-  readonly rows = signal<FlatReportRow[]>([]);
+  readonly rows = signal<FlatTreeRow<ReportDefinitionUiNode>[]>([]);
   /** JSON of the last definition synced in either direction, to break the value<->rows loop */
   private lastSync = "";
+
+  protected readonly isGroup = isGroupNode;
 
   constructor() {
     super();
@@ -115,11 +102,11 @@ export class EditReportDefinitionComponent
     // mirror external value changes (form load/reset) into the working rows
     effect(() => {
       const value = this.valueSignal();
-      const arr = Array.isArray(value) ? (value as ReportDefinitionDto[]) : [];
+      const arr = Array.isArray(value) ? value : [];
       const json = JSON.stringify(arr);
       if (json !== this.lastSync) {
         this.lastSync = json;
-        this.rows.set(flattenTree(toUiNodes(arr)));
+        this.rows.set(flattenTree(toUiNodes(arr), reportDefinitionTree));
       }
     });
   }
@@ -137,99 +124,85 @@ export class EditReportDefinitionComponent
   }
 
   setQuery(index: number, query: string): void {
-    this.updateRow(index, { query });
+    this.updateNode(index, { query });
   }
 
   setGroupTitle(index: number, event: Event): void {
     const groupTitle = (event.target as HTMLInputElement).value;
-    this.updateRow(index, { groupTitle });
+    this.updateNode(index, { groupTitle });
   }
 
   addQuery(): void {
-    this.appendRoot(newQueryRow());
+    this.append(newQueryNode());
   }
 
   addGroup(): void {
-    this.appendRoot(newGroupRow());
+    this.append(newGroupNode());
   }
 
   /** add a query as the first child of the group at `groupIndex` */
   addChildQuery(groupIndex: number): void {
-    this.insertChild(groupIndex, newQueryRow());
+    this.insertInto(groupIndex, newQueryNode());
   }
 
   /** add a sub-group as the first child of the group at `groupIndex` */
   addChildGroup(groupIndex: number): void {
-    this.insertChild(groupIndex, newGroupRow());
+    this.insertInto(groupIndex, newGroupNode());
   }
 
   /** remove the row and, for a group, its whole subtree */
   remove(index: number): void {
-    const rows = [...this.rows()];
-    rows.splice(index, subtreeLength(rows, index));
-    this.rows.set(normalizeLevels(rows));
-    this.persist();
-  }
-
-  private appendRoot(row: Omit<FlatReportRow, "level">): void {
-    this.rows.update((rows) => [...rows, { ...row, level: 0 }]);
-    this.persist();
-  }
-
-  private insertChild(
-    groupIndex: number,
-    row: Omit<FlatReportRow, "level">,
-  ): void {
-    const rows = [...this.rows()];
-    const level = rows[groupIndex].level + 1;
-    rows.splice(groupIndex + 1, 0, { ...row, level });
-    this.rows.set(normalizeLevels(rows));
-    this.persist();
-  }
-
-  onDrop(event: CdkDragDrop<FlatReportRow[]>): void {
-    const { previousIndex, currentIndex } = event;
-    if (previousIndex === currentIndex) {
-      return;
-    }
-    let rows = [...this.rows()];
-    const len = subtreeLength(rows, previousIndex);
-    const headerId = rows[previousIndex].uniqueId;
-    // ids of the dragged group's descendants (empty for a query) — they must follow the header
-    const childIds = rows
-      .slice(previousIndex + 1, previousIndex + len)
-      .map((r) => r.uniqueId);
-
-    // move the dragged header to its new position, then pull its subtree back beneath it
-    moveItemInArray(rows, previousIndex, currentIndex);
-    if (childIds.length) {
-      const children = rows.filter((r) => childIds.includes(r.uniqueId));
-      rows = rows.filter((r) => !childIds.includes(r.uniqueId));
-      const headerIndex = rows.findIndex((r) => r.uniqueId === headerId);
-      rows.splice(headerIndex + 1, 0, ...children);
-    }
-
-    // nest according to the row now above the moved subtree, shifting the whole subtree with it
-    const headerIndex = rows.findIndex((r) => r.uniqueId === headerId);
-    const delta =
-      nestingLevelBelow(rows[headerIndex - 1]) - rows[headerIndex].level;
-    for (let i = headerIndex; i < headerIndex + len; i++) {
-      rows[i] = { ...rows[i], level: rows[i].level + delta };
-    }
-
-    this.rows.set(normalizeLevels(rows));
-    this.persist();
-  }
-
-  private updateRow(index: number, patch: Partial<FlatReportRow>): void {
     this.rows.update((rows) =>
-      rows.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+      removeSubtree(rows, index, reportDefinitionTree),
+    );
+    this.persist();
+  }
+
+  onDrop(event: CdkDragDrop<unknown>): void {
+    // how far the row was dragged sideways determines how deep it is nested;
+    // truncated, so that only a full indentation step re-nests (and not slight drift)
+    const levelDelta = Math.trunc(event.distance.x / this.indentPerLevel);
+    this.rows.update((rows) =>
+      moveSubtree(
+        rows,
+        event.previousIndex,
+        event.currentIndex,
+        reportDefinitionTree,
+        { levelDelta },
+      ),
+    );
+    this.persist();
+  }
+
+  private append(node: ReportDefinitionUiNode): void {
+    this.rows.update((rows) => [
+      ...rows,
+      { id: node.uniqueId, level: 0, data: node },
+    ]);
+    this.persist();
+  }
+
+  private insertInto(groupIndex: number, node: ReportDefinitionUiNode): void {
+    this.rows.update((rows) =>
+      insertChild(rows, groupIndex, node, reportDefinitionTree),
+    );
+    this.persist();
+  }
+
+  private updateNode(
+    index: number,
+    patch: Partial<ReportDefinitionUiNode>,
+  ): void {
+    this.rows.update((rows) =>
+      updateRow(rows, index, { ...rows[index].data, ...patch }),
     );
     this.persist();
   }
 
   private persist(): void {
-    const definition = toReportDefinition(rebuildTree(this.rows()));
+    const definition = toReportDefinition(
+      rebuildTree(this.rows(), reportDefinitionTree),
+    );
     const json = JSON.stringify(definition);
     // Ignore no-op writes: a re-emitted (unchanged) value would otherwise re-mark a pristine
     // form dirty. `lastSync` is the value last synced in either direction.

--- a/src/app/features/reporting/edit-report-definition/edit-report-definition.component.ts
+++ b/src/app/features/reporting/edit-report-definition/edit-report-definition.component.ts
@@ -90,11 +90,15 @@ export class EditReportDefinitionComponent
   readonly indentPerLevel = 24;
 
   /** the definition as a flat, indented list of rows (working copy) */
-  readonly rows = signal<FlatTreeRow<ReportDefinitionUiNode>[]>([]);
+  private readonly flatRows = signal<FlatTreeRow<ReportDefinitionUiNode>[]>([]);
+
+  /** the rows as rendered, with the display flags the template needs derived once per change */
+  readonly rows = computed(() =>
+    this.flatRows().map((row) => ({ ...row, isGroup: isGroupNode(row.data) })),
+  );
+
   /** JSON of the last definition synced in either direction, to break the value<->rows loop */
   private lastSync = "";
-
-  protected readonly isGroup = isGroupNode;
 
   constructor() {
     super();
@@ -106,7 +110,7 @@ export class EditReportDefinitionComponent
       const json = JSON.stringify(arr);
       if (json !== this.lastSync) {
         this.lastSync = json;
-        this.rows.set(flattenTree(toUiNodes(arr), reportDefinitionTree));
+        this.flatRows.set(flattenTree(toUiNodes(arr), reportDefinitionTree));
       }
     });
   }
@@ -152,7 +156,7 @@ export class EditReportDefinitionComponent
 
   /** remove the row and, for a group, its whole subtree */
   remove(index: number): void {
-    this.rows.update((rows) =>
+    this.flatRows.update((rows) =>
       removeSubtree(rows, index, reportDefinitionTree),
     );
     this.persist();
@@ -162,7 +166,7 @@ export class EditReportDefinitionComponent
     // how far the row was dragged sideways determines how deep it is nested;
     // truncated, so that only a full indentation step re-nests (and not slight drift)
     const levelDelta = Math.trunc(event.distance.x / this.indentPerLevel);
-    this.rows.update((rows) =>
+    this.flatRows.update((rows) =>
       moveSubtree(
         rows,
         event.previousIndex,
@@ -175,7 +179,7 @@ export class EditReportDefinitionComponent
   }
 
   private append(node: ReportDefinitionUiNode): void {
-    this.rows.update((rows) => [
+    this.flatRows.update((rows) => [
       ...rows,
       { id: node.uniqueId, level: 0, data: node },
     ]);
@@ -183,7 +187,7 @@ export class EditReportDefinitionComponent
   }
 
   private insertInto(groupIndex: number, node: ReportDefinitionUiNode): void {
-    this.rows.update((rows) =>
+    this.flatRows.update((rows) =>
       insertChild(rows, groupIndex, node, reportDefinitionTree),
     );
     this.persist();
@@ -193,7 +197,7 @@ export class EditReportDefinitionComponent
     index: number,
     patch: Partial<ReportDefinitionUiNode>,
   ): void {
-    this.rows.update((rows) =>
+    this.flatRows.update((rows) =>
       updateRow(rows, index, { ...rows[index].data, ...patch }),
     );
     this.persist();
@@ -201,7 +205,7 @@ export class EditReportDefinitionComponent
 
   private persist(): void {
     const definition = toReportDefinition(
-      rebuildTree(this.rows(), reportDefinitionTree),
+      rebuildTree(this.flatRows(), reportDefinitionTree),
     );
     const json = JSON.stringify(definition);
     // Ignore no-op writes: a re-emitted (unchanged) value would otherwise re-mark a pristine

--- a/src/app/features/reporting/edit-report-definition/report-definition-ui-node.spec.ts
+++ b/src/app/features/reporting/edit-report-definition/report-definition-ui-node.spec.ts
@@ -1,11 +1,9 @@
+import { flattenTree, rebuildTree } from "#src/app/utils/flat-tree/flat-tree";
 import {
-  FlatReportRow,
-  flattenTree,
-  groupNodeIds,
   isGroupNode,
-  normalizeLevels,
-  rebuildTree,
-  subtreeLength,
+  newGroupNode,
+  newQueryNode,
+  reportDefinitionTree,
   toReportDefinition,
   toUiNodes,
 } from "./report-definition-ui-node";
@@ -38,16 +36,10 @@ describe("report-definition-ui-node", () => {
     expect(nodes[1].items[0].uniqueId).not.toBe(nodes[0].uniqueId);
   });
 
-  it("collects the ids of every group (drop target), including nested ones", () => {
-    const nodes = toUiNodes([
-      { query: "q" },
-      { groupTitle: "G", items: [{ groupTitle: "Sub", items: [] }] },
-    ]);
-
-    expect(groupNodeIds(nodes)).toEqual([
-      nodes[1].uniqueId,
-      nodes[1].items[0].uniqueId,
-    ]);
+  it("creates new query and group nodes with distinct ids", () => {
+    expect(isGroupNode(newQueryNode())).toBe(false);
+    expect(isGroupNode(newGroupNode())).toBe(true);
+    expect(newQueryNode().uniqueId).not.toBe(newQueryNode().uniqueId);
   });
 
   it("round-trips a nested definition through flat rows and back", () => {
@@ -59,45 +51,16 @@ describe("report-definition-ui-node", () => {
       },
     ]);
 
-    const flat = flattenTree(nodes);
-    expect(flat.map((r) => [r.isGroup, r.level])).toEqual([
+    const rows = flattenTree(nodes, reportDefinitionTree);
+    expect(rows.map((r) => [isGroupNode(r.data), r.level])).toEqual([
       [false, 0], // a
       [true, 0], // G
       [false, 1], // b
       [true, 1], // Sub
       [false, 2], // c
     ]);
-    expect(toReportDefinition(rebuildTree(flat))).toEqual(
+    expect(toReportDefinition(rebuildTree(rows, reportDefinitionTree))).toEqual(
       toReportDefinition(nodes),
     );
-  });
-
-  it("clamps levels so a row is at most one deeper than the group above it", () => {
-    const rows: FlatReportRow[] = [
-      { uniqueId: "q1", query: "", isGroup: false, level: 2 }, // first row -> forced to 0
-      { uniqueId: "g", groupTitle: "", isGroup: true, level: 3 }, // -> 0
-      { uniqueId: "q2", query: "", isGroup: false, level: 9 }, // under group -> 1
-      { uniqueId: "q3", query: "", isGroup: false, level: 5 }, // under a query -> capped at 1
-    ];
-
-    expect(normalizeLevels(rows).map((r) => r.level)).toEqual([0, 0, 1, 1]);
-  });
-
-  it("measures the subtree length of a group (itself plus its descendants)", () => {
-    const flat = flattenTree(
-      toUiNodes([
-        {
-          groupTitle: "G",
-          items: [
-            { query: "b" },
-            { groupTitle: "Sub", items: [{ query: "c" }] },
-          ],
-        },
-        { query: "after" },
-      ]),
-    );
-
-    expect(subtreeLength(flat, 0)).toBe(4); // G, b, Sub, c
-    expect(subtreeLength(flat, 4)).toBe(1); // "after"
   });
 });

--- a/src/app/features/reporting/edit-report-definition/report-definition-ui-node.ts
+++ b/src/app/features/reporting/edit-report-definition/report-definition-ui-node.ts
@@ -1,10 +1,11 @@
 import { v4 as uuid } from "uuid";
+import { FlatTreeAdapter } from "#src/app/utils/flat-tree/flat-tree";
 import { ReportDefinitionDto } from "../report-config";
 
 /**
  * UI-only representation of a {@link ReportDefinitionDto} node, carrying a transient
- * `uniqueId` used for drag & drop (CdkDropList ids / `@for` tracking). The id is not
- * persisted — {@link toReportDefinition} strips it back to the plain DTO shape.
+ * `uniqueId` used for drag & drop (`@for` tracking). The id is not persisted —
+ * {@link toReportDefinition} strips it back to the plain DTO shape.
  */
 export interface ReportDefinitionUiNode {
   uniqueId: string;
@@ -19,6 +20,30 @@ export interface ReportDefinitionUiNode {
 /** A node is a group when it carries an `items` array; otherwise it is a query. */
 export function isGroupNode(node: ReportDefinitionUiNode): boolean {
   return Array.isArray(node.items);
+}
+
+/**
+ * Edit the definition as a flat, indented list: only groups can hold nested items,
+ * queries are always leaves.
+ */
+export const reportDefinitionTree: FlatTreeAdapter<ReportDefinitionUiNode> = {
+  id: (node) => node.uniqueId,
+  children: (node) => node.items,
+  withChildren: (node, items) => ({ ...node, items }),
+};
+
+/** A new, empty query node. */
+export function newQueryNode(): ReportDefinitionUiNode {
+  return { uniqueId: uuid(), query: "" };
+}
+
+/** A new, empty group node. */
+export function newGroupNode(): ReportDefinitionUiNode {
+  return {
+    uniqueId: uuid(),
+    groupTitle: $localize`:ReportConfig:New group`,
+    items: [],
+  };
 }
 
 /** Convert persisted report-definition DTOs into UI nodes with transient ids. */
@@ -45,114 +70,4 @@ export function toReportDefinition(
       ? { groupTitle: node.groupTitle, items: toReportDefinition(node.items) }
       : { query: node.query ?? "" },
   );
-}
-
-/** Collect the ids of every group node (the connectable drop targets) in the tree. */
-export function groupNodeIds(nodes: ReportDefinitionUiNode[]): string[] {
-  let ids: string[] = [];
-  for (const node of nodes) {
-    if (isGroupNode(node)) {
-      ids.push(node.uniqueId);
-      ids = ids.concat(groupNodeIds(node.items));
-    }
-  }
-  return ids;
-}
-
-/**
- * A single visible row of the flattened editor: the tree rendered as one linear list where
- * nesting is expressed by {@link level} (indentation). Editing / drag & drop happen on this flat
- * list (a single CdkDropList), which sidesteps the CDK nested-drop-list limitations, and the
- * nested {@link ReportDefinitionUiNode} tree is reconstructed from it via {@link rebuildTree}.
- */
-export interface FlatReportRow {
-  uniqueId: string;
-  query?: string;
-  groupTitle?: string;
-  isGroup: boolean;
-  /** nesting depth; a row is a child of the nearest preceding group with a smaller level */
-  level: number;
-}
-
-/** Flatten the nested tree into rows (pre-order DFS), carrying the depth as `level`. */
-export function flattenTree(
-  nodes: ReportDefinitionUiNode[],
-  level = 0,
-): FlatReportRow[] {
-  const rows: FlatReportRow[] = [];
-  for (const node of nodes) {
-    if (isGroupNode(node)) {
-      rows.push({
-        uniqueId: node.uniqueId,
-        groupTitle: node.groupTitle ?? "",
-        isGroup: true,
-        level,
-      });
-      rows.push(...flattenTree(node.items, level + 1));
-    } else {
-      rows.push({
-        uniqueId: node.uniqueId,
-        query: node.query ?? "",
-        isGroup: false,
-        level,
-      });
-    }
-  }
-  return rows;
-}
-
-/** Reconstruct the nested tree from flat rows: each group owns the following rows of greater level. */
-export function rebuildTree(rows: FlatReportRow[]): ReportDefinitionUiNode[] {
-  const root: ReportDefinitionUiNode[] = [];
-  // stack of the currently-open groups' item arrays, keyed by their level
-  const stack: { level: number; items: ReportDefinitionUiNode[] }[] = [
-    { level: -1, items: root },
-  ];
-  for (const row of rows) {
-    while (stack.length > 1 && stack[stack.length - 1].level >= row.level) {
-      stack.pop();
-    }
-    const parent = stack[stack.length - 1].items;
-    if (row.isGroup) {
-      const node: ReportDefinitionUiNode = {
-        uniqueId: row.uniqueId,
-        groupTitle: row.groupTitle ?? "",
-        items: [],
-      };
-      parent.push(node);
-      stack.push({ level: row.level, items: node.items });
-    } else {
-      parent.push({ uniqueId: row.uniqueId, query: row.query ?? "" });
-    }
-  }
-  return root;
-}
-
-/**
- * Clamp levels so the flat list is always a valid tree: the first row is at level 0, and every
- * other row is at most one level deeper than the row above it — and only deeper when that row is
- * a group (a query cannot have children).
- */
-export function normalizeLevels(rows: FlatReportRow[]): FlatReportRow[] {
-  const out: FlatReportRow[] = [];
-  for (let i = 0; i < rows.length; i++) {
-    if (i === 0) {
-      out.push({ ...rows[i], level: 0 });
-      continue;
-    }
-    const prev = out[i - 1];
-    const max = prev.isGroup ? prev.level + 1 : prev.level;
-    out.push({ ...rows[i], level: Math.max(0, Math.min(rows[i].level, max)) });
-  }
-  return out;
-}
-
-/** Number of rows making up the subtree rooted at `index` (the row itself plus its descendants). */
-export function subtreeLength(rows: FlatReportRow[], index: number): number {
-  const base = rows[index].level;
-  let end = index + 1;
-  while (end < rows.length && rows[end].level > base) {
-    end++;
-  }
-  return end - index;
 }

--- a/src/app/utils/flat-tree/flat-tree.spec.ts
+++ b/src/app/utils/flat-tree/flat-tree.spec.ts
@@ -90,110 +90,102 @@ describe("flat-tree", () => {
     expect(subtreeLength(rows, 3)).toBe(2); // Sub, c
   });
 
-  describe("moveSubtree", () => {
-    it("moves a group together with its whole subtree", () => {
-      const rows = flattenTree(tree, adapter);
+  it("moveSubtree moves a group together with its whole subtree", () => {
+    const rows = flattenTree(tree, adapter);
 
-      // drag "G" (index 1) to the top
-      const moved = moveSubtree(rows, 1, 0, adapter);
+    // drag "G" (index 1) to the top
+    const moved = moveSubtree(rows, 1, 0, adapter);
 
-      expect(describeRows(moved)).toEqual([
-        "G@0",
-        "b@1",
-        "Sub@1",
-        "c@2",
-        "a@0",
-      ]);
+    expect(describeRows(moved)).toEqual(["G@0", "b@1", "Sub@1", "c@2", "a@0"]);
+  });
+
+  it("moveSubtree accounts for the descendants moved along when dropping further down", () => {
+    const rows = flattenTree(
+      [group("G", leaf("b")), leaf("x"), leaf("y")],
+      adapter,
+    );
+
+    // drag "G" (index 0) below "y": cdk reports the index it would take without its child
+    const moved = moveSubtree(rows, 0, 3, adapter, { levelDelta: 0 });
+
+    expect(describeRows(moved)).toEqual(["x@0", "y@0", "G@0", "b@1"]);
+  });
+
+  it("moveSubtree nests a row into the group above it when dragged to the right", () => {
+    const rows = flattenTree([group("G"), leaf("a")], adapter);
+
+    const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 1 });
+
+    expect(describeRows(moved)).toEqual(["G@0", "a@1"]);
+  });
+
+  it("moveSubtree un-nests a row when dragged to the left", () => {
+    const rows = flattenTree([group("G", leaf("a")), leaf("z")], adapter);
+
+    const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
+
+    expect(describeRows(moved)).toEqual(["G@0", "a@0", "z@0"]);
+  });
+
+  it("moveSubtree does not nest deeper than the row above allows", () => {
+    const rows = flattenTree([leaf("a"), leaf("b")], adapter);
+
+    // "a" is a leaf and cannot take children, however far "b" is dragged to the right
+    const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 3 });
+
+    expect(describeRows(moved)).toEqual(["a@0", "b@0"]);
+  });
+
+  it("moveSubtree does not nest beyond maxLevel", () => {
+    const rows = flattenTree([group("G"), leaf("a")], adapter);
+
+    const moved = moveSubtree(rows, 1, 1, adapter, {
+      levelDelta: 1,
+      maxLevel: 0,
     });
 
-    it("accounts for the descendants moved along when dropping further down", () => {
-      const rows = flattenTree(
-        [group("G", leaf("b")), leaf("x"), leaf("y")],
-        adapter,
-      );
+    expect(describeRows(moved)).toEqual(["G@0", "a@0"]);
+  });
 
-      // drag "G" (index 0) below "y": cdk reports the index it would take without its child
-      const moved = moveSubtree(rows, 0, 3, adapter, { levelDelta: 0 });
+  it("moveSubtree does not drop in shallower than the row below, which it would adopt", () => {
+    const rows = flattenTree(
+      [group("G", group("S", leaf("x"), leaf("y"))), leaf("B")],
+      adapter,
+    );
 
-      expect(describeRows(moved)).toEqual(["x@0", "y@0", "G@0", "b@1"]);
-    });
+    // drop "B" between "S" and its children: staying at level 0 would make x/y its children
+    const moved = moveSubtree(rows, 4, 2, adapter, { levelDelta: 0 });
 
-    it("nests a row into the group above it when dragged to the right", () => {
-      const rows = flattenTree([group("G"), leaf("a")], adapter);
+    expect(describeRows(moved)).toEqual(["G@0", "S@1", "B@2", "x@2", "y@2"]);
+  });
 
-      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 1 });
+  it("moveSubtree cannot un-nest a first child that has siblings following it", () => {
+    const rows = flattenTree([group("G", leaf("a"), leaf("b"))], adapter);
 
-      expect(describeRows(moved)).toEqual(["G@0", "a@1"]);
-    });
+    // promoting "a" would turn its sibling "b" into a child of "a"
+    const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
 
-    it("un-nests a row when dragged to the left", () => {
-      const rows = flattenTree([group("G", leaf("a")), leaf("z")], adapter);
+    expect(describeRows(moved)).toEqual(["G@0", "a@1", "b@1"]);
+  });
 
-      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
+  it("moveSubtree ignores dropping a group into its own subtree", () => {
+    const rows = flattenTree(
+      [group("G", leaf("b"), leaf("c")), leaf("z")],
+      adapter,
+    );
 
-      expect(describeRows(moved)).toEqual(["G@0", "a@0", "z@0"]);
-    });
+    const moved = moveSubtree(rows, 0, 1, adapter);
 
-    it("does not nest deeper than the row above allows", () => {
-      const rows = flattenTree([leaf("a"), leaf("b")], adapter);
+    expect(describeRows(moved)).toEqual(["G@0", "b@1", "c@1", "z@0"]);
+  });
 
-      // "a" is a leaf and cannot take children, however far "b" is dragged to the right
-      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 3 });
+  it("moveSubtree promotes rows orphaned by the move", () => {
+    const rows = flattenTree([group("G", leaf("b")), leaf("z")], adapter);
 
-      expect(describeRows(moved)).toEqual(["a@0", "b@0"]);
-    });
+    // drag "G" (index 0) to the bottom, leaving its former child behind
+    const moved = moveSubtree(rows, 0, 2, adapter);
 
-    it("does not nest beyond maxLevel", () => {
-      const rows = flattenTree([group("G"), leaf("a")], adapter);
-
-      const moved = moveSubtree(rows, 1, 1, adapter, {
-        levelDelta: 1,
-        maxLevel: 0,
-      });
-
-      expect(describeRows(moved)).toEqual(["G@0", "a@0"]);
-    });
-
-    it("does not drop in shallower than the row below, which it would adopt", () => {
-      const rows = flattenTree(
-        [group("G", group("S", leaf("x"), leaf("y"))), leaf("B")],
-        adapter,
-      );
-
-      // drop "B" between "S" and its children: staying at level 0 would make x/y its children
-      const moved = moveSubtree(rows, 4, 2, adapter, { levelDelta: 0 });
-
-      expect(describeRows(moved)).toEqual(["G@0", "S@1", "B@2", "x@2", "y@2"]);
-    });
-
-    it("cannot un-nest a first child that has siblings following it", () => {
-      const rows = flattenTree([group("G", leaf("a"), leaf("b"))], adapter);
-
-      // promoting "a" would turn its sibling "b" into a child of "a"
-      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
-
-      expect(describeRows(moved)).toEqual(["G@0", "a@1", "b@1"]);
-    });
-
-    it("ignores dropping a group into its own subtree", () => {
-      const rows = flattenTree(
-        [group("G", leaf("b"), leaf("c")), leaf("z")],
-        adapter,
-      );
-
-      const moved = moveSubtree(rows, 0, 1, adapter);
-
-      expect(describeRows(moved)).toEqual(["G@0", "b@1", "c@1", "z@0"]);
-    });
-
-    it("promotes rows orphaned by the move", () => {
-      const rows = flattenTree([group("G", leaf("b")), leaf("z")], adapter);
-
-      // drag "G" (index 0) to the bottom, leaving its former child behind
-      const moved = moveSubtree(rows, 0, 2, adapter);
-
-      expect(describeRows(moved)).toEqual(["z@0", "G@0", "b@1"]);
-    });
+    expect(describeRows(moved)).toEqual(["z@0", "G@0", "b@1"]);
   });
 
   it("removes a row together with its subtree", () => {

--- a/src/app/utils/flat-tree/flat-tree.spec.ts
+++ b/src/app/utils/flat-tree/flat-tree.spec.ts
@@ -1,0 +1,233 @@
+import {
+  FlatTreeAdapter,
+  FlatTreeRow,
+  flattenTree,
+  insertChild,
+  moveSubtree,
+  normalizeLevels,
+  rebuildTree,
+  removeSubtree,
+  subtreeLength,
+  updateRow,
+} from "./flat-tree";
+
+interface TestNode {
+  id: string;
+  /** absent for nodes that cannot have children at all */
+  children?: TestNode[];
+}
+
+const adapter: FlatTreeAdapter<TestNode> = {
+  id: (node) => node.id,
+  children: (node) => node.children,
+  withChildren: (node, children) => ({ ...node, children }),
+};
+
+/** a group node (can have children) */
+function group(id: string, ...children: TestNode[]): TestNode {
+  return { id, children };
+}
+
+/** a leaf node that can never have children */
+function leaf(id: string): TestNode {
+  return { id };
+}
+
+/** compact representation of rows for assertions: `"id@level"` */
+function describeRows(rows: FlatTreeRow<TestNode>[]): string[] {
+  return rows.map((row) => `${row.id}@${row.level}`);
+}
+
+describe("flat-tree", () => {
+  //     a
+  //     G
+  //      ├ b
+  //      └ Sub
+  //         └ c
+  const tree = [leaf("a"), group("G", leaf("b"), group("Sub", leaf("c")))];
+
+  it("flattens a tree into indented rows, without the nested children", () => {
+    const rows = flattenTree(tree, adapter);
+
+    expect(describeRows(rows)).toEqual(["a@0", "G@0", "b@1", "Sub@1", "c@2"]);
+    expect(rows[1].data.children).toEqual([]);
+    expect(rows[0].data.children).toBeUndefined();
+  });
+
+  it("rebuilds the original tree from the flat rows", () => {
+    expect(rebuildTree(flattenTree(tree, adapter), adapter)).toEqual(tree);
+  });
+
+  it("clamps levels so rows form a valid tree", () => {
+    const rows: FlatTreeRow<TestNode>[] = [
+      { id: "a", level: 2, data: leaf("a") }, // first row -> forced to 0
+      { id: "G", level: 3, data: group("G") }, // -> 0
+      { id: "b", level: 9, data: leaf("b") }, // below a group -> 1
+      { id: "c", level: 5, data: leaf("c") }, // below a leaf -> stays at 1
+    ];
+
+    expect(describeRows(normalizeLevels(rows, adapter))).toEqual([
+      "a@0",
+      "G@0",
+      "b@1",
+      "c@1",
+    ]);
+  });
+
+  it("keeps all rows at the top level when maxLevel is 0", () => {
+    const rows = flattenTree(tree, adapter);
+
+    expect(
+      describeRows(normalizeLevels(rows, adapter, { maxLevel: 0 })),
+    ).toEqual(["a@0", "G@0", "b@0", "Sub@0", "c@0"]);
+  });
+
+  it("measures a subtree as the row itself plus its descendants", () => {
+    const rows = flattenTree(tree, adapter);
+
+    expect(subtreeLength(rows, 0)).toBe(1); // a
+    expect(subtreeLength(rows, 1)).toBe(4); // G, b, Sub, c
+    expect(subtreeLength(rows, 3)).toBe(2); // Sub, c
+  });
+
+  describe("moveSubtree", () => {
+    it("moves a group together with its whole subtree", () => {
+      const rows = flattenTree(tree, adapter);
+
+      // drag "G" (index 1) to the top
+      const moved = moveSubtree(rows, 1, 0, adapter);
+
+      expect(describeRows(moved)).toEqual([
+        "G@0",
+        "b@1",
+        "Sub@1",
+        "c@2",
+        "a@0",
+      ]);
+    });
+
+    it("accounts for the descendants moved along when dropping further down", () => {
+      const rows = flattenTree(
+        [group("G", leaf("b")), leaf("x"), leaf("y")],
+        adapter,
+      );
+
+      // drag "G" (index 0) below "y": cdk reports the index it would take without its child
+      const moved = moveSubtree(rows, 0, 3, adapter, { levelDelta: 0 });
+
+      expect(describeRows(moved)).toEqual(["x@0", "y@0", "G@0", "b@1"]);
+    });
+
+    it("nests a row into the group above it when dragged to the right", () => {
+      const rows = flattenTree([group("G"), leaf("a")], adapter);
+
+      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 1 });
+
+      expect(describeRows(moved)).toEqual(["G@0", "a@1"]);
+    });
+
+    it("un-nests a row when dragged to the left", () => {
+      const rows = flattenTree([group("G", leaf("a")), leaf("z")], adapter);
+
+      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
+
+      expect(describeRows(moved)).toEqual(["G@0", "a@0", "z@0"]);
+    });
+
+    it("does not nest deeper than the row above allows", () => {
+      const rows = flattenTree([leaf("a"), leaf("b")], adapter);
+
+      // "a" is a leaf and cannot take children, however far "b" is dragged to the right
+      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: 3 });
+
+      expect(describeRows(moved)).toEqual(["a@0", "b@0"]);
+    });
+
+    it("does not nest beyond maxLevel", () => {
+      const rows = flattenTree([group("G"), leaf("a")], adapter);
+
+      const moved = moveSubtree(rows, 1, 1, adapter, {
+        levelDelta: 1,
+        maxLevel: 0,
+      });
+
+      expect(describeRows(moved)).toEqual(["G@0", "a@0"]);
+    });
+
+    it("does not drop in shallower than the row below, which it would adopt", () => {
+      const rows = flattenTree(
+        [group("G", group("S", leaf("x"), leaf("y"))), leaf("B")],
+        adapter,
+      );
+
+      // drop "B" between "S" and its children: staying at level 0 would make x/y its children
+      const moved = moveSubtree(rows, 4, 2, adapter, { levelDelta: 0 });
+
+      expect(describeRows(moved)).toEqual(["G@0", "S@1", "B@2", "x@2", "y@2"]);
+    });
+
+    it("cannot un-nest a first child that has siblings following it", () => {
+      const rows = flattenTree([group("G", leaf("a"), leaf("b"))], adapter);
+
+      // promoting "a" would turn its sibling "b" into a child of "a"
+      const moved = moveSubtree(rows, 1, 1, adapter, { levelDelta: -1 });
+
+      expect(describeRows(moved)).toEqual(["G@0", "a@1", "b@1"]);
+    });
+
+    it("ignores dropping a group into its own subtree", () => {
+      const rows = flattenTree(
+        [group("G", leaf("b"), leaf("c")), leaf("z")],
+        adapter,
+      );
+
+      const moved = moveSubtree(rows, 0, 1, adapter);
+
+      expect(describeRows(moved)).toEqual(["G@0", "b@1", "c@1", "z@0"]);
+    });
+
+    it("promotes rows orphaned by the move", () => {
+      const rows = flattenTree([group("G", leaf("b")), leaf("z")], adapter);
+
+      // drag "G" (index 0) to the bottom, leaving its former child behind
+      const moved = moveSubtree(rows, 0, 2, adapter);
+
+      expect(describeRows(moved)).toEqual(["z@0", "G@0", "b@1"]);
+    });
+  });
+
+  it("removes a row together with its subtree", () => {
+    const rows = flattenTree(tree, adapter);
+
+    expect(describeRows(removeSubtree(rows, 1, adapter))).toEqual(["a@0"]);
+    expect(describeRows(removeSubtree(rows, 3, adapter))).toEqual([
+      "a@0",
+      "G@0",
+      "b@1",
+    ]);
+  });
+
+  it("inserts a node as the first child of a group", () => {
+    const rows = flattenTree(tree, adapter);
+
+    const extended = insertChild(rows, 1, leaf("new"), adapter);
+
+    expect(describeRows(extended)).toEqual([
+      "a@0",
+      "G@0",
+      "new@1",
+      "b@1",
+      "Sub@1",
+      "c@2",
+    ]);
+  });
+
+  it("replaces the node of a single row", () => {
+    const rows = flattenTree(tree, adapter);
+
+    const updated = updateRow(rows, 0, { ...rows[0].data, id: "a" });
+
+    expect(updated[0].data).not.toBe(rows[0].data);
+    expect(describeRows(updated)).toEqual(describeRows(rows));
+  });
+});

--- a/src/app/utils/flat-tree/flat-tree.ts
+++ b/src/app/utils/flat-tree/flat-tree.ts
@@ -1,0 +1,215 @@
+/**
+ * Helpers to edit a tree of nodes as a single flat, indented list.
+ *
+ * Editing a nested structure with `@angular/cdk/drag-drop` through nested `cdkDropList`s is
+ * unreliable: items cannot be moved into or out of arbitrary nesting levels, and a parent can be
+ * dropped into its own child. Instead, the tree is flattened into one list of {@link FlatTreeRow}s
+ * where nesting is only expressed by {@link FlatTreeRow.level} (rendered as indentation) and shown
+ * as a single `cdkDropList`. Dragging then is plain reordering, the nesting level is chosen by how
+ * far a row is dragged horizontally, and the nested tree is reconstructed via {@link rebuildTree}.
+ *
+ * The helpers are generic over the node type; a {@link FlatTreeAdapter} maps them onto a concrete
+ * structure (e.g. `MenuItem.subMenu` or a report definition's `items`).
+ */
+
+/** A single row of the flattened tree: one node, with its depth in the tree. */
+export interface FlatTreeRow<T> {
+  /** unique, stable id of the node (used for drag & drop tracking) */
+  id: string;
+  /** nesting depth; a row is a child of the nearest preceding row with a smaller level */
+  level: number;
+  /** the node itself, without its children (they are rows of their own) */
+  data: T;
+}
+
+/** Maps the generic flat-tree helpers onto a concrete node type. */
+export interface FlatTreeAdapter<T> {
+  /** unique, stable id of a node */
+  id: (node: T) => string;
+  /**
+   * The child nodes of a node, or `undefined` if the node cannot have children at all.
+   * Nodes returning an (empty) array can be nested into, others are always leaves.
+   */
+  children: (node: T) => T[] | undefined;
+  /** a copy of the node with the given child nodes */
+  withChildren: (node: T, children: T[]) => T;
+}
+
+/** Options restricting how deep rows may be nested. */
+export interface FlatTreeOptions {
+  /** maximum allowed nesting level; 0 disables nesting entirely (default: unlimited) */
+  maxLevel?: number;
+}
+
+/** Flatten a nested tree into rows (pre-order), carrying the depth as `level`. */
+export function flattenTree<T>(
+  nodes: T[] | undefined,
+  adapter: FlatTreeAdapter<T>,
+  level = 0,
+): FlatTreeRow<T>[] {
+  const rows: FlatTreeRow<T>[] = [];
+  for (const node of nodes ?? []) {
+    const children = adapter.children(node);
+    rows.push({
+      id: adapter.id(node),
+      level,
+      // children become rows of their own, so they are cleared on the row's own node
+      data: children ? adapter.withChildren(node, []) : node,
+    });
+    rows.push(...flattenTree(children, adapter, level + 1));
+  }
+  return rows;
+}
+
+/** Reconstruct the nested tree from flat rows: each row owns the following rows of greater level. */
+export function rebuildTree<T>(
+  rows: FlatTreeRow<T>[],
+  adapter: FlatTreeAdapter<T>,
+): T[] {
+  const nodes: T[] = [];
+  let i = 0;
+  while (i < rows.length) {
+    const row = rows[i];
+    const length = subtreeLength(rows, i);
+    nodes.push(
+      adapter.children(row.data) === undefined
+        ? row.data
+        : adapter.withChildren(
+            row.data,
+            rebuildTree(rows.slice(i + 1, i + length), adapter),
+          ),
+    );
+    i += length;
+  }
+  return nodes;
+}
+
+/**
+ * Clamp levels so the flat list always describes a valid tree: the first row is at level 0, every
+ * other row is at most one level deeper than the row above it — and only deeper if that row can
+ * have children at all — and no row is deeper than `maxLevel`.
+ */
+export function normalizeLevels<T>(
+  rows: FlatTreeRow<T>[],
+  adapter: FlatTreeAdapter<T>,
+  options?: FlatTreeOptions,
+): FlatTreeRow<T>[] {
+  const normalized: FlatTreeRow<T>[] = [];
+  for (const row of rows) {
+    const max = maxLevelBelow(
+      normalized[normalized.length - 1],
+      adapter,
+      options,
+    );
+    normalized.push({ ...row, level: Math.max(0, Math.min(row.level, max)) });
+  }
+  return normalized;
+}
+
+/** The deepest level a row directly below `above` may have (0 if there is no row above). */
+function maxLevelBelow<T>(
+  above: FlatTreeRow<T> | undefined,
+  adapter: FlatTreeAdapter<T>,
+  options?: FlatTreeOptions,
+): number {
+  if (!above) {
+    return 0;
+  }
+  const level = adapter.children(above.data) ? above.level + 1 : above.level;
+  return Math.min(level, options?.maxLevel ?? Number.MAX_SAFE_INTEGER);
+}
+
+/** Number of rows forming the subtree rooted at `index` (the row itself plus its descendants). */
+export function subtreeLength<T>(
+  rows: FlatTreeRow<T>[],
+  index: number,
+): number {
+  const base = rows[index].level;
+  let end = index + 1;
+  while (end < rows.length && rows[end].level > base) {
+    end++;
+  }
+  return end - index;
+}
+
+/**
+ * Move the subtree rooted at `previousIndex` to `currentIndex` (as reported by a `cdkDropList`,
+ * which only moves the dragged row itself — its descendants follow it here) and re-nest it by
+ * `levelDelta` levels, within what the rows it comes to rest between allow.
+ */
+export function moveSubtree<T>(
+  rows: FlatTreeRow<T>[],
+  previousIndex: number,
+  currentIndex: number,
+  adapter: FlatTreeAdapter<T>,
+  options?: FlatTreeOptions & {
+    /** how many levels to nest the row in or out, e.g. from the horizontal drag distance */
+    levelDelta?: number;
+  },
+): FlatTreeRow<T>[] {
+  const length = subtreeLength(rows, previousIndex);
+  const dragged = rows[previousIndex];
+
+  // move the subtree as a whole; `currentIndex` counts the dragged row only, so dropping it
+  // further down has to account for the descendants taken out of the list along with it
+  const moved = [...rows];
+  const subtree = moved.splice(previousIndex, length);
+  const insertAt =
+    currentIndex <= previousIndex
+      ? currentIndex
+      : Math.max(previousIndex, currentIndex - length + 1);
+  moved.splice(insertAt, 0, ...subtree);
+
+  // Nest by the dragged distance, but only as deep as the row above allows and not shallower
+  // than the row below: a shallower row would adopt the rows following it as its own children.
+  const maxLevel = maxLevelBelow(moved[insertAt - 1], adapter, options);
+  const minLevel = Math.min(moved[insertAt + length]?.level ?? 0, maxLevel);
+  const targetLevel = Math.max(
+    minLevel,
+    Math.min(dragged.level + (options?.levelDelta ?? 0), maxLevel),
+  );
+  const delta = targetLevel - dragged.level;
+  for (let i = insertAt; i < insertAt + length; i++) {
+    moved[i] = { ...moved[i], level: moved[i].level + delta };
+  }
+
+  return normalizeLevels(moved, adapter, options);
+}
+
+/** Remove the row at `index` together with its whole subtree. */
+export function removeSubtree<T>(
+  rows: FlatTreeRow<T>[],
+  index: number,
+  adapter: FlatTreeAdapter<T>,
+  options?: FlatTreeOptions,
+): FlatTreeRow<T>[] {
+  const remaining = [...rows];
+  remaining.splice(index, subtreeLength(rows, index));
+  return normalizeLevels(remaining, adapter, options);
+}
+
+/** Insert `node` as the first child of the row at `parentIndex`. */
+export function insertChild<T>(
+  rows: FlatTreeRow<T>[],
+  parentIndex: number,
+  node: T,
+  adapter: FlatTreeAdapter<T>,
+  options?: FlatTreeOptions,
+): FlatTreeRow<T>[] {
+  const extended = [...rows];
+  extended.splice(parentIndex + 1, 0, {
+    id: adapter.id(node),
+    level: rows[parentIndex].level + 1,
+    data: node,
+  });
+  return normalizeLevels(extended, adapter, options);
+}
+
+/** Replace the node of the row at `index`, keeping its position and nesting. */
+export function updateRow<T>(
+  rows: FlatTreeRow<T>[],
+  index: number,
+  node: T,
+): FlatTreeRow<T>[] {
+  return rows.map((row, i) => (i === index ? { ...row, data: node } : row));
+}


### PR DESCRIPTION
@Abhinegi2 , I have looked a bit into the multiple drag&drop code we have across components, while reviewing your SQL Admin PR. This is an attempt by claude to simplify and establish more code reuse. Please have a look at it :blush: 



-----

Two independent drag & drop cleanups, one commit each (plus a follow-up fix). Both touch admin editors but are otherwise unrelated — reviewable separately.

## 1. Shared flat-tree drag & drop — menu + report editors

New `src/app/utils/flat-tree/`: generic helpers to edit a tree as one flat, indented list in a single `cdkDropList`.

- The admin menu editor moves off nested, connected `cdkDropList`s. Those can't reliably move items across nesting levels, which forced a `structuredClone` of the whole tree on every drop and a `try/catch` swallowing invalid drops — dropping a parent into its own child is now structurally impossible. `allowSubMenu: false` (shortcuts) becomes `maxLevel: 0` instead of a special case.
- `AdminMenuItemComponent` no longer recurses or carries drag state; it renders one item.
- The SQL report editor uses the same helpers and loses its bespoke drop logic.
- Nesting is now chosen by horizontal drag distance, clamped between what the rows above **and below** allow — without the lower clamp, a shallow drop silently adopts the rows following it.
- Fixes along the way: `openEditDialog` passed the `allowEntityLinks` InputSignal itself rather than its value, so shortcut items offered entity links when edited.

## 2. Entity form editor ("configure data structure")

- Drop handlers no longer splice the arrays CDK hands over and then fake a signal change. Each drop list carries its identity as `cdkDropListData`, each field carries itself as `cdkDragData`, and a drop is a pure `moveFieldBetweenGroups(...)`.
- The toolbar's "drag & drop to / **from** here" now actually works both ways. It had no `id` and nothing connected to it. It also needed `cdkDragBoundary` removed: that clamps the hit-test pointer to `boundary.right - (previewWidth - grabOffset)`, which stops short of the toolbar — no boundary inside the page can satisfy it.

## Verified

Full suite green. New unit tests cover the tree logic, the template wiring (`cdkDropListData` / `cdkDragData` asserted on the rendered directives) and that the config input is never mutated. Drag gestures were exercised in a real browser: menu nest/un-nest and reorder; report nest/un-nest plus the correct refusal to lift a first child that has siblings; entity form group→group, group→toolbar and toolbar→group.

## Not tested

- **Shortcut dashboard widget** (`allowSubMenu=false`): unit-tested only, not clicked through in the app.
- **No e2e coverage for the admin menu editor** — there was none before either, and drag & drop has a long-standing `todo` in `admin.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop editing for admin form fields, including moving, reordering, removing, and adding fields to groups.
  * Added more intuitive menu editing with indentation, nesting, unnesting, and movement of complete menu sections.
  * Enhanced report-definition editing with easier query and group nesting, reordering, and removal.
  * Added clearer visual feedback during drag-and-drop interactions.
* **Bug Fixes**
  * Prevented invalid nesting, preserved child items during edits, and improved handling of drag-and-drop targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->