### PR TITLE
fix(sync): raise permission purge to error level when local edits may be lost

### DIFF
--- a/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
@@ -10,6 +10,7 @@ import { Subject } from "rxjs";
 import { SyncState } from "../../session/session-states/sync-state.enum";
 import { SyncedPouchDatabase } from "./synced-pouch-database";
 import { NotAvailableOfflineError } from "../../session/not-available-offline.error";
+import { Logging } from "../../logging/logging.service";
 
 describe("SyncedPouchDatabase", () => {
   let service: SyncedPouchDatabase;
@@ -443,6 +444,62 @@ describe("SyncedPouchDatabase", () => {
 
       expect(purgeSpy).toHaveBeenCalledWith("Child:1");
       expect(purgeSpy).toHaveBeenCalledWith("School:2");
+    });
+
+    it("should log at warn level when the client had just synced (no data at risk)", async () => {
+      const warnSpy = vi.spyOn(Logging, "warn");
+      const errorSpy = vi.spyOn(Logging, "error");
+      localStorage.setItem(service.LAST_SYNC_KEY, new Date().toISOString());
+      vi.spyOn(
+        service["remoteDatabase"],
+        "collectAndClearLostPermissions",
+      ).mockReturnValue(["Child:1"]);
+
+      await service.sync();
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("purging local docs"),
+        expect.objectContaining({ count: 1, riskOfDataLoss: false }),
+      );
+    });
+
+    it("should log at error level when the client was stale (local edits may be lost)", async () => {
+      const errorSpy = vi.spyOn(Logging, "error");
+      const staleSync = new Date(
+        Date.now() - service.PURGE_DATA_LOSS_RISK_THRESHOLD - 60000,
+      ).toISOString();
+      localStorage.setItem(service.LAST_SYNC_KEY, staleSync);
+      vi.spyOn(
+        service["remoteDatabase"],
+        "collectAndClearLostPermissions",
+      ).mockReturnValue(["Child:1"]);
+
+      await service.sync();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("purging local docs"),
+        expect.objectContaining({ riskOfDataLoss: true }),
+      );
+    });
+
+    it("should log at error level when the last sync time is unknown", async () => {
+      const errorSpy = vi.spyOn(Logging, "error");
+      localStorage.removeItem(service.LAST_SYNC_KEY);
+      vi.spyOn(
+        service["remoteDatabase"],
+        "collectAndClearLostPermissions",
+      ).mockReturnValue(["Child:1"]);
+
+      await service.sync();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("purging local docs"),
+        expect.objectContaining({
+          riskOfDataLoss: true,
+          syncGapMs: undefined,
+        }),
+      );
     });
 
     it("should not purge anything if no permissions were lost", async () => {

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -61,6 +61,19 @@ export class SyncedPouchDatabase extends PouchDatabase {
    */
   SYNC_STALL_TIMEOUT = 300000;
 
+  /**
+   * How far behind the server a client may be for a permission purge to be
+   * considered harmless (ms).
+   *
+   * A purge deletes local docs without syncing them first, so anything edited
+   * locally since the last completed sync is lost. If that window is only a few
+   * sync cycles wide the client had nothing pending and the purge is routine;
+   * beyond it, local edits may have been destroyed and someone has to look.
+   * Set to 10x SYNC_INTERVAL so a client that merely missed a couple of cycles
+   * is not treated as data loss.
+   */
+  PURGE_DATA_LOSS_RISK_THRESHOLD = 300000;
+
   private readonly navigator: Navigator;
   private readonly loginStateSubject: LoginStateSubject;
   private readonly alertService?: AlertService;
@@ -353,16 +366,35 @@ export class SyncedPouchDatabase extends PouchDatabase {
       .filter((id) => !id.startsWith("_design/"));
 
     if (lostPermissionIds.length > 0) {
+      // how far behind the server this client was: local edits made since then are lost
+      const lastSyncCompleted = localStorage.getItem(this.LAST_SYNC_KEY);
+      const syncGapMs = lastSyncCompleted
+        ? Date.now() - new Date(lastSyncCompleted).getTime()
+        : undefined;
+      // An unknown gap cannot be ruled out as data loss, so it is treated as risky.
+      const riskOfDataLoss =
+        syncGapMs === undefined ||
+        Number.isNaN(syncGapMs) ||
+        syncGapMs > this.PURGE_DATA_LOSS_RISK_THRESHOLD;
+
       // deleting local data based on server response - log for traceability of possible data loss.
-      Logging.warn(
-        "sync: purging local docs after server reported lost permissions",
-        {
-          db: this.dbName,
-          count: lostPermissionIds.length,
-          // how far behind the server this client was: local edits made since then are lost
-          lastSyncCompleted: localStorage.getItem(this.LAST_SYNC_KEY),
-        },
-      );
+      // The document count does not measure data loss - the sync gap does: a large purge on a
+      // just-synced client is routine, while a small purge on a stale one can destroy local edits.
+      // Only the latter is raised to error so it reaches alerting.
+      const message =
+        "sync: purging local docs after server reported lost permissions";
+      const context = {
+        db: this.dbName,
+        count: lostPermissionIds.length,
+        lastSyncCompleted,
+        syncGapMs,
+        riskOfDataLoss,
+      };
+      if (riskOfDataLoss) {
+        Logging.error(message, context);
+      } else {
+        Logging.warn(message, context);
+      }
     }
 
     for (const _id of lostPermissionIds) {


### PR DESCRIPTION
- relates to #4198

## What

The sync path that purges local documents after the server reports lost permissions logged at `warn` level unconditionally (`synced-pouch-database.ts`). Sentry issue [AAM-DIGITAL-74M](https://aam-digital.sentry.io/issues/AAM-DIGITAL-74M) has been `escalating` for eight consecutive daily monitoring runs — **177 lifetime events, 37 in the last 24h alone** (up from 16 the previous day) — and because every event is `level=warning`, it has never generated a single alert. A path that can destroy unsynced user data is the one thing that should not be silent.

Simply raising everything to `error` would be noisy and wrong. Monitoring across several runs established that **the document count does not measure data loss — the sync gap does**:

| observed purge | docs | gap since last completed sync | actual risk |
|---|---|---|---|
| largest today | 1958 | ~28 seconds | none — everything had just synced |
| earlier run | 3294 | ~27 seconds | none |
| earlier run | 531 | ~35.5 hours | real — device was a day and a half stale |

Triaging by volume ranks those exactly backwards.

## Change

Severity is now derived from the sync gap:

- gap within `PURGE_DATA_LOSS_RISK_THRESHOLD` (5 min, 10× `SYNC_INTERVAL`) → stays `Logging.warn`
- gap beyond it, **or a missing/unparseable last-sync time** → `Logging.error`, so it reaches alerting

`syncGapMs` and `riskOfDataLoss` are added to the structured context, so triage no longer means subtracting two timestamps by hand.

The purge itself is unchanged — this only affects how it is reported. The threshold is a single named constant and easy to re-tune once real error-level volume is visible.

Ordering note: `purgeDocsWithLostPermissions()` runs before `syncState` emits `COMPLETED`, which is what rewrites the last-sync key — so the value read here is genuinely the *previous* completed sync, which is the window in which local edits are at risk.

## Testing

`npx ng test --configuration=ci --include='src/app/core/database/pouchdb/synced-pouch-database.spec.ts'` → **22 passed**, including three new cases covering the just-synced (warn), stale (error), and unknown-last-sync (error) branches.

Manual verification: not reproducible locally without a server-driven `lostPermissions` response; the behaviour is covered by the unit tests above, and the change is confined to log severity and context.

## PR Checklist

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — covered by unit tests; see note above
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeFid5CygnguNrhyDLgoJR)_