### PR TITLE
fix(entity-form): fall back to read-only view when the form has no control for a field

### DIFF
--- a/src/app/core/entity/entity-field-edit/entity-field-edit.component.html
+++ b/src/app/core/entity/entity-field-edit/entity-field-edit.component.html
@@ -1,4 +1,4 @@
-@if (_field() && form() && _field().editComponent) {
+@if (_field() && form() && _field().editComponent && formControl()) {
   <div
     class="flex-row"
     [class.hidden]="_field()?.hideFromForm"

--- a/src/app/core/entity/entity-field-edit/entity-field-edit.component.spec.ts
+++ b/src/app/core/entity/entity-field-edit/entity-field-edit.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormControl, FormGroup } from "@angular/forms";
 
 import { ComponentRegistry } from "../../../dynamic-components";
 import { EntityFormService } from "../../common-components/entity-form/entity-form.service";
@@ -56,5 +57,47 @@ describe("EntityFieldEditComponent", () => {
     const result = component._field();
     expect(result).toBeDefined();
     expect(mockFormService.extendFormFieldConfig).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to the read-only view if the form has no control for the field", () => {
+    // e.g. after the entity schema was edited in the admin UI, a configured field
+    // can be missing from the already-built formGroup
+    mockFormService.extendFormFieldConfig.mockReturnValue({
+      id: "testField",
+      editComponent: "EditText",
+    });
+    fixture.componentRef.setInput("field", "testField");
+    fixture.componentRef.setInput("entity", new Entity());
+    fixture.componentRef.setInput("form", { formGroup: new FormGroup({}) });
+
+    expect(component.formControl()).toBeNull();
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(
+      fixture.nativeElement.querySelector("app-entity-field-view"),
+    ).toBeTruthy();
+  });
+
+  it("should not fall back to the read-only view if the form has a control for the field", () => {
+    mockFormService.extendFormFieldConfig.mockReturnValue({
+      id: "testField",
+      editComponent: "EditText",
+    });
+    fixture.componentRef.setInput("field", "testField");
+    fixture.componentRef.setInput("entity", new Entity());
+    fixture.componentRef.setInput("form", {
+      formGroup: new FormGroup({ testField: new FormControl("") }),
+    });
+
+    expect(component.formControl()).toBeTruthy();
+    // the edit branch is entered, so the read-only fallback is not rendered
+    // (rendering the dynamic edit component itself is out of scope here)
+    try {
+      fixture.detectChanges();
+    } catch {
+      // dynamic edit component has its own dependencies, not provided in this test
+    }
+    expect(
+      fixture.nativeElement.querySelector("app-entity-field-view"),
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
Found by the automated monitoring routine. Sentry: [AAM-DIGITAL-73J](https://aam-digital.sentry.io/issues/AAM-DIGITAL-73J) + [AAM-DIGITAL-74A](https://aam-digital.sentry.io/issues/AAM-DIGITAL-74A) — same fault, two issue IDs.

## What

34 events on 7 Aug on one production instance, all `TypeError: Cannot read properties of null (reading '_rawValidators')` on `3.87.3`. The burst starts in the admin entity editor and then fires on every record detail view of that entity type for the next ~2h and 20min, once per change-detection pass — so it is not a cosmetic warning, it takes the record view down.

The cause is in the template guard of `EntityFieldEditComponent`:

```html
@if (_field() && form() && _field().editComponent) {
```

`formControl()` is `computed<FormControl | null>` and returns `null` whenever `form.formGroup.get(field.id)` finds no control — a configured field that is not (or not yet) in the already-built `formGroup`. Nothing in the guard covers that, so the `null` reaches:

- `<app-dynamic-edit [formControl]="formControl()">` (line 50)
- `<app-error-hint [form]="formControl()">` (line 56)

Angular's `FormControlDirective.ngOnChanges` → `setUpControl(null)` → `getControlValidators` → `control._rawValidators` throws.

The observed trigger is editing an entity's fields in the admin UI: the schema gains/renames a field while a `formGroup` built from the previous schema is still live. Marking this as the likely trigger rather than confirmed — the correlation is the route sequence in the event stream (admin entity editor first, record views after), not something reproducible from the events alone.

## Change

Add `formControl()` to the guard. The component already has a read-only `@else` branch (`app-entity-field-view`), so a field with no control now degrades to the display view instead of throwing. There is no case where the edit branch could work without a control — `<app-dynamic-edit>` requires one — so the guard cannot suppress a working render.

One line of template, plus tests.

## Testing

`npx ng test --configuration=ci --include='src/app/core/entity/entity-field-edit/entity-field-edit.component.spec.ts'` → **4 passed**, two of them new (no control → read-only fallback; control present → edit branch still taken).

Wider check: `--include='src/app/core/entity/**/*.spec.ts'` → **158 passed / 1 skipped** across 25 files. eslint and prettier clean.

The regression test was checked against the unpatched template and does fail without the fix. Note the message differs by build: dev-mode Angular reports `Cannot find control with unspecified name attribute` where the production bundle reports `_rawValidators` — same defect, a `null` reaching `FormControlDirective`.

Not reproduced manually: it needs a live schema edit against an open form.

## PR Checklist

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — covered by unit tests; see the note above
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K27ppE2GJDyx1DyvWjeMVR)_