### PR TITLE
fix(import): count all values of a column that have no value mapping

### DIFF
--- a/src/app/core/basic-datatypes/configurable-enum/configurable-enum-datatype/configurable-enum.datatype.spec.ts
+++ b/src/app/core/basic-datatypes/configurable-enum/configurable-enum-datatype/configurable-enum.datatype.spec.ts
@@ -172,6 +172,21 @@ describe("Schema data type: configurable-enum", () => {
     expect(actualMapped).toBeUndefined();
   });
 
+  it("should return undefined for values that are marked as not to be imported", async () => {
+    enumService.getEnumValues.mockReturnValue(genders);
+
+    const actualMapped = await dataType.importMapFunction(
+      "skipped",
+      {
+        dataType: "configurable-enum",
+        additional: "genders",
+      },
+      { values: { MALEx: GENDER_MALE.id, skipped: null } },
+    );
+
+    expect(actualMapped).toBeUndefined();
+  });
+
   it("should create invalid option when mapping dialog is skipped", async () => {
     enumService.getEnumValues.mockReturnValue(genders);
 

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.spec.ts
@@ -63,6 +63,17 @@ describe("DiscreteImportConfigComponent", () => {
     expect(component.tooltip()).toContain("All values");
   });
 
+  it("should count values that are marked as not to be imported", () => {
+    fixture.componentRef.setInput("col", {
+      column: "gender",
+      propertyName: "category",
+      additional: { values: { female: "F", male: null, other: null } },
+    });
+
+    expect(component.badge()).toBe("2");
+    expect(component.tooltip()).toContain("2");
+  });
+
   it("should open dialog and notify with the configured mapping", async () => {
     const onChangeFn = vi.fn();
     const rawData = [{ gender: "male" }, { gender: "female" }];

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-config.component.ts
@@ -44,7 +44,7 @@ export class DiscreteImportConfigComponent {
     if (!valueMappings) {
       return undefined;
     }
-    return Object.values(valueMappings).filter((v) => v === undefined).length;
+    return Object.values(valueMappings).filter((v) => v == null).length;
   });
 
   readonly badge = computed(() => {

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.spec.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.spec.ts
@@ -116,6 +116,46 @@ describe("DiscreteImportDialogComponent", () => {
     });
   });
 
+  it("should keep values without an assignment when the mapping is saved and reopened", async () => {
+    data.col.additional = {
+      values: { male: "M", female: "F", other: "other" },
+    };
+    component.ngOnInit();
+    component.form.patchValue({ female: undefined, other: undefined });
+
+    await component.save();
+
+    expect(data.col.additional).toEqual({
+      values: { male: "M", female: null, other: null },
+    });
+    // the mapping has to survive being serialized, e.g. when stored with the import history
+    data.col.additional = JSON.parse(JSON.stringify(data.col.additional));
+
+    component.ngOnInit();
+
+    const reopenedValues = component.form.getRawValue();
+    expect(reopenedValues.female).toBeNull();
+    expect(reopenedValues.other).toBeNull();
+  });
+
+  it("should treat a value assigned to unchecked as mapped", async () => {
+    const confirmationSpy = vi.spyOn(
+      TestBed.inject(ConfirmationDialogService),
+      "getConfirmation",
+    );
+    data.entityType = {
+      schema: new Map([["paid", { dataType: "boolean" }]]),
+    } as unknown as typeof TestEntity;
+    data.col = { column: "paid", propertyName: "paid" };
+    data.values = ["yes", "no"];
+
+    component.ngOnInit();
+    await component.save();
+
+    expect(confirmationSpy).not.toHaveBeenCalled();
+    expect(data.col.additional).toEqual({ values: { yes: true, no: false } });
+  });
+
   it("should correctly auto-map numeric CSV values (parsed as numbers) to string enum option IDs", () => {
     const numericEnumOptions = [
       { id: "1a", label: "1a" },

--- a/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete-import-config/discrete-import-dialog.component.ts
@@ -180,7 +180,7 @@ export class DiscreteImportDialogComponent implements OnInit {
 
   async save() {
     const rawValues = this.getValuesInDatabaseFormat(this.form.getRawValue());
-    const allFilled = Object.values(rawValues).every((val) => !!val);
+    const allFilled = Object.values(rawValues).every((val) => val !== null);
     const confirmed =
       allFilled ||
       (await this.confirmation.getConfirmation(
@@ -207,12 +207,27 @@ export class DiscreteImportDialogComponent implements OnInit {
    */
   private getValuesInDatabaseFormat(rawValues: any) {
     for (const k in rawValues) {
-      rawValues[k] = this.schemaService.valueToDatabaseFormat(
+      const value = this.schemaService.valueToDatabaseFormat(
         rawValues[k],
         this.schema,
       );
+      // mark a value the user did not assign explicitly as null, because an empty value is
+      // dropped whenever the mapping is serialized (e.g. stored with the import history),
+      // which loses the information that this value should not be imported at all
+      rawValues[k] = this.isAssigned(value) ? value : null;
     }
 
     return rawValues;
+  }
+
+  /**
+   * Whether the given value is a target value the user picked,
+   * which includes deliberately empty values like `false` for an unchecked checkbox.
+   */
+  private isAssigned(value: any): boolean {
+    if (Array.isArray(value)) {
+      return value.some((v) => this.isAssigned(v));
+    }
+    return value !== undefined && value !== null;
   }
 }

--- a/src/app/core/basic-datatypes/discrete/discrete.datatype.ts
+++ b/src/app/core/basic-datatypes/discrete/discrete.datatype.ts
@@ -40,8 +40,10 @@ export abstract class DiscreteDatatype<
     }
 
     // If mapping dialog was opened but this specific value was not mapped,
-    // skip the property by returning undefined
-    if (valueMappings[val] === undefined) {
+    // skip the property by returning undefined.
+    // A value without a mapping is marked as null, but can also be missing entirely
+    // in a mapping that was stored before that.
+    if (valueMappings[val] == null) {
       return undefined;
     }
 


### PR DESCRIPTION
- closes #4221

The warning badge on a column's "Configure value mapping" button counted mapping entries whose value is empty. An empty value does not survive serializing the mapping (e.g. when it is stored with the import history), so those entries were silently dropped and the badge showed too low a count. Reopening the dialog then also auto-assigned those values again, undoing the user's decision to not import them.

Values without an assignment are now marked as `null` instead, so they survive and the count stays correct. A value that is deliberately mapped to an empty target value (an unchecked checkbox) counts as mapped, both for the badge and for the confirmation prompt on save. This also ticks the "warning popup for boolean value mapping is misleading" item of #1991.

Not covered here: reusing a previous mapping from the import history applies it to a new file, whose values are not necessarily keys of the stored mapping, so the badge cannot count them. Different trigger and repro, to be filed separately.

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

Test on the PR deployment (demo mode is enough, the import runs entirely in the browser). The steps use the education base config: Participant/Child has a `Gender` dropdown, School has a `Private School` checkbox.

Save these two files locally first.

`gender.csv`

```csv
name,gender
Aisha,f
Ben,m
Chandra,nb
Dara,none
Ella,f
```

`school.csv`

```csv
name,private
Green Valley School,yes
Riverbank School,no
```

### 1. The badge counts every value that has no mapping

1. Import, upload `gender.csv`, select the record type Participant, continue.
2. Map the `gender` column to `Gender`. The value mapping dialog opens on its own.
3. All 4 values of the file (`f`, `m`, `nb`, `none`) are pre-filled with themselves. Assign each one properly: `f` to Female, `m` to Male, `nb` and `none` to Non-binary. Save & Close.
   - no badge on the button, the tooltip states that all values are mapped
4. Reopen, clear **one** assignment, Save, confirm the "Ignore values?" prompt.
   - badge shows `1`
5. Reopen, clear **two more** assignments, Save, confirm.
   - badge shows `3` (this showed a wrong, too low number before)
6. Reopen once more.
   - the 3 cleared rows are still empty (before, cleared values were auto-assigned again)
   - after Save & Close the badge still shows `3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discrete-value import mapping to correctly handle unmapped `null` and `undefined` values.
  * Preserved valid mappings for falsy values such as `false` and `0`.
  * Ensured unmapped values remain consistent when saved, serialized, and reopened.
  * Updated mapping counts, badges, and tooltips to accurately reflect unmapped entries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->