### PR TITLE
fix(admin): keep the entity form editor usable when a field group has empty entries

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -133,6 +133,29 @@ describe("AdminEntityFormComponent", () => {
     ]);
   });
 
+  it("should skip empty entries in a field group rather than fail (malformed config)", async () => {
+    const fieldsInView = ["date"];
+    fixture.componentRef.setInput("config", {
+      fieldGroups: [{ fields: [null, ...fieldsInView, undefined] }],
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const noteUserFacingFields = Array.from(TestEntity.schema.entries())
+      .filter(([key, value]) => !value.isInternalField)
+      .sort(([aId, a], [bId, b]) => a.label.localeCompare(b.label))
+      .map(([key]) => key);
+    // identical to a config without the empty entries: they are dropped, everything else still works
+    expect(component.availableFields()).toEqual([
+      component.createNewFieldPlaceholder,
+      component.createNewTextPlaceholder,
+      ...noteUserFacingFields.filter((x) => !fieldsInView.includes(x)),
+    ]);
+    expect(component.dummyForm()).toBeTruthy();
+    expect(component.fieldGroups()).toEqual([{ fields: fieldsInView }]);
+  });
+
   /**
    * Simulate dropping `field` into the drop list `to` (a field group's index or the toolbar).
    * Drags start from the toolbar unless `from` says otherwise.

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -138,7 +138,7 @@ export class AdminEntityFormComponent {
   fieldGroups = linkedSignal<FormConfig | undefined, FieldGroup[]>({
     source: this.config,
     computation: (config, previous) => {
-      const incoming = config?.fieldGroups ?? [];
+      const incoming = dropEmptyFields(config?.fieldGroups ?? []);
       if (
         previous &&
         JSON.stringify(previous.value) === JSON.stringify(incoming)
@@ -598,6 +598,26 @@ export class AdminEntityFormComponent {
   clearSearch() {
     this.searchFilter.setValue("");
   }
+}
+
+/**
+ * Remove empty (null / undefined) entries from the groups' field lists.
+ *
+ * These are not a valid `ColumnConfig` and only ever come from a malformed config, but every
+ * consumer dereferences them (`toFormFieldConfig(field).id`) and would throw on the whole editor.
+ * Dropping them here keeps the rest of the configuration editable so the admin can repair it.
+ */
+function dropEmptyFields(groups: FieldGroup[]): FieldGroup[] {
+  return groups.map((group) =>
+    group?.fields?.some((field) => field === null || field === undefined)
+      ? {
+          ...group,
+          fields: group.fields.filter(
+            (field) => field !== null && field !== undefined,
+          ),
+        }
+      : group,
+  );
 }
 
 /**


### PR DESCRIPTION
- part of #4249

Found by the automated monitoring routine. Sentry: [AAM-DIGITAL-75V](https://aam-digital.sentry.io/issues/AAM-DIGITAL-75V).

## What

`TypeError: Cannot read properties of null (reading 'id')` on `/admin/entity/:entityType/`, 10 Aug 12:31Z, production `3.87.3`, one admin on `freunde-alter-menschen`. Small event count (3) but it takes the **entire entity form editor** down for that entity type — and it fires exactly when the config is malformed, i.e. when the admin most needs the editor to repair it. 12 seconds later that tenant started logging `Invalid config attribute` on every page load and has not stopped (54 events in 24h, including on three public forms) — see #4249 for that side of it.

## Cause

Confirmed in source, not inferred. `ColumnConfig` is `string | FormFieldConfig`, and `toFormFieldConfig` only special-cases the string:

```ts
export function toFormFieldConfig(column: ColumnConfig): FormFieldConfig {
  if (typeof column === "string") {
    return { id: column };
  } else {
    return column;      // <-- null in, null out
  }
}
```

So an empty entry in a field group's `fields` array survives into `computeAvailableFieldsList`:

```ts
const usedFields = this.getUsedFields(this.fieldGroups()).map((x) => toFormFieldConfig(x));
const unusedFields = Array.from(entityType.schema.entries())
  .filter(([key]) => !usedFields.some((x) => x.id === key))   // admin-entity-form.component.ts:261 — throws
```

The stack trace in Sentry lands on exactly this line, via `initForm` → `availableFields`. The rendering path reaches the same problem independently, through `EntityFieldViewComponent._field` → `extendFormFieldConfig` → `entityType.schema.get(fullField.id)`, so guarding only line 261 would just move the crash.

## Change

Drop empty entries where the working copy is derived from the `config` input (`fieldGroups` linked signal). One place covers every consumer — the template, `getUsedFields`, `initForm`, `connectedGroups` — instead of a guard per call site.

An entry that is `null`/`undefined` is not a valid `ColumnConfig` under any interpretation: it has no id, so it can name no field and can render nothing. Dropping it cannot suppress a working field. Groups without empty entries are returned by identity, so the signal's existing "config only re-states what we emitted" short-circuit still holds and nothing re-clones.

This does **not** silently rewrite stored config: `configChange` only updates the parent's in-memory `componentConfig.config`; persistence still requires the admin to save.

## Testing

`npx ng test --configuration=ci --include='src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts'` → **22 passed**, one of them new.

Wider check: `--include='src/app/core/admin/**/*.spec.ts'` → **148 passed / 44 files**. eslint and prettier clean.

The regression test was run against the unpatched component and fails there with the production error verbatim — `TypeError: Cannot read properties of null (reading 'id')` — so it reproduces the reported defect rather than an approximation of it.

Not reproduced manually: it needs a tenant config that already contains the malformed entry.

## PR Checklist

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — covered by unit tests; see the note above
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwMk8QzhJS7fiWa6VQcL2v)_