### PR TITLE
fix(admin): don't offer resetting to base settings for a field being created

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -285,7 +285,7 @@
   <button mat-button mat-dialog-close i18n="Button label">Cancel</button>
   @if (data.overwriteLocally) {
     <div
-      matTooltip="This field does not exist yet, so it has no general settings to reset to."
+      matTooltip="This field does not exist yet, so it has no general settings to reset to. A new field with these settings will be created on the datatype."
       i18n-matTooltip="
         Tooltip explaining why resetting is unavailable while creating a field
       "

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -284,14 +284,23 @@
   <button mat-button (click)="save()" i18n="Button label">Apply</button>
   <button mat-button mat-dialog-close i18n="Button label">Cancel</button>
   @if (data.overwriteLocally) {
-    <button
-      mat-button
-      (click)="resetToBaseFieldSettings()"
-      i18n="Button label"
-      matTooltip="Discard any changes you have made to this field only for this view and reset it to the general settings"
-      i18n-matTooltip
+    <div
+      matTooltip="This field does not exist yet, so it has no general settings to reset to."
+      i18n-matTooltip="
+        Tooltip explaining why resetting is unavailable while creating a field
+      "
+      [matTooltipDisabled]="fieldIdForm.disabled"
     >
-      Reset to base field settings
-    </button>
+      <button
+        mat-button
+        [disabled]="fieldIdForm.enabled"
+        (click)="resetToBaseFieldSettings()"
+        i18n="Button label"
+        matTooltip="Discard any changes you have made to this field only for this view and reset it to the general settings"
+        i18n-matTooltip
+      >
+        Reset to base field settings
+      </button>
+    </div>
   }
 </mat-dialog-actions>

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -484,7 +484,8 @@ export class AdminEntityFormComponent {
    */
   private async createNewField(): Promise<string | undefined> {
     const newField = await this.openFieldConfig({ id: null });
-    if (!newField) {
+    if (!newField?.id) {
+      // without an id there is no field to add
       return undefined;
     }
 


### PR DESCRIPTION
- closes #4249

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

The affected site has already been cleaned up manually, so this PR only covers the safeguard.

**Reproduce the original problem (on master)**

1. Go to Admin -> Templates and Forms -> Public Forms and open a public form.
2. Open the "Configure Fields" tab and click "Edit".
3. Drag "Create New Field" into a field section, type a label (the field id fills in automatically), then click "Reset to base field settings" instead of Apply.
4. Nothing visible happens, so click "Save".
5. Open the browser console and reload: `Invalid config attribute: expected an object. Skipping field.` is logged, and it keeps being logged on every load. The entity config now holds an attribute keyed `undefined` whose value is a string, and nothing in the UI can remove it.

**Verify the fix (on this branch)**

6. Repeat steps 1 to 3. "Reset to base field settings" is now greyed out, with a tooltip explaining that the field does not exist yet.
7. Type and re-edit the label. The button stays disabled (the id is generated from the label, so this used to enable it).
8. Save the form, reload, and check the console: no `Invalid config attribute` warning, and no attribute keyed `undefined` in the config.
9. Click "Edit Field" on a field that is already in the form. "Reset to base field settings" is enabled there, shows its usual tooltip, and still resets the field and closes the dialog.
10. Go to Admin -> Record Types & Data Structures, open the same record type and create a new field there. Unchanged: that editor never showed the reset button, since it edits the record type globally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tooltip explaining why reset settings are unavailable for newly created fields.
  * Reset controls are disabled while entering a new field ID.

* **Bug Fixes**
  * Prevented incomplete field creations from being saved or registered without a valid field ID.
  * Improved handling of cancelled field creation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->