### PR TITLE
refactor: move account_manager role check into UserAdminService

### DIFF
--- a/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.spec.ts
@@ -169,14 +169,15 @@ describe("EntityDeleteService", () => {
   });
 
   it("should skip account deletion silently if current user lacks account_manager role", async () => {
+    // given: UserAdminService rejects the lookup because the current user cannot manage accounts
     const userEntity = new TestEntity();
     TestEntity.enableUserAccounts = true;
-    mockSessionSubject.next({ id: "session-id", name: "test", roles: [] });
-    mockUserAdminService.getUser.mockReturnValue(of({ id: "kc-user-id" }));
+    mockUserAdminService.getUser.mockReturnValue(
+      throwError(() => new UserAdminApiError(403)),
+    );
 
     await service.deleteEntity(userEntity);
 
-    expect(mockUserAdminService.getUser).not.toHaveBeenCalled();
     expect(mockUserAdminService.deleteUser).not.toHaveBeenCalled();
     expect(mockConfirmationDialog.getConfirmation).not.toHaveBeenCalled();
     TestEntity.enableUserAccounts = false;

--- a/src/app/core/entity/entity-actions/entity-delete.service.ts
+++ b/src/app/core/entity/entity-actions/entity-delete.service.ts
@@ -14,7 +14,6 @@ import {
   UserAdminService,
 } from "../../user/user-admin-service/user-admin.service";
 import { UserAccount } from "../../user/user-admin-service/user-account";
-import { SessionSubject } from "../../session/auth/session-info";
 import { itemReferencesId } from "../entity-mapper/entity-relations.service";
 import { firstValueFrom } from "rxjs";
 import { UserAccountActionGuardService } from "../../user/user-admin-service/user-account-action-guard.service";
@@ -37,7 +36,6 @@ export class EntityDeleteService extends CascadingEntityAction {
   private userAdminService = inject(UserAdminService);
   private confirmationDialog = inject(ConfirmationDialogService);
   private readonly accountActionGuard = inject(UserAccountActionGuardService);
-  private readonly sessionInfo = inject(SessionSubject, { optional: true });
 
   /**
    * The actual delete action without user interactions.
@@ -71,12 +69,6 @@ export class EntityDeleteService extends CascadingEntityAction {
   }
 
   private async handleUserAccountDeletion(entity: Entity): Promise<boolean> {
-    const session = this.sessionInfo?.value;
-    if (!session?.roles.includes(UserAdminService.ACCOUNT_MANAGER_ROLE)) {
-      // Cannot manage accounts without admin role — skip silently
-      return true;
-    }
-
     let linkedAccount: UserAccount | null;
     try {
       linkedAccount = await firstValueFrom(

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
@@ -6,19 +6,31 @@ import {
 import { KeycloakAdminService } from "./keycloak-admin.service";
 import { environment } from "../../../../environments/environment.spec";
 import { Role } from "./user-account";
-import { UserAdminApiError } from "./user-admin.service";
+import { UserAdminApiError, UserAdminService } from "./user-admin.service";
 import { Logging } from "app/core/logging/logging.service";
+import { SessionSubject } from "../../session/auth/session-info";
 
 describe("KeycloakAdminService", () => {
   let service: KeycloakAdminService;
   let httpTestingController: HttpTestingController;
+  let sessionSubject: SessionSubject;
 
   const BASE_URL = `${environment.userAdminApi}/admin/realms/${environment.realm}`;
 
   beforeEach(() => {
+    sessionSubject = new SessionSubject();
+    sessionSubject.next({
+      id: "admin",
+      name: "admin",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [KeycloakAdminService],
+      providers: [
+        KeycloakAdminService,
+        { provide: SessionSubject, useValue: sessionSubject },
+      ],
     });
 
     service = TestBed.inject(KeycloakAdminService);
@@ -269,5 +281,33 @@ describe("KeycloakAdminService", () => {
         message: "No internet connection",
       }),
     );
+  });
+
+  it("should error without sending a request if the user cannot manage accounts", async () => {
+    sessionSubject.next({ id: "user", name: "user", roles: [] });
+
+    service.getAllUsers().subscribe({
+      next: () => fail("Should have failed"),
+      error: (error) => {
+        expect(error).toBeInstanceOf(UserAdminApiError);
+        expect(error.status).toBe(403);
+      },
+    });
+
+    httpTestingController.expectNone(`${BASE_URL}/users`);
+  });
+
+  it("should error without sending a request if getUser is called without account_manager role", async () => {
+    sessionSubject.next({ id: "user", name: "user", roles: [] });
+
+    service.getUser("some-entity-id").subscribe({
+      next: () => fail("Should have failed"),
+      error: (error) => {
+        expect(error).toBeInstanceOf(UserAdminApiError);
+        expect(error.status).toBe(403);
+      },
+    });
+
+    httpTestingController.expectNone((req) => req.url === `${BASE_URL}/users`);
   });
 });

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
@@ -310,4 +310,50 @@ describe("KeycloakAdminService", () => {
 
     httpTestingController.expectNone((req) => req.url === `${BASE_URL}/users`);
   });
+
+  it("should error without sending a request if createUser is called without account_manager role", async () => {
+    sessionSubject.next({ id: "user", name: "user", roles: [] });
+
+    service.createUser("test-entity-id", "test@example.com", []).subscribe({
+      next: () => fail("Should have failed"),
+      error: (error) => {
+        expect(error).toBeInstanceOf(UserAdminApiError);
+        expect(error.status).toBe(403);
+      },
+    });
+
+    httpTestingController.expectNone((req) => req.url === `${BASE_URL}/users`);
+  });
+
+  it("should error without sending a request if updateUser is called without account_manager role", async () => {
+    sessionSubject.next({ id: "user", name: "user", roles: [] });
+
+    service.updateUser("test-id", { email: "new@example.com" }).subscribe({
+      next: () => fail("Should have failed"),
+      error: (error) => {
+        expect(error).toBeInstanceOf(UserAdminApiError);
+        expect(error.status).toBe(403);
+      },
+    });
+
+    httpTestingController.expectNone(
+      (req) => req.url === `${BASE_URL}/users/test-id`,
+    );
+  });
+
+  it("should error without sending a request if resendInvitation is called without account_manager role", async () => {
+    sessionSubject.next({ id: "user", name: "user", roles: [] });
+
+    service.resendInvitation("test-id").subscribe({
+      next: () => fail("Should have failed"),
+      error: (error) => {
+        expect(error).toBeInstanceOf(UserAdminApiError);
+        expect(error.status).toBe(403);
+      },
+    });
+
+    httpTestingController.expectNone(
+      (req) => req.url === `${BASE_URL}/users/test-id/execute-actions-email`,
+    );
+  });
 });

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.ts
@@ -170,6 +170,10 @@ export class KeycloakAdminService extends UserAdminService {
   }
 
   override getUser(userEntityId: string): Observable<UserAccount> {
+    if (!this.canManageAccounts()) {
+      return throwError(() => new UserAdminApiError(403));
+    }
+
     return this.findUserBy({
       q: `exact_username:${userEntityId}`,
     }).pipe(
@@ -273,6 +277,10 @@ export class KeycloakAdminService extends UserAdminService {
    * Fetches all users with their roles.
    */
   getAllUsers(): Observable<UserAccount[]> {
+    if (!this.canManageAccounts()) {
+      return throwError(() => new UserAdminApiError(403));
+    }
+
     return this.findUsersBy({}).pipe(
       switchMap((users) => {
         if (users.length === 0) {

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.ts
@@ -55,6 +55,10 @@ export class KeycloakAdminService extends UserAdminService {
     email: string,
     roles: Role[],
   ): Observable<UserAccount> {
+    if (!this.canManageAccounts()) {
+      return throwError(() => new UserAdminApiError(403));
+    }
+
     const newKeycloakUser = new KeycloakUserDto(email, userEntityId);
 
     return this.http.post(`${this.keycloakUrl}/users`, newKeycloakUser).pipe(
@@ -113,6 +117,10 @@ export class KeycloakAdminService extends UserAdminService {
     userAccountId: string,
     updatedUser: Partial<UserAccount>,
   ): Observable<{ userUpdated: boolean }> {
+    if (!this.canManageAccounts()) {
+      return throwError(() => new UserAdminApiError(403));
+    }
+
     return this.getUserByAccountId(userAccountId).pipe(
       switchMap((userAccount) =>
         this.updateKeycloakUser(
@@ -163,6 +171,10 @@ export class KeycloakAdminService extends UserAdminService {
   }
 
   override resendInvitation(userAccountId: string): Observable<void> {
+    if (!this.canManageAccounts()) {
+      return throwError(() => new UserAdminApiError(403));
+    }
+
     return this.sendEmail(userAccountId, "VERIFY_EMAIL").pipe(
       map(() => undefined),
       catchError((err) => throwError(() => this.transformStandardError(err))),

--- a/src/app/core/user/user-admin-service/user-admin.service.ts
+++ b/src/app/core/user/user-admin-service/user-admin.service.ts
@@ -1,5 +1,7 @@
+import { inject } from "@angular/core";
 import { Observable } from "rxjs";
 import { Role, UserAccount } from "./user-account";
+import { SessionSubject } from "../../session/auth/session-info";
 
 /**
  * Admin functionalities to manage users in an authentication server like Keycloak.
@@ -9,6 +11,20 @@ export abstract class UserAdminService {
    * Users with this role can create and update other accounts.
    */
   static readonly ACCOUNT_MANAGER_ROLE = "account_manager";
+
+  private readonly sessionInfo = inject(SessionSubject, { optional: true });
+
+  /**
+   * Whether the current user has the role required to manage accounts
+   * (e.g. list, create, update or delete accounts) on the authentication server.
+   */
+  canManageAccounts(): boolean {
+    return (
+      this.sessionInfo?.value?.roles?.includes(
+        UserAdminService.ACCOUNT_MANAGER_ROLE,
+      ) ?? false
+    );
+  }
 
   /**
    * Get the user account details of the user linked to the given entity.
@@ -91,6 +107,8 @@ export class UserAdminApiError extends Error {
 
   private generateDefaultMessage(status: number) {
     switch (status) {
+      case 403:
+        return $localize`:User API error:You do not have permission to manage user accounts.`;
       case 404:
         return $localize`:User API error:The entry does not exist.`;
       case 409:


### PR DESCRIPTION
## Summary
Moves the account_manager role check logic into UserAdminService, improving code organization and reducing duplication across delete operations.

## Test plan
- [ ] Verify user admin operations respect account_manager role requirements
- [ ] Confirm entity delete operations still properly validate roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission checks for account-management actions.
  * Unauthorized account and user lookups now return a clear access-denied error without making requests.
  * Added localized messaging for permission errors.

* **Bug Fixes**
  * Improved account deletion behavior when linked-account access is unavailable.
  * Prevented account deletion confirmation when required permissions are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->