### PR TITLE
fix(admin): keep field configs unchanged while rendering the form preview

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.spec.ts
@@ -260,6 +260,30 @@ describe("AdminEntityFormComponent", () => {
     expect(JSON.stringify(testConfig)).toBe(configBefore);
   });
 
+  it("should keep a field that only overwrites some settings unchanged while rendering the preview", async () => {
+    // the preview is rendered before the dummy entity is available,
+    // so the field config must not be completed with details from its schema
+    const partiallyOverwrittenField = {
+      id: "name",
+      displayFullLengthLabel: true,
+    };
+    const previewFixture = TestBed.createComponent(AdminEntityFormComponent);
+    previewFixture.componentRef.setInput("config", {
+      fieldGroups: [{ fields: [partiallyOverwrittenField, "other"] }],
+    });
+    previewFixture.componentRef.setInput("entityType", TestEntity);
+
+    previewFixture.detectChanges();
+    await previewFixture.whenStable();
+
+    expect(previewFixture.componentInstance.fieldGroups()[0].fields[0]).toEqual(
+      {
+        id: "name",
+        displayFullLengthLabel: true,
+      },
+    );
+  });
+
   it("should reorder the field groups", () => {
     component.dropFieldGroups({
       previousIndex: 0,

--- a/src/app/core/entity/entity-field-edit/entity-field-edit.component.spec.ts
+++ b/src/app/core/entity/entity-field-edit/entity-field-edit.component.spec.ts
@@ -59,6 +59,20 @@ describe("EntityFieldEditComponent", () => {
     expect(mockFormService.extendFormFieldConfig).not.toHaveBeenCalled();
   });
 
+  it("should not modify the given field config while extending it without an entity", () => {
+    mockSchemaService.getComponent.mockReturnValue("EditText");
+    const fieldConfig = { id: "testField", displayFullLengthLabel: true };
+    fixture.componentRef.setInput("field", fieldConfig);
+    fixture.componentRef.setInput("entity", undefined);
+
+    expect(component._field().editComponent).toBe("EditText");
+    // the config object comes from the app config and must not be changed here
+    expect(fieldConfig).toEqual({
+      id: "testField",
+      displayFullLengthLabel: true,
+    });
+  });
+
   it("should fall back to the read-only view if the form has no control for the field", () => {
     // e.g. after the entity schema was edited in the admin UI, a configured field
     // can be missing from the already-built formGroup

--- a/src/app/core/entity/entity-field-edit/entity-field-edit.component.ts
+++ b/src/app/core/entity/entity-field-edit/entity-field-edit.component.ts
@@ -81,7 +81,8 @@ export class EntityFieldEditComponent<T extends Entity = Entity> {
         entity.getConstructor(),
       );
     }
-    const result = toFormFieldConfig(field);
+    // copy, so that the given config (which may come from the app config) is not changed here
+    const result = { ...toFormFieldConfig(field) };
     // add editComponent (because we cannot rely on the entity's schema yet for a new field)
     result.editComponent =
       result.editComponent ??


### PR DESCRIPTION
- closes #4259

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Cause

`EntityFieldEditComponent` completes a field config with an `editComponent` when no entity is available yet. `toFormFieldConfig` returns the given object unchanged for an object input, so that value was written straight into the config object the component had been handed, which in the admin UI is the working copy of the app config.

A field that only overwrites some settings has no `dataType` of its own, so the lookup fell through to the default datatype and produced `"editComponent": "EditText"`. The next save persisted it, which breaks the dropdown of configurable-enum fields and renders text blocks as input fields.

This only became reachable with the fix for #4180: `dummyEntity` used to be assigned synchronously at the start of `initForm()`, so the preview never rendered without an entity. It is now set together with `dummyForm` after the `await`, which leaves exactly one render pass in that state.

Fields configured as a plain string were never affected, because `toFormFieldConfig` builds a throwaway object for them. That matches the issue: only partly overwritten fields break.


## Manual Testing Steps

Sample data: **Education Project** demo, logged in as an admin.

**Reproduce the problem (on master)**

1. Go to Settings > Record Types & Data Structures > Student > Public Forms and open the "Example form".
2. Open the "Configure Fields" tab, click "Edit", remove the "Phone Number" field and click "Save".
3. Open the public form link. The "Admission" field, which nobody touched, is now a plain text box showing raw text like `Wed Aug 12 2026 17:25:42 GMT+0530 (India Standard Time)` instead of a date field.

**Verify the fix (on this branch)**

1. Repeat steps 1 and 2 above.
2. Open the public form link. "Admission" is a proper date field with a calendar icon, and "Gender" is a dropdown.
3. The edit itself still worked: "Phone Number" is gone from the form.
4. Re-open the "Configure Fields" tab and save again. Nothing new is added to the fields.

**Also worth checking**

- Add a text block to a public form, save, re-open the form config, remove an unrelated field and save again. The text block still shows as text on the public form and does not turn into an input field.
- The "Details View & Fields" editor of a record type still behaves as before (fields render, drag and drop works, editing a field still applies).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented field configuration from being unintentionally modified when preparing entity field editors.
  * Preserved partially customized field settings when preview data is unavailable.
  * Ensured configured edit components continue to resolve correctly without an entity.

* **Tests**
  * Added regression coverage for field configuration preservation and editor resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->