### PR TITLE
fix(Admin UI): correctly include SiteSetting and PublicFormConfig for AI agent download

### DIFF
--- a/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.html
+++ b/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.html
@@ -17,6 +17,7 @@
       <li i18n>Application Configuration</li>
       <li i18n>Permissions</li>
       <li i18n>Configurable Enums</li>
+      <li i18n>Site Settings</li>
       <li i18n>Report Configurations</li>
       <li i18n>Public Form Configurations</li>
     </ul>

--- a/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.spec.ts
+++ b/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.spec.ts
@@ -4,20 +4,30 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { DownloadService } from "../../export/download-service/download.service";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
+import { Config } from "../../config/config";
+import { ConfigurableEnum } from "../../basic-datatypes/configurable-enum/configurable-enum";
+import { SiteSettings } from "../../site-settings/site-settings";
+import { ReportEntity } from "../../../features/reporting/report-config";
+import { PublicFormConfig } from "../../../features/public-form/public-form-config";
 
 describe("AdminAiAgentComponent", () => {
   let component: AdminAiAgentComponent;
   let fixture: ComponentFixture<AdminAiAgentComponent>;
+  let mockEntityMapper: {
+    loadType: ReturnType<typeof vi.fn>;
+    load: ReturnType<typeof vi.fn>;
+  };
+  let mockDownloadService: { triggerDownload: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
-    const mockEntityMapper = {
+    mockEntityMapper = {
       loadType: vi.fn().mockName("EntityMapperService.loadType"),
       load: vi.fn().mockName("EntityMapperService.load"),
     };
     mockEntityMapper.loadType.mockReturnValue(Promise.resolve([]));
     mockEntityMapper.load.mockReturnValue(Promise.resolve(null));
 
-    const mockDownloadService = {
+    mockDownloadService = {
       triggerDownload: vi.fn().mockName("DownloadService.triggerDownload"),
     };
     mockDownloadService.triggerDownload.mockReturnValue(Promise.resolve());
@@ -43,5 +53,50 @@ describe("AdminAiAgentComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("downloads all AI context document sources", async () => {
+    const configDocument = { sentinel: "config" };
+    const permissionsDocument = { sentinel: "permissions" };
+    const configurableEnumDocument = { sentinel: "configurable-enum" };
+    const siteSettingsDocument = { sentinel: "site-settings" };
+    const reportDocument = { sentinel: "report" };
+    const publicFormDocument = { sentinel: "public-form" };
+
+    mockEntityMapper.load.mockImplementation((_entityType, key) =>
+      Promise.resolve(
+        key === Config.CONFIG_KEY ? configDocument : permissionsDocument,
+      ),
+    );
+    mockEntityMapper.loadType.mockImplementation((entityType) => {
+      if (entityType === ConfigurableEnum) {
+        return Promise.resolve([configurableEnumDocument]);
+      }
+      if (entityType === SiteSettings) {
+        return Promise.resolve([siteSettingsDocument]);
+      }
+      if (entityType === ReportEntity) {
+        return Promise.resolve([reportDocument]);
+      }
+      if (entityType === PublicFormConfig) {
+        return Promise.resolve([publicFormDocument]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await component.downloadAiContext();
+
+    expect(mockDownloadService.triggerDownload).toHaveBeenCalledWith(
+      [
+        configDocument,
+        permissionsDocument,
+        configurableEnumDocument,
+        siteSettingsDocument,
+        reportDocument,
+        publicFormDocument,
+      ],
+      "json",
+      expect.any(String),
+    );
   });
 });

--- a/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.spec.ts
+++ b/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.spec.ts
@@ -7,8 +7,8 @@ import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testi
 import { Config } from "../../config/config";
 import { ConfigurableEnum } from "../../basic-datatypes/configurable-enum/configurable-enum";
 import { SiteSettings } from "../../site-settings/site-settings";
-import { ReportEntity } from "../../../features/reporting/report-config";
-import { PublicFormConfig } from "../../../features/public-form/public-form-config";
+import { ReportEntity } from "#src/app/features/reporting/report-config";
+import { PublicFormConfig } from "#src/app/features/public-form/public-form-config";
 
 describe("AdminAiAgentComponent", () => {
   let component: AdminAiAgentComponent;
@@ -19,12 +19,31 @@ describe("AdminAiAgentComponent", () => {
   };
   let mockDownloadService: { triggerDownload: ReturnType<typeof vi.fn> };
 
+  const configurableEnumDocument = { sentinel: "configurable-enum" };
+  const siteSettingsDocument = { sentinel: "site-settings" };
+  const reportDocument = { sentinel: "report" };
+  const publicFormDocument = { sentinel: "public-form" };
+
   beforeEach(async () => {
     mockEntityMapper = {
       loadType: vi.fn().mockName("EntityMapperService.loadType"),
       load: vi.fn().mockName("EntityMapperService.load"),
     };
-    mockEntityMapper.loadType.mockReturnValue(Promise.resolve([]));
+    mockEntityMapper.loadType.mockImplementation((entityType) => {
+      if (entityType === ConfigurableEnum) {
+        return Promise.resolve([configurableEnumDocument]);
+      }
+      if (entityType === SiteSettings) {
+        return Promise.resolve([siteSettingsDocument]);
+      }
+      if (entityType === ReportEntity) {
+        return Promise.resolve([reportDocument]);
+      }
+      if (entityType === PublicFormConfig) {
+        return Promise.resolve([publicFormDocument]);
+      }
+      return Promise.resolve([]);
+    });
     mockEntityMapper.load.mockReturnValue(Promise.resolve(null));
 
     mockDownloadService = {
@@ -58,31 +77,12 @@ describe("AdminAiAgentComponent", () => {
   it("downloads all AI context document sources", async () => {
     const configDocument = { sentinel: "config" };
     const permissionsDocument = { sentinel: "permissions" };
-    const configurableEnumDocument = { sentinel: "configurable-enum" };
-    const siteSettingsDocument = { sentinel: "site-settings" };
-    const reportDocument = { sentinel: "report" };
-    const publicFormDocument = { sentinel: "public-form" };
 
     mockEntityMapper.load.mockImplementation((_entityType, key) =>
       Promise.resolve(
         key === Config.CONFIG_KEY ? configDocument : permissionsDocument,
       ),
     );
-    mockEntityMapper.loadType.mockImplementation((entityType) => {
-      if (entityType === ConfigurableEnum) {
-        return Promise.resolve([configurableEnumDocument]);
-      }
-      if (entityType === SiteSettings) {
-        return Promise.resolve([siteSettingsDocument]);
-      }
-      if (entityType === ReportEntity) {
-        return Promise.resolve([reportDocument]);
-      }
-      if (entityType === PublicFormConfig) {
-        return Promise.resolve([publicFormDocument]);
-      }
-      return Promise.resolve([]);
-    });
 
     await component.downloadAiContext();
 
@@ -90,6 +90,25 @@ describe("AdminAiAgentComponent", () => {
       [
         configDocument,
         permissionsDocument,
+        configurableEnumDocument,
+        siteSettingsDocument,
+        reportDocument,
+        publicFormDocument,
+      ],
+      "json",
+      expect.any(String),
+    );
+  });
+
+  it("omits config and permissions documents that fail to load", async () => {
+    mockEntityMapper.load.mockImplementation(() =>
+      Promise.reject(new Error("document not found")),
+    );
+
+    await component.downloadAiContext();
+
+    expect(mockDownloadService.triggerDownload).toHaveBeenCalledWith(
+      [
         configurableEnumDocument,
         siteSettingsDocument,
         reportDocument,

--- a/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.ts
+++ b/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.ts
@@ -7,8 +7,8 @@ import { ViewTitleComponent } from "../../common-components/view-title/view-titl
 import { DownloadService } from "../../export/download-service/download.service";
 import { Config } from "../../config/config";
 import { ConfigurableEnum } from "../../basic-datatypes/configurable-enum/configurable-enum";
-import { ReportEntity } from "../../../features/reporting/report-config";
-import { PublicFormConfig } from "../../../features/public-form/public-form-config";
+import { ReportEntity } from "#src/app/features/reporting/report-config";
+import { PublicFormConfig } from "#src/app/features/public-form/public-form-config";
 import moment from "moment";
 import { SiteSettings } from "../../site-settings/site-settings";
 

--- a/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.ts
+++ b/src/app/core/admin/admin-ai-agent/admin-ai-agent.component.ts
@@ -41,25 +41,22 @@ export class AdminAiAgentComponent {
    * them as a single JSON file suitable for use as AI agent context.
    */
   async downloadAiContext(): Promise<void> {
-    const [configurableEnums, reportConfigs, publicFormConfigs] =
-      await Promise.all([
-        this.entityMapper.loadType(ConfigurableEnum),
-        this.entityMapper.loadType(SiteSettings),
-        this.entityMapper.loadType(ReportEntity),
-        this.entityMapper.loadType(PublicFormConfig),
-      ]);
-
-    const configDocs = await Promise.all([
-      this.entityMapper.load(Config, Config.CONFIG_KEY).catch(() => null),
-      this.entityMapper.load(Config, Config.PERMISSION_KEY).catch(() => null),
-    ]);
-
-    const docs = [
-      ...configDocs.filter(Boolean),
-      ...configurableEnums,
-      ...reportConfigs,
-      ...publicFormConfigs,
+    const documentSources = [
+      this.entityMapper
+        .load(Config, Config.CONFIG_KEY)
+        .then((document) => [document])
+        .catch(() => []),
+      this.entityMapper
+        .load(Config, Config.PERMISSION_KEY)
+        .then((document) => [document])
+        .catch(() => []),
+      this.entityMapper.loadType(ConfigurableEnum),
+      this.entityMapper.loadType(SiteSettings),
+      this.entityMapper.loadType(ReportEntity),
+      this.entityMapper.loadType(PublicFormConfig),
     ];
+
+    const docs = (await Promise.all(documentSources)).flat();
 
     await this.downloadService.triggerDownload(
       docs,


### PR DESCRIPTION
## Summary
- Refactor the downloadAiContext method to use a more readable approach for handling Promise.all with error scenarios
- Flatten document sources into a single array after awaiting all promises

## Test plan
- [x] Verify the AI context download still works correctly
- [x] Ensure error handling for missing Config documents is preserved

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI context downloads now include Site Settings.
  * Context exports gather all configured documents in parallel and provide a unified JSON download.

* **Bug Fixes**
  * Improved handling of document-loading failures so available context can still be downloaded when individual documents cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->