### PR TITLE
feat(Admin UI): reset system and empty data functions

### DIFF
--- a/src/app/core/admin/admin-overview/admin-overview.component.html
+++ b/src/app/core/admin/admin-overview/admin-overview.component.html
@@ -236,13 +236,31 @@
         <span matListItemTitle i18n>PouchDB Debug: Send to console.log()</span>
       </mat-list-item>
       <mat-list-item
-        (click)="clearDatabase()"
+        (click)="emptyRecords()"
         button
-        matTooltip="Delete all data in the database."
+        matTooltip="Delete all data while keeping the system configuration and the profiles of users with an account."
         i18n-matTooltip
         matTooltipPosition="before"
       >
-        <span matListItemTitle i18n>Empty Database</span>
+        <span matListItemTitle class="color-error" i18n>Empty Records</span>
+      </mat-list-item>
+      <mat-list-item
+        (click)="resetSystem()"
+        button
+        matTooltip="Delete everything, including all records and the complete system configuration, keeping only your own user profile, to set up this system from scratch."
+        i18n-matTooltip
+        matTooltipPosition="before"
+      >
+        <span matListItemTitle class="color-error" i18n>Reset System</span>
+      </mat-list-item>
+      <mat-list-item
+        (click)="resetLocalDevice()"
+        button
+        matTooltip="Clear all data cached on this device and re-synchronize from the server. Does not affect other users or delete anything on the server."
+        i18n-matTooltip
+        matTooltipPosition="before"
+      >
+        <span matListItemTitle i18n>Reset Local Device</span>
       </mat-list-item>
       <mat-list-item
         [routerLink]="['/admin/conflicts']"

--- a/src/app/core/admin/admin-overview/admin-overview.component.spec.ts
+++ b/src/app/core/admin/admin-overview/admin-overview.component.spec.ts
@@ -229,7 +229,7 @@ describe("AdminComponent", () => {
     expect(mockSystemResetService.resetSystem).toHaveBeenCalled();
   });
 
-  it("should delegate resetting the local device to the backup service", async () => {
+  it("should delegate resetting the local device to the local device reset service", async () => {
     await component.resetLocalDevice();
 
     expect(mockLocalDeviceResetService.resetLocalDevice).toHaveBeenCalled();

--- a/src/app/core/admin/admin-overview/admin-overview.component.spec.ts
+++ b/src/app/core/admin/admin-overview/admin-overview.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminOverviewComponent } from "./admin-overview.component";
 import { BackupService } from "../backup/backup.service";
+import { SystemResetService } from "../system-reset/system-reset.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 import { ConfigService } from "../../config/config.service";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { SessionType } from "../../session/session-type";
@@ -20,10 +22,19 @@ describe("AdminComponent", () => {
     clearDatabase: vi.fn(),
     restoreData: vi.fn(),
   };
+  const mockLocalDeviceResetService = {
+    resetLocalDevice: vi.fn(),
+  };
+  const mockSystemResetService = {
+    emptyRecords: vi.fn(),
+    resetSystem: vi.fn(),
+  };
   let mockDownloadService: any;
 
   const confirmationDialogMock = {
     getConfirmation: vi.fn(),
+    getConfirmationWithKeyword: vi.fn(),
+    showProgressDialog: vi.fn().mockReturnValue({ close: vi.fn() }),
   };
 
   function createFileReaderMock(result: string = "") {
@@ -44,6 +55,9 @@ describe("AdminComponent", () => {
   }
 
   beforeEach(async () => {
+    // the mocks above are shared across tests, so their recorded calls have to be reset
+    vi.clearAllMocks();
+
     environment.session_type = SessionType.mock;
     mockDownloadService = {
       triggerDownload: vi.fn(),
@@ -53,6 +67,11 @@ describe("AdminComponent", () => {
       imports: [AdminOverviewComponent, MockedTestingModule.withState()],
       providers: [
         { provide: BackupService, useValue: mockBackupService },
+        { provide: SystemResetService, useValue: mockSystemResetService },
+        {
+          provide: LocalDeviceResetService,
+          useValue: mockLocalDeviceResetService,
+        },
         {
           provide: ConfirmationDialogService,
           useValue: confirmationDialogMock,
@@ -197,13 +216,22 @@ describe("AdminComponent", () => {
     expect(mockBackupService.restoreData).toHaveBeenCalled();
   });
 
-  it("should open dialog when clearing database", async () => {
-    mockBackupService.getDatabaseExport.mockResolvedValue([]);
-    confirmationDialogMock.getConfirmation.mockResolvedValue(true);
+  // detailed behavior of these bulk-delete actions is covered by SystemResetService's own spec
+  it("should delegate emptying records to the system reset service", async () => {
+    await component.emptyRecords();
 
-    await component.clearDatabase();
-    expect(mockBackupService.getDatabaseExport).toHaveBeenCalled();
-    expect(confirmationDialogMock.getConfirmation).toHaveBeenCalled();
-    expect(mockBackupService.clearDatabase).toHaveBeenCalled();
+    expect(mockSystemResetService.emptyRecords).toHaveBeenCalled();
+  });
+
+  it("should delegate resetting the system to the system reset service", async () => {
+    await component.resetSystem();
+
+    expect(mockSystemResetService.resetSystem).toHaveBeenCalled();
+  });
+
+  it("should delegate resetting the local device to the backup service", async () => {
+    await component.resetLocalDevice();
+
+    expect(mockLocalDeviceResetService.resetLocalDevice).toHaveBeenCalled();
   });
 });

--- a/src/app/core/admin/admin-overview/admin-overview.component.ts
+++ b/src/app/core/admin/admin-overview/admin-overview.component.ts
@@ -55,8 +55,8 @@ import { Logging } from "#src/app/core/logging/logging.service";
 })
 export class AdminOverviewComponent {
   private backupService = inject(BackupService);
-  private systemResetService = inject(SystemResetService);
-  private localDeviceResetService = inject(LocalDeviceResetService);
+  private readonly systemResetService = inject(SystemResetService);
+  private readonly localDeviceResetService = inject(LocalDeviceResetService);
   private downloadService = inject(DownloadService);
   private dbResolver = inject(DatabaseResolverService);
   private confirmationDialog = inject(ConfirmationDialogService);

--- a/src/app/core/admin/admin-overview/admin-overview.component.ts
+++ b/src/app/core/admin/admin-overview/admin-overview.component.ts
@@ -7,6 +7,8 @@ import {
 } from "@angular/core";
 import { AdminSectionStateService } from "./admin-section-state.service";
 import { BackupService } from "../backup/backup.service";
+import { SystemResetService } from "../system-reset/system-reset.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { ConfigService } from "../../config/config.service";
@@ -53,6 +55,8 @@ import { Logging } from "#src/app/core/logging/logging.service";
 })
 export class AdminOverviewComponent {
   private backupService = inject(BackupService);
+  private systemResetService = inject(SystemResetService);
+  private localDeviceResetService = inject(LocalDeviceResetService);
   private downloadService = inject(DownloadService);
   private dbResolver = inject(DatabaseResolverService);
   private confirmationDialog = inject(ConfirmationDialogService);
@@ -235,31 +239,15 @@ export class AdminOverviewComponent {
     return target.files[0];
   }
 
-  /**
-   * Reset the database removing all entities except user accounts.
-   */
-  async clearDatabase() {
-    const restorePoint = await this.backupService.getDatabaseExport();
+  async emptyRecords() {
+    await this.systemResetService.emptyRecords();
+  }
 
-    const confirmed = await this.confirmationDialog.getConfirmation(
-      `Empty complete database?`,
-      `Are you sure you want to clear the database? This will delete all existing records in the database!`,
-    );
+  async resetSystem() {
+    await this.systemResetService.resetSystem();
+  }
 
-    if (!confirmed) {
-      return;
-    }
-
-    await this.backupService.clearDatabase();
-
-    const snackBarRef = this.snackBar.open(`Import completed`, "Undo", {
-      duration: 8000,
-    });
-    snackBarRef
-      .onAction()
-      .pipe(untilDestroyed(this))
-      .subscribe(async () => {
-        await this.backupService.restoreData(restorePoint, true);
-      });
+  async resetLocalDevice() {
+    await this.localDeviceResetService.resetLocalDevice();
   }
 }

--- a/src/app/core/admin/admin-overview/admin-overview.stories.ts
+++ b/src/app/core/admin/admin-overview/admin-overview.stories.ts
@@ -10,6 +10,8 @@ import { AdminOverviewComponent } from "./admin-overview.component";
 import { AdminOverviewService } from "./admin-overview.service";
 import { AlertService } from "../../alerts/alert.service";
 import { BackupService } from "../backup/backup.service";
+import { SystemResetService } from "../system-reset/system-reset.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { ConfigService } from "../../config/config.service";
@@ -31,12 +33,18 @@ const mockBackupService = {
   restoreData: () => Promise.resolve(),
 };
 
+const mockSystemResetService = {
+  emptyRecords: () => Promise.resolve(),
+  resetSystem: () => Promise.resolve(),
+};
+
 const mockDownloadService = {
   triggerDownload: () => Promise.resolve(),
 };
 
 const mockConfirmationDialogService = {
   getConfirmation: () => Promise.resolve(true),
+  getConfirmationWithKeyword: () => Promise.resolve(true),
   showProgressDialog: () => ({ close: () => {} }),
 };
 
@@ -78,6 +86,11 @@ export default {
         AdminOverviewService,
         { provide: AlertService, useValue: mockAlertService },
         { provide: BackupService, useValue: mockBackupService },
+        { provide: SystemResetService, useValue: mockSystemResetService },
+        {
+          provide: LocalDeviceResetService,
+          useValue: { resetLocalDevice: () => Promise.resolve() },
+        },
         { provide: DownloadService, useValue: mockDownloadService },
         {
           provide: ConfirmationDialogService,

--- a/src/app/core/admin/backup/backup.service.spec.ts
+++ b/src/app/core/admin/backup/backup.service.spec.ts
@@ -7,10 +7,8 @@ import { DataTransformationService } from "../../export/data-transformation-serv
 import { MemoryPouchDatabase } from "../../database/pouchdb/memory-pouch-database";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
 import { SyncStateSubject } from "app/core/session/session-type";
-import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
-import { of } from "rxjs";
-import { LOCATION_TOKEN } from "../../../utils/di-tokens";
-import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
+// import the entity types used in the specs below, so that they are registered
+import "../../config/config";
 
 describe("BackupService", () => {
   let db: PouchDatabase;
@@ -31,7 +29,6 @@ describe("BackupService", () => {
           provide: DatabaseResolverService,
           useValue: { getDatabase: () => db },
         },
-        { provide: LOCATION_TOKEN, useValue: {} },
       ],
     });
 
@@ -40,24 +37,28 @@ describe("BackupService", () => {
 
   afterEach(async () => {
     await db.destroy();
-    vi.unstubAllGlobals();
-    sessionStorage.removeItem(RESET_PENDING_KEY);
   });
 
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
 
-  it("clearDatabase should remove all records", async () => {
+  it("clearDatabase should remove all records but the config", async () => {
     await db.put({ _id: "Test:1", test: 1 });
-
-    const res = await db.getAll();
-    expect(res).toHaveLength(1);
+    await db.put({ _id: "Config:CONFIG_ENTITY", data: {} });
 
     await service.clearDatabase();
 
     const resAfter = await db.getAll();
-    expect(resAfter).toHaveLength(0);
+    expect(resAfter.map((doc) => doc._id)).toEqual(["Config:CONFIG_ENTITY"]);
+  });
+
+  it("clearDatabase should remove database indices, which are part of the restored backup", async () => {
+    await db.put({ _id: "_design/some_index", views: {} });
+
+    await service.clearDatabase();
+
+    expect(await db.getAll()).toEqual([]);
   });
 
   it("getDatabaseExport should return all records", async () => {
@@ -130,20 +131,6 @@ describe("BackupService", () => {
     expect(res).toHaveLength(1);
     expect(res[0].other, "empty property was added anyway").toBeUndefined();
     expect(res.map(ignoreRevProperty)).toEqual([{ _id: "Test:1", test: 1 }]);
-  });
-
-  it("should reset the application after confirmation", async () => {
-    const confirmationDialog = TestBed.inject(ConfirmationDialogService);
-    vi.spyOn(confirmationDialog, "getConfirmation").mockReturnValue({
-      afterClosed: () => of(true),
-    } as any);
-    localStorage.setItem("someItem", "someValue");
-
-    await service.resetApplication();
-
-    expect(localStorage.getItem("someItem")).toBeNull();
-    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBe("1");
-    expect(TestBed.inject(LOCATION_TOKEN).pathname).toBe("");
   });
 
   function ignoreRevProperty(x) {

--- a/src/app/core/admin/backup/backup.service.ts
+++ b/src/app/core/admin/backup/backup.service.ts
@@ -2,25 +2,21 @@ import { inject, Injectable } from "@angular/core";
 import { Database } from "../../database/database";
 import { Config } from "../../config/config";
 import { DatabaseResolverService } from "../../database/database-resolver.service";
-import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
-import { LOCATION_TOKEN, LOCAL_STORAGE_TOKEN } from "../../../utils/di-tokens";
-import { Logging } from "../../logging/logging.service";
-import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
 
 /**
  * Create and load backups of the database.
+ *
+ * This only reads and writes the raw documents.
+ * For the admin actions to empty or reset a system see the SystemResetService,
+ * for clearing the data cached on the current device see the LocalDeviceResetService.
  */
 @Injectable({
   providedIn: "root",
 })
 export class BackupService {
-  private readonly localStorage = inject(LOCAL_STORAGE_TOKEN);
   private dbResolver = inject(DatabaseResolverService);
 
   private db: Database;
-
-  private readonly confirmationDialog = inject(ConfirmationDialogService);
-  private readonly location = inject(LOCATION_TOKEN);
 
   constructor() {
     this.db = this.dbResolver.getDatabase();
@@ -36,19 +32,22 @@ export class BackupService {
   }
 
   /**
-   * Removes all but the config of the database
+   * Removes all but the config of the database.
+   *
+   * This is used to wipe the database before restoring a backup file.
+   * The config is kept so that restoring a backup that does not contain a config
+   * does not leave the system unusable.
+   *
+   * The database indices are removed as well. They are part of the backup that is
+   * restored immediately afterwards, so they do not have to be rebuilt from scratch.
    *
    * @returns Promise<any> a promise that resolves after all remove operations are done
    */
   async clearDatabase(): Promise<void> {
-    const allDocs = await this.db.getAll();
-    for (const row of allDocs) {
-      if (row._id.startsWith(Config.ENTITY_TYPE + ":")) {
-        // skip config in order to not break login!
-        continue;
-      }
-      await this.db.remove(row);
-    }
+    // skip config in order to not break login!
+    await this.db.removeAll(
+      (doc) => !doc._id.startsWith(Config.ENTITY_TYPE + ":"),
+    );
   }
 
   /**
@@ -64,28 +63,5 @@ export class BackupService {
       delete record._rev;
       await this.db.put(record, forceUpdate);
     }
-  }
-
-  async resetApplication() {
-    const choice = await this.confirmationDialog.getConfirmation(
-      $localize`:Reset Application Confirmation:Reset Application`,
-      $localize`:Reset Application Confirmation:Are you sure you want to reset the application? This will delete all application data from your device and you will have to synchronize again.`,
-    );
-    if (!choice) {
-      return;
-    }
-
-    // deleting ALL local data (incl. possibly unsynced docs) - log for traceability of possible data loss
-    Logging.warn(
-      "Resetting application: user confirmed deletion of all local data",
-    );
-
-    // Reload the page first to kill all PouchDB connections, in-flight sync,
-    // view indexing, and other async operations. IDB databases are deleted on
-    // the fresh page by `runPendingReset()` (before Angular bootstraps) where no
-    // connections exist, avoiding race conditions with PouchDB's IDB transactions.
-    this.localStorage.clear();
-    sessionStorage.setItem(RESET_PENDING_KEY, "1");
-    this.location.pathname = "";
   }
 }

--- a/src/app/core/admin/system-reset/system-reset.service.spec.ts
+++ b/src/app/core/admin/system-reset/system-reset.service.spec.ts
@@ -1,0 +1,348 @@
+import type { Mock } from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+
+import { SystemResetService } from "./system-reset.service";
+import { BackupService } from "../backup/backup.service";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { LOCATION_TOKEN, NAVIGATOR_TOKEN } from "../../../utils/di-tokens";
+import { PouchDatabase } from "../../database/pouchdb/pouch-database";
+import { MemoryPouchDatabase } from "../../database/pouchdb/memory-pouch-database";
+import { DatabaseResolverService } from "../../database/database-resolver.service";
+import { SyncStateSubject } from "app/core/session/session-type";
+import {
+  DatabaseEntity,
+  entityRegistry,
+  EntityRegistry,
+} from "../../entity/database-entity.decorator";
+import { Entity } from "../../entity/model/entity";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { UserAdminService } from "../../user/user-admin-service/user-admin.service";
+import { SessionSubject } from "../../session/auth/session-info";
+// import the entity types used in the specs below, so that they are registered
+import "../../config/config";
+import "../../basic-datatypes/configurable-enum/configurable-enum";
+import "../../site-settings/site-settings";
+import "../../import/import-metadata";
+import "../../../features/reporting/report-config";
+
+/** a record type that login accounts can be linked to (i.e. holding "user profiles") */
+@DatabaseEntity("SystemResetUserProfileTestEntity")
+class SystemResetUserProfileTestEntity extends Entity {
+  static override enableUserAccounts = true;
+}
+
+describe("SystemResetService", () => {
+  let service: SystemResetService;
+  let db: PouchDatabase;
+  let mockUserAdminService: { getAllUsers: Mock };
+  let sessionSubject: SessionSubject;
+
+  const mockBackupService = {
+    getDatabaseExport: vi.fn(),
+    restoreData: vi.fn(),
+  };
+  const mockLocation = { pathname: "/admin" };
+  const mockNavigator = { onLine: true };
+  let onActionSubscriber: () => any;
+  const mockSnackBarRef = {
+    onAction: vi.fn().mockReturnValue({
+      subscribe: (fn: () => any) => (onActionSubscriber = fn),
+    }),
+  };
+  const mockSnackBar = {
+    open: vi.fn().mockReturnValue(mockSnackBarRef),
+  };
+  const confirmationDialogMock = {
+    getConfirmation: vi.fn(),
+    getConfirmationWithKeyword: vi.fn(),
+    showProgressDialog: vi.fn().mockReturnValue({ close: vi.fn() }),
+  };
+
+  /** confirm every dialog, as the user does before an action actually runs */
+  function userConfirms() {
+    confirmationDialogMock.getConfirmationWithKeyword.mockResolvedValue(true);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation.pathname = "/admin";
+    mockNavigator.onLine = true;
+    onActionSubscriber = undefined;
+    // read the real database, so that the restore point reflects when it was taken
+    mockBackupService.getDatabaseExport.mockImplementation(() => db.getAll());
+    mockSnackBar.open.mockReturnValue(mockSnackBarRef);
+    confirmationDialogMock.showProgressDialog.mockReturnValue({
+      close: vi.fn(),
+    });
+
+    db = new MemoryPouchDatabase("unit-test-db", new SyncStateSubject());
+    db.init();
+
+    mockUserAdminService = { getAllUsers: vi.fn().mockReturnValue(of([])) };
+    sessionSubject = new SessionSubject();
+    sessionSubject.next({
+      name: "admin",
+      id: "admin",
+      roles: [UserAdminService.ACCOUNT_MANAGER_ROLE],
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        SystemResetService,
+        { provide: BackupService, useValue: mockBackupService },
+        {
+          provide: ConfirmationDialogService,
+          useValue: confirmationDialogMock,
+        },
+        { provide: MatSnackBar, useValue: mockSnackBar },
+        { provide: LOCATION_TOKEN, useValue: mockLocation },
+        { provide: NAVIGATOR_TOKEN, useValue: mockNavigator },
+        {
+          provide: DatabaseResolverService,
+          useValue: { getDatabase: () => db },
+        },
+        { provide: EntityRegistry, useValue: entityRegistry },
+        { provide: UserAdminService, useValue: mockUserAdminService },
+        { provide: SessionSubject, useValue: sessionSubject },
+      ],
+    });
+    service = TestBed.inject(SystemResetService);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  describe("emptyRecords (Empty Records)", () => {
+    it("should delete records of user-facing types", async () => {
+      userConfirms();
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":2" });
+
+      await service.emptyRecords();
+
+      expect(await db.getAll()).toEqual([]);
+    });
+
+    it("should delete records of types that are not registered (anymore)", async () => {
+      userConfirms();
+      await db.put({ _id: "SomeRemovedType:1" });
+
+      await service.emptyRecords();
+
+      expect(await db.getAll()).toEqual([]);
+    });
+
+    it("should keep the system configuration", async () => {
+      userConfirms();
+      const configDocs = [
+        "Config:CONFIG_ENTITY",
+        "Config:Permissions",
+        "ConfigurableEnum:genders",
+        "SiteSettings:global",
+        "ReportConfig:1",
+      ];
+      for (const _id of configDocs) {
+        await db.put({ _id });
+      }
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+
+      await service.emptyRecords();
+
+      expect((await db.getAll()).map((doc) => doc._id).sort()).toEqual(
+        configDocs.sort(),
+      );
+    });
+
+    it("should keep database indices, because the app keeps running without a reload", async () => {
+      userConfirms();
+      await db.put({ _id: "_design/some_index", views: {} });
+
+      await service.emptyRecords();
+
+      expect((await db.getAll()).map((doc) => doc._id)).toEqual([
+        "_design/some_index",
+      ]);
+    });
+
+    it("should keep only those records that a login account is linked to", async () => {
+      userConfirms();
+      const withAccount = SystemResetUserProfileTestEntity.ENTITY_TYPE + ":1";
+      const withoutAccount =
+        SystemResetUserProfileTestEntity.ENTITY_TYPE + ":2";
+      await db.put({ _id: withAccount });
+      await db.put({ _id: withoutAccount });
+      mockUserAdminService.getAllUsers.mockReturnValue(
+        of([{ id: "keycloak-1", userEntityId: withAccount, enabled: true }]),
+      );
+
+      await service.emptyRecords();
+
+      expect((await db.getAll()).map((doc) => doc._id)).toEqual([withAccount]);
+    });
+
+    it("should keep all records that could have an account if the accounts cannot be looked up", async () => {
+      userConfirms();
+      const profileIds = [
+        SystemResetUserProfileTestEntity.ENTITY_TYPE + ":1",
+        SystemResetUserProfileTestEntity.ENTITY_TYPE + ":2",
+      ];
+      for (const _id of profileIds) {
+        await db.put({ _id });
+      }
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+      mockUserAdminService.getAllUsers.mockReturnValue(
+        throwError(() => new Error("no access to user management")),
+      );
+
+      await service.emptyRecords();
+
+      expect((await db.getAll()).map((doc) => doc._id)).toEqual(profileIds);
+    });
+
+    it("should delete the import history together with the imported records", async () => {
+      userConfirms();
+      await db.put({ _id: "ImportMetadata:1" });
+
+      await service.emptyRecords();
+
+      expect(await db.getAll()).toEqual([]);
+    });
+
+    it("should not delete any records if the user does not confirm", async () => {
+      confirmationDialogMock.getConfirmationWithKeyword.mockResolvedValue(
+        false,
+      );
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+
+      await service.emptyRecords();
+
+      expect(await db.getAll()).toHaveLength(1);
+    });
+
+    it("should only export the restore point once the deletion actually goes ahead", async () => {
+      confirmationDialogMock.getConfirmationWithKeyword.mockResolvedValue(
+        false,
+      );
+
+      await service.emptyRecords();
+
+      expect(mockBackupService.getDatabaseExport).not.toHaveBeenCalled();
+    });
+
+    it("should offer to undo emptying records by restoring the previous data", async () => {
+      userConfirms();
+      await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+
+      await service.emptyRecords();
+      await onActionSubscriber();
+
+      // the restore point has to be exported before the records are deleted,
+      // otherwise the undo silently restores nothing
+      const [restoredDocs] = mockBackupService.restoreData.mock.calls[0];
+      expect(restoredDocs.map((doc) => doc._id)).toEqual([
+        TestEntity.ENTITY_TYPE + ":1",
+      ]);
+    });
+  });
+
+  describe("resetSystem (Reset System)", () => {
+    it("should delete records and the complete system configuration", async () => {
+      userConfirms();
+      for (const _id of [
+        TestEntity.ENTITY_TYPE + ":1",
+        "Config:CONFIG_ENTITY",
+        "Config:Permissions",
+        "ConfigurableEnum:genders",
+        "SiteSettings:global",
+        "ReportConfig:1",
+        "ImportMetadata:1",
+      ]) {
+        await db.put({ _id });
+      }
+
+      await service.resetSystem();
+
+      expect(await db.getAll()).toEqual([]);
+    });
+
+    it("should delete database indices, which are recreated on the reload right after", async () => {
+      userConfirms();
+      await db.put({ _id: "_design/some_index", views: {} });
+
+      await service.resetSystem();
+
+      expect(await db.getAll()).toEqual([]);
+      expect(mockLocation.pathname).toBe("");
+    });
+
+    it("should not touch the replication checkpoints of the sync", async () => {
+      userConfirms();
+      await db.put({ _id: "_local/checkpoint", last_seq: 5 });
+
+      await service.resetSystem();
+
+      expect(await db.get("_local/checkpoint")).toBeTruthy();
+    });
+
+    it("should keep only the profile of the user performing the reset", async () => {
+      userConfirms();
+      const ownProfile = SystemResetUserProfileTestEntity.ENTITY_TYPE + ":own";
+      const otherProfile =
+        SystemResetUserProfileTestEntity.ENTITY_TYPE + ":other";
+      await db.put({ _id: ownProfile });
+      await db.put({ _id: otherProfile });
+      await db.put({ _id: "Config:CONFIG_ENTITY" });
+      sessionSubject.next({
+        name: "admin",
+        id: "admin",
+        roles: [],
+        entityId: ownProfile,
+      });
+
+      await service.resetSystem();
+
+      expect((await db.getAll()).map((doc) => doc._id)).toEqual([ownProfile]);
+      // other users' profiles are deleted, so the accounts do not have to be queried
+      expect(mockUserAdminService.getAllUsers).not.toHaveBeenCalled();
+    });
+
+    it("should delete all profiles if the current user has none linked", async () => {
+      userConfirms();
+      await db.put({
+        _id: SystemResetUserProfileTestEntity.ENTITY_TYPE + ":1",
+      });
+
+      await service.resetSystem();
+
+      expect(await db.getAll()).toEqual([]);
+    });
+
+    it("should not reset the system if the user does not confirm", async () => {
+      confirmationDialogMock.getConfirmationWithKeyword.mockResolvedValue(
+        false,
+      );
+      await db.put({ _id: "Config:CONFIG_ENTITY" });
+
+      await service.resetSystem();
+
+      expect(await db.getAll()).toHaveLength(1);
+      expect(mockLocation.pathname).toBe("/admin");
+    });
+  });
+
+  it("should refuse to delete records while offline, to avoid conflicts with other users", async () => {
+    mockNavigator.onLine = false;
+    await db.put({ _id: TestEntity.ENTITY_TYPE + ":1" });
+
+    await service.emptyRecords();
+    await service.resetSystem();
+
+    expect(await db.getAll()).toHaveLength(1);
+    expect(
+      confirmationDialogMock.getConfirmationWithKeyword,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/admin/system-reset/system-reset.service.spec.ts
+++ b/src/app/core/admin/system-reset/system-reset.service.spec.ts
@@ -30,7 +30,7 @@ import "#src/app/features/reporting/report-config";
 /** a record type that login accounts can be linked to (i.e. holding "user profiles") */
 @DatabaseEntity("SystemResetUserProfileTestEntity")
 class SystemResetUserProfileTestEntity extends Entity {
-  static override enableUserAccounts = true;
+  static override readonly enableUserAccounts = true;
 }
 
 describe("SystemResetService", () => {
@@ -151,8 +151,9 @@ describe("SystemResetService", () => {
 
       await service.emptyRecords();
 
-      expect((await db.getAll()).map((doc) => doc._id).sort()).toEqual(
-        configDocs.sort(),
+      const byId = (a: string, b: string) => a.localeCompare(b);
+      expect((await db.getAll()).map((doc) => doc._id).toSorted(byId)).toEqual(
+        configDocs.toSorted(byId),
       );
     });
 

--- a/src/app/core/admin/system-reset/system-reset.service.spec.ts
+++ b/src/app/core/admin/system-reset/system-reset.service.spec.ts
@@ -25,7 +25,7 @@ import "../../config/config";
 import "../../basic-datatypes/configurable-enum/configurable-enum";
 import "../../site-settings/site-settings";
 import "../../import/import-metadata";
-import "../../../features/reporting/report-config";
+import "#src/app/features/reporting/report-config";
 
 /** a record type that login accounts can be linked to (i.e. holding "user profiles") */
 @DatabaseEntity("SystemResetUserProfileTestEntity")

--- a/src/app/core/admin/system-reset/system-reset.service.ts
+++ b/src/app/core/admin/system-reset/system-reset.service.ts
@@ -72,7 +72,7 @@ export class SystemResetService {
     ImportMetadata.ENTITY_TYPE,
   ];
 
-  private db: Database;
+  private readonly db: Database;
 
   constructor() {
     this.db = this.dbResolver.getDatabase();

--- a/src/app/core/admin/system-reset/system-reset.service.ts
+++ b/src/app/core/admin/system-reset/system-reset.service.ts
@@ -1,0 +1,338 @@
+import { inject, Injectable, signal } from "@angular/core";
+import { BackupService } from "../backup/backup.service";
+import { ConfirmationDialogService } from "../../common-components/confirmation-dialog/confirmation-dialog.service";
+import {
+  CustomYesNoButtons,
+  DELETE_CONFIRMATION_KEYWORD,
+  OkButton,
+} from "../../common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
+import { LOCATION_TOKEN, NAVIGATOR_TOKEN } from "../../../utils/di-tokens";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { Database } from "../../database/database";
+import { DatabaseResolverService } from "../../database/database-resolver.service";
+import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { Entity, EntityConstructor } from "../../entity/model/entity";
+import { ImportMetadata } from "../../import/import-metadata";
+import {
+  UserAdminApiError,
+  UserAdminService,
+} from "../../user/user-admin-service/user-admin.service";
+import { SessionSubject } from "../../session/auth/session-info";
+import { firstValueFrom } from "rxjs";
+import { Logging } from "../../logging/logging.service";
+
+/**
+ * Which records have to be kept when deleting all records,
+ * because a login account is linked to them as its "profile".
+ */
+interface UserProfilesToKeep {
+  /** ids of the records that a login account is linked to */
+  linkedProfileIds: Set<string>;
+
+  /**
+   * Whether the login accounts could actually be looked up.
+   *
+   * If false (e.g. missing permissions, no user management server or offline),
+   * all records of types that can have user accounts are kept instead,
+   * because it is unknown which of them are linked to an account.
+   */
+  accountsVerified: boolean;
+}
+
+/**
+ * Admin actions to bulk-delete records ("Empty Records") or reset the whole
+ * system ("Reset System").
+ *
+ * This owns both what exactly is deleted and the confirmation dialogs, progress
+ * feedback and undo option shown to the user, because the two have to say the
+ * same thing: the dialog describes upfront what the deletion then does.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class SystemResetService {
+  private readonly backupService = inject(BackupService);
+  private readonly confirmationDialog = inject(ConfirmationDialogService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly location = inject(LOCATION_TOKEN);
+  private readonly dbResolver = inject(DatabaseResolverService);
+  private readonly entityRegistry = inject(EntityRegistry);
+  private readonly userAdminService = inject(UserAdminService);
+  private readonly sessionInfo = inject(SessionSubject, { optional: true });
+  private readonly navigator = inject<Navigator>(NAVIGATOR_TOKEN, {
+    optional: true,
+  });
+
+  /**
+   * Internal entity types that document past data operations rather than system configuration.
+   * These are deleted together with the records they refer to,
+   * so that no import history remains offering to "undo" an import of records that no longer exist.
+   */
+  private static readonly DATA_HISTORY_TYPES: string[] = [
+    ImportMetadata.ENTITY_TYPE,
+  ];
+
+  private db: Database;
+
+  constructor() {
+    this.db = this.dbResolver.getDatabase();
+    // WARNING: currently only the default "app" database is reset
+  }
+
+  /**
+   * Delete all records of all record types, keeping the system configuration.
+   */
+  async emptyRecords() {
+    if (!(await this.ensureDeletionPossible())) {
+      return;
+    }
+
+    const profilesToKeep = await this.getUserProfilesToKeep();
+
+    const confirmed = await this.confirmationDialog.getConfirmationWithKeyword(
+      $localize`:Empty records confirmation title:Delete all records?`,
+      $localize`:Empty records confirmation text:**IMPORTANT: Are you absolutely sure you want to delete all records?**
+
+This deletes all existing records of all record types in the database (like all cases, all activities and all notes), including all files and photos attached to them. Attached files cannot be restored by the undo option.
+
+Your system configuration (forms, dropdown options, reports, user roles) is kept. ${this.getKeptProfilesDescription(profilesToKeep)}
+
+This step cannot be reverted easily, if at all. In case of doubt, download a backup before taking this step.`,
+      DELETE_CONFIRMATION_KEYWORD,
+      CustomYesNoButtons(
+        $localize`:Empty records confirmation button:Yes, delete all records`,
+        $localize`:Empty records cancel button:Cancel`,
+      ),
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    // only export the whole database once the deletion is actually going ahead
+    const restorePoint = await this.backupService.getDatabaseExport();
+
+    const progressRef = this.confirmationDialog.showProgressDialog(
+      signal($localize`Deleting all records ...`),
+    );
+    try {
+      await this.deleteAllRecords(profilesToKeep);
+    } finally {
+      progressRef.close();
+    }
+
+    const snackBarRef = this.snackBar.open(
+      $localize`All records deleted`,
+      $localize`Undo`,
+      { duration: 8000 },
+    );
+    snackBarRef.onAction().subscribe(async () => {
+      await this.backupService.restoreData(restorePoint, true);
+    });
+  }
+
+  /**
+   * Delete everything, including the system configuration,
+   * leaving a system that has to be set up from scratch.
+   */
+  async resetSystem() {
+    if (!(await this.ensureDeletionPossible())) {
+      return;
+    }
+
+    const confirmed = await this.confirmationDialog.getConfirmationWithKeyword(
+      $localize`:Reset system confirmation title:Reset the whole system?`,
+      $localize`:Reset system confirmation text:**IMPORTANT: Are you absolutely sure you want to reset this system?**
+
+This deletes everything: all records of all record types including their attached files and photos, AND the complete configuration of your system (forms, fields, dropdown options, reports, templates, user roles and permissions).
+
+Only your own user profile is kept, so that you can keep working with your account. The profiles of all other users are deleted as well (their login accounts themselves are not deleted here).
+
+Afterwards you have to set up the system from scratch. This step cannot be reverted. Download a backup before taking this step.`,
+      DELETE_CONFIRMATION_KEYWORD,
+      CustomYesNoButtons(
+        $localize`:Reset system confirmation button:Yes, reset the system`,
+        $localize`:Reset system cancel button:Cancel`,
+      ),
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const progressRef = this.confirmationDialog.showProgressDialog(
+      signal($localize`Resetting the system ...`),
+    );
+    try {
+      await this.deleteEverything();
+    } finally {
+      progressRef.close();
+    }
+
+    // reload the app, which now starts up as a fresh system offering the initial setup
+    this.location.pathname = "";
+  }
+
+  /**
+   * Delete all records of all record types ("Empty Records"),
+   * keeping the system configuration (entity types, dropdown options,
+   * permissions, reports, templates and site settings) unchanged.
+   *
+   * The database's own index documents are kept as well: the app keeps running
+   * after this action and only recreates its indices on the next startup.
+   */
+  private async deleteAllRecords(
+    profilesToKeep: UserProfilesToKeep,
+  ): Promise<void> {
+    // log before deleting for traceability of possible data loss
+    Logging.warn("Emptying records: deleting all records of all record types");
+
+    const deletedDocs = await this.db.removeAll((doc) =>
+      this.isRecordDocument(
+        doc._id,
+        profilesToKeep.linkedProfileIds,
+        !profilesToKeep.accountsVerified,
+      ),
+    );
+    Logging.debug("Emptied records", { deletedDocs });
+  }
+
+  /**
+   * Delete everything ("Reset System"): all records as well as the complete
+   * system configuration (entity types, dropdown options, permissions, reports,
+   * templates and site settings), leaving a system that has to be set up from scratch.
+   *
+   * Only the profile of the user performing the reset is kept, so that they can
+   * keep working with their own account while setting the system up anew.
+   * The profiles of all other users are deleted (their login accounts are not touched).
+   *
+   * The database's own index documents are deleted as well;
+   * they are recreated when the app reloads right after this.
+   */
+  private async deleteEverything(): Promise<void> {
+    // log before deleting for traceability of possible data loss
+    Logging.warn(
+      "Resetting system: deleting all records and the system configuration",
+    );
+
+    const ownProfileId = this.sessionInfo?.value?.entityId;
+
+    const deletedDocs = await this.db.removeAll(
+      (doc) => doc._id !== ownProfileId,
+    );
+    Logging.debug("Reset system", { deletedDocs });
+  }
+
+  /**
+   * Look up which records must be kept by {@link deleteAllRecords}
+   * because a login account is linked to them.
+   *
+   * This runs before the confirmation dialog,
+   * so that the user can be told upfront what exactly will be kept.
+   */
+  private async getUserProfilesToKeep(): Promise<UserProfilesToKeep> {
+    try {
+      const accounts = await firstValueFrom(
+        this.userAdminService.getAllUsers(),
+      );
+      const linkedProfileIds = new Set(
+        accounts.map((account) => account.userEntityId).filter(Boolean),
+      );
+      return { linkedProfileIds, accountsVerified: true };
+    } catch (err) {
+      // a missing account_manager role is an expected, common case and not worth a warning
+      if (err instanceof UserAdminApiError && err.status === 403) {
+        Logging.debug(
+          "Could not look up user accounts before deleting records",
+          {
+            error: err,
+          },
+        );
+      } else {
+        Logging.warn(
+          "Could not look up user accounts before deleting records",
+          {
+            error: err,
+          },
+        );
+      }
+      return { linkedProfileIds: new Set(), accountsVerified: false };
+    }
+  }
+
+  /**
+   * These bulk deletions must only run online, so that they take effect for everybody
+   * immediately. Inform the user and abort the action otherwise.
+   */
+  private async ensureDeletionPossible(): Promise<boolean> {
+    // offline the deletions would sit in the local database while other users keep
+    // working on records that are already deleted here, producing conflicts once
+    // the deletions are finally synced
+    if (this.navigator?.onLine ?? true) {
+      return true;
+    }
+
+    await this.confirmationDialog.getConfirmation(
+      $localize`:Delete records offline title:Not available offline`,
+      $localize`:Delete records offline text:This action requires an internet connection, so that it takes effect for all users immediately. Deleting the records offline would let others keep working on records that no longer exist here, causing conflicts once your changes are synchronised. Please connect to the internet and try again.`,
+      OkButton,
+      false,
+    );
+    return false;
+  }
+
+  /**
+   * Describe for the user which records are kept because a login account is linked to them.
+   */
+  private getKeptProfilesDescription(profilesToKeep: UserProfilesToKeep) {
+    if (!profilesToKeep.accountsVerified) {
+      return $localize`:Kept user profiles, accounts unknown:The linked login accounts could not be checked, so for safety all records of the record types that can have a login account (usually "User") are kept.`;
+    }
+
+    return $localize`:Kept user profiles:Only those records that a login account is linked to are kept, so that users keep their profile.`;
+  }
+
+  /**
+   * Whether the given document holds user data ("a record")
+   * as opposed to system configuration or internal database documents.
+   *
+   * @param docId the document to check
+   * @param profileIdsToKeep ids of user profile records that must not be deleted
+   * @param keepAllPotentialProfiles whether to additionally keep every record of a type
+   *        that can have user accounts, because it is unknown which of them actually have one
+   */
+  private isRecordDocument(
+    docId: string,
+    profileIdsToKeep: Set<string>,
+    keepAllPotentialProfiles: boolean,
+  ): boolean {
+    // documents used by the database itself (e.g. "_design/..." indices) are not records
+    if (docId.startsWith("_")) {
+      return false;
+    }
+
+    if (profileIdsToKeep.has(docId)) {
+      return false;
+    }
+
+    const entityType = this.getEntityType(docId);
+    if (keepAllPotentialProfiles && entityType?.enableUserAccounts) {
+      return false;
+    }
+    if (
+      SystemResetService.DATA_HISTORY_TYPES.includes(entityType?.ENTITY_TYPE)
+    ) {
+      return true;
+    }
+
+    // types that are not (or no longer) registered are leftover records, not config
+    return !entityType?.isInternalEntity;
+  }
+
+  private getEntityType(docId: string): EntityConstructor | undefined {
+    const type = Entity.extractTypeFromId(docId);
+    return this.entityRegistry.has(type)
+      ? this.entityRegistry.get(type)
+      : undefined;
+  }
+}

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog.service.ts
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog.service.ts
@@ -3,6 +3,8 @@ import { MatDialog } from "@angular/material/dialog";
 import {
   ConfirmationDialogButton,
   ConfirmationDialogComponent,
+  ConfirmationDialogConfig,
+  DELETE_CONFIRMATION_KEYWORD,
   YesNoButtons,
 } from "./confirmation-dialog/confirmation-dialog.component";
 import { firstValueFrom } from "rxjs";
@@ -43,16 +45,42 @@ export class ConfirmationDialogService {
     buttons: ConfirmationDialogButton[] = YesNoButtons,
     closeButton = true,
   ): Promise<boolean | string | undefined> {
-    const dialogRef = this.ngZone.run(() => {
-      return this.dialog.open(ConfirmationDialogComponent, {
-        data: {
-          title: title,
-          text: text,
-          buttons: buttons,
-          closeButton: closeButton,
-        },
-      });
+    return this.openDialog({ title, text, buttons, closeButton });
+  }
+
+  /**
+   * Open a confirmation dialog for a critical, irreversible action,
+   * where the user additionally has to type the given keyword to unlock the confirming buttons.
+   *
+   * @param title The title displayed for the dialog
+   * @param text The text displayed for the dialog
+   * @param confirmationKeyword The word the user has to type to be able to confirm,
+   *        e.g. {@link DELETE_CONFIRMATION_KEYWORD}
+   * @param buttons The buttons to show. Defaults to 'yes' and 'no', but can be arbitrary
+   * @param closeButton Whether a single icon-button with an 'x' is shown to the user
+   */
+  getConfirmationWithKeyword(
+    title: string,
+    text: string,
+    confirmationKeyword: string,
+    buttons: ConfirmationDialogButton[] = YesNoButtons,
+    closeButton = true,
+  ): Promise<boolean | string | undefined> {
+    return this.openDialog({
+      title,
+      text,
+      buttons,
+      closeButton,
+      confirmationKeyword,
     });
+  }
+
+  private openDialog(
+    data: ConfirmationDialogConfig,
+  ): Promise<boolean | string | undefined> {
+    const dialogRef = this.ngZone.run(() =>
+      this.dialog.open(ConfirmationDialogComponent, { data }),
+    );
     return firstValueFrom(dialogRef.afterClosed());
   }
 

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.html
@@ -13,11 +13,12 @@
         >Type "{{ data.confirmationKeyword }}" to confirm</mat-label
       >
       <input
+        #confirmationInput
         matInput
         cdkFocusInitial
         autocomplete="off"
         [value]="typedConfirmation()"
-        (input)="typedConfirmation.set($any($event.target).value)"
+        (input)="typedConfirmation.set(confirmationInput.value)"
       />
     </mat-form-field>
   }

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.html
@@ -6,12 +6,28 @@
 </h1>
 <div mat-dialog-content>
   <markdown>{{ data.text }}</markdown>
+
+  @if (data.confirmationKeyword) {
+    <mat-form-field class="full-width">
+      <mat-label i18n="Label of the input to confirm a critical action"
+        >Type "{{ data.confirmationKeyword }}" to confirm</mat-label
+      >
+      <input
+        matInput
+        cdkFocusInitial
+        autocomplete="off"
+        [value]="typedConfirmation()"
+        (input)="typedConfirmation.set($any($event.target).value)"
+      />
+    </mat-form-field>
+  }
 </div>
 
 <div mat-dialog-actions>
   @for (button of data.buttons; track button.text) {
     <button
       mat-stroked-button
+      [disabled]="isBlocked(button)"
       (click)="button.click()"
       [mat-dialog-close]="button.dialogResult"
     >

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.spec.ts
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.spec.ts
@@ -1,33 +1,117 @@
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-
-import { ConfirmationDialogComponent } from "./confirmation-dialog.component";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
-import { MarkdownModule } from "ngx-markdown";
+import { provideMarkdown } from "ngx-markdown";
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogConfig,
+  YesNoButtons,
+} from "./confirmation-dialog.component";
 
 describe("ConfirmationDialogComponent", () => {
-  let component: ConfirmationDialogComponent;
   let fixture: ComponentFixture<ConfirmationDialogComponent>;
 
-  beforeEach(waitForAsync(() => {
+  async function createComponent(data: Partial<ConfirmationDialogConfig>) {
     TestBed.configureTestingModule({
-      imports: [ConfirmationDialogComponent, MarkdownModule.forRoot()],
+      imports: [ConfirmationDialogComponent],
       providers: [
-        { provide: MatDialogRef, useValue: {} },
+        provideMarkdown(),
+        { provide: MatDialogRef, useValue: { close: () => undefined } },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: { title: "test title", text: "test text" },
+          useValue: {
+            title: "Title",
+            text: "",
+            buttons: YesNoButtons,
+            ...data,
+          },
         },
       ],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
+    });
     fixture = TestBed.createComponent(ConfirmationDialogComponent);
-    component = fixture.componentInstance;
     fixture.detectChanges();
+    // markdown parsing is asynchronous, so let it settle before asserting on the DOM
+    await new Promise((resolve) => setTimeout(resolve));
+    fixture.detectChanges();
+  }
+
+  it("should create", async () => {
+    await createComponent({ title: "test title", text: "test text" });
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  it("should render a multi-paragraph markdown text with formatting", async () => {
+    // dialog texts of destructive admin actions rely on this to structure their warning
+    await createComponent({
+      text: `**IMPORTANT: Are you sure?**
+
+This deletes all records.
+
+This cannot be reverted.`,
+    });
+
+    const content: HTMLElement = fixture.nativeElement.querySelector(
+      "[mat-dialog-content]",
+    );
+    expect(content.querySelectorAll("p")).toHaveLength(3);
+    expect(content.querySelector("strong").textContent).toBe(
+      "IMPORTANT: Are you sure?",
+    );
+    expect(content.textContent).not.toContain("**");
+  });
+
+  describe("with a required confirmation keyword", () => {
+    /** the buttons rendered in the dialog, in the order of `YesNoButtons` */
+    function getButtons(): HTMLButtonElement[] {
+      return Array.from(
+        fixture.nativeElement.querySelectorAll("[mat-dialog-actions] button"),
+      );
+    }
+
+    function typeConfirmation(value: string) {
+      const input: HTMLInputElement =
+        fixture.nativeElement.querySelector("input");
+      input.value = value;
+      input.dispatchEvent(new Event("input"));
+      fixture.detectChanges();
+    }
+
+    it("should not show an input if no keyword is required", async () => {
+      await createComponent({ text: "no keyword needed" });
+
+      expect(fixture.nativeElement.querySelector("input")).toBeNull();
+      expect(getButtons().every((button) => !button.disabled)).toBe(true);
+    });
+
+    it("should block confirming until the keyword is typed correctly", async () => {
+      await createComponent({ text: "sure?", confirmationKeyword: "delete" });
+      const [confirmButton, cancelButton] = getButtons();
+
+      expect(confirmButton.disabled).toBe(true);
+      // aborting the action must always stay possible
+      expect(cancelButton.disabled).toBe(false);
+
+      typeConfirmation("del");
+      expect(confirmButton.disabled).toBe(true);
+
+      typeConfirmation("delete");
+      expect(confirmButton.disabled).toBe(false);
+    });
+
+    it("should accept the keyword regardless of case and surrounding whitespace", async () => {
+      await createComponent({ text: "sure?", confirmationKeyword: "delete" });
+
+      typeConfirmation("  DeLeTe ");
+
+      expect(getButtons()[0].disabled).toBe(false);
+    });
+
+    it("should block confirming again when the keyword is removed", async () => {
+      await createComponent({ text: "sure?", confirmationKeyword: "delete" });
+
+      typeConfirmation("delete");
+      typeConfirmation("");
+
+      expect(getButtons()[0].disabled).toBe(true);
+    });
   });
 });

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.ts
@@ -42,7 +42,7 @@ export class ConfirmationDialogComponent {
   typedConfirmation = signal("");
 
   /** whether the required keyword has been entered correctly */
-  private keywordEntered = computed(() => {
+  private readonly keywordEntered = computed(() => {
     const keyword = this.data.confirmationKeyword;
     return (
       !keyword ||

--- a/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,4 +1,10 @@
-import { Component, inject, ChangeDetectionStrategy } from "@angular/core";
+import {
+  Component,
+  inject,
+  ChangeDetectionStrategy,
+  signal,
+  computed,
+} from "@angular/core";
 import {
   MAT_DIALOG_DATA,
   MatDialogModule,
@@ -6,6 +12,8 @@ import {
 } from "@angular/material/dialog";
 import { DialogCloseComponent } from "../../dialog-close/dialog-close.component";
 import { MatButtonModule } from "@angular/material/button";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
 import { MarkdownComponent } from "ngx-markdown";
 
 /**
@@ -21,12 +29,34 @@ import { MarkdownComponent } from "ngx-markdown";
     DialogCloseComponent,
     MatDialogModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
     MarkdownComponent,
   ],
 })
 export class ConfirmationDialogComponent {
   dialogRef = inject<MatDialogRef<ConfirmationDialogComponent>>(MatDialogRef);
   data = inject<ConfirmationDialogConfig>(MAT_DIALOG_DATA);
+
+  /** what the user has typed into the confirmation input (if a keyword is required) */
+  typedConfirmation = signal("");
+
+  /** whether the required keyword has been entered correctly */
+  private keywordEntered = computed(() => {
+    const keyword = this.data.confirmationKeyword;
+    return (
+      !keyword ||
+      this.typedConfirmation().trim().toLowerCase() === keyword.toLowerCase()
+    );
+  });
+
+  /**
+   * Confirming buttons stay disabled until the required keyword has been typed,
+   * while buttons that abort the action (e.g. "Cancel") remain available.
+   */
+  isBlocked(button: ConfirmationDialogButton): boolean {
+    return !!button.dialogResult && !this.keywordEntered();
+  }
 }
 
 /**
@@ -46,7 +76,20 @@ export interface ConfirmationDialogConfig {
    * This button is on the top-right of the dialog and closes it with no result
    */
   closeButton?: boolean;
+
+  /**
+   * If set, the user has to type this keyword into an input field
+   * before the confirming buttons become available.
+   *
+   * Use this as an additional safeguard for critical, irreversible actions.
+   */
+  confirmationKeyword?: string;
 }
+
+/**
+ * The keyword a user has to type to confirm an action that deletes data irreversibly.
+ */
+export const DELETE_CONFIRMATION_KEYWORD = $localize`:Keyword to be typed by the user to confirm deleting data:delete`;
 
 export interface ConfirmationDialogButton {
   text: string;

--- a/src/app/core/config/config.service.spec.ts
+++ b/src/app/core/config/config.service.spec.ts
@@ -979,6 +979,24 @@ describe("ConfigService", () => {
       }
     });
 
+    it("should not abort app when the config doc is deleted (e.g. admin resetting the system)", async () => {
+      vi.useFakeTimers();
+      try {
+        const { reloadMock } = await setupReloadTest();
+
+        // a deleted doc holds no data, which must not be reported as a corrupt config
+        updateSubject.next({ entity: new Config(), type: "remove" });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(Logging.error).not.toHaveBeenCalled();
+        expect(window.alert).not.toHaveBeenCalled();
+        expect(reloadMock).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+      }
+    });
+
     it("should stop auto-reloading after the retry budget is exhausted to avoid a reload loop", async () => {
       vi.useFakeTimers();
       try {

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -35,7 +35,10 @@ export class ConfigService extends LatestEntityLoader<Config> {
     // eslint-disable-next-line
     entityMapper: EntityMapperService, // Prefer using the inject() function not possible here because base class requires the dependency to be passed to super()
   ) {
-    super(Config, Config.CONFIG_KEY, entityMapper);
+    // deletions are not emitted: a deleted config doc holds no data and would be
+    // misreported as a corrupt config by onInit() below. Deleting the config happens
+    // when an admin resets the system, which reloads the app right afterwards anyway.
+    super(Config, Config.CONFIG_KEY, entityMapper, false);
   }
 
   override onInit() {

--- a/src/app/core/database/database.ts
+++ b/src/app/core/database/database.ts
@@ -124,6 +124,26 @@ export abstract class Database {
   }
 
   /**
+   * Delete all documents of the database matching the given filter.
+   *
+   * Note that `getAll()` also returns the database's own "_design/..." index
+   * documents, so a filter that does not exclude them deletes the indices as well.
+   * They are only recreated when the app starts up again
+   * (see {@link DatabaseIndexingService}), so only delete them if the calling code
+   * reloads the app or restores the documents immediately afterwards.
+   *
+   * @param shouldDelete filter deciding for each document whether it is deleted
+   * @returns the number of deleted documents
+   */
+  async removeAll(shouldDelete: (doc: any) => boolean): Promise<number> {
+    const docsToDelete = (await this.getAll()).filter(shouldDelete);
+    for (const doc of docsToDelete) {
+      await this.remove(doc);
+    }
+    return docsToDelete.length;
+  }
+
+  /**
    * @returns true if there are no documents in the database
    */
   abstract isEmpty(): Promise<boolean>;

--- a/src/app/core/database/database.ts
+++ b/src/app/core/database/database.ts
@@ -132,11 +132,15 @@ export abstract class Database {
    * (see {@link DatabaseIndexingService}), so only delete them if the calling code
    * reloads the app or restores the documents immediately afterwards.
    *
-   * @param shouldDelete filter deciding for each document whether it is deleted
+   * @param shouldDelete filter deciding for each document whether it is deleted.
+   *        Pass a specialized document type if the filter reads fields other than `_id`.
    * @returns the number of deleted documents
    */
-  async removeAll(shouldDelete: (doc: any) => boolean): Promise<number> {
-    const docsToDelete = (await this.getAll()).filter(shouldDelete);
+  async removeAll<T extends { _id: string }>(
+    shouldDelete: (doc: T) => boolean,
+  ): Promise<number> {
+    const allDocs: T[] = await this.getAll();
+    const docsToDelete = allDocs.filter(shouldDelete);
     for (const doc of docsToDelete) {
       await this.remove(doc);
     }

--- a/src/app/core/database/local-device-reset.service.spec.ts
+++ b/src/app/core/database/local-device-reset.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from "@angular/core/testing";
+
+import { LocalDeviceResetService } from "./local-device-reset.service";
+import { ConfirmationDialogService } from "../common-components/confirmation-dialog/confirmation-dialog.service";
+import { LOCAL_STORAGE_TOKEN, LOCATION_TOKEN } from "../../utils/di-tokens";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
+
+describe("LocalDeviceResetService", () => {
+  let service: LocalDeviceResetService;
+  const mockLocation = { pathname: "/support" };
+  const confirmationDialogMock = { getConfirmation: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation.pathname = "/support";
+
+    TestBed.configureTestingModule({
+      providers: [
+        LocalDeviceResetService,
+        {
+          provide: ConfirmationDialogService,
+          useValue: confirmationDialogMock,
+        },
+        { provide: LOCATION_TOKEN, useValue: mockLocation },
+        { provide: LOCAL_STORAGE_TOKEN, useValue: localStorage },
+      ],
+    });
+    service = TestBed.inject(LocalDeviceResetService);
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(RESET_PENDING_KEY);
+    localStorage.clear();
+  });
+
+  it("should clear local data and reload after confirmation", async () => {
+    confirmationDialogMock.getConfirmation.mockResolvedValue(true);
+    localStorage.setItem("someItem", "someValue");
+
+    await service.resetLocalDevice();
+
+    expect(localStorage.getItem("someItem")).toBeNull();
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBe("1");
+    expect(mockLocation.pathname).toBe("");
+  });
+
+  it("should not touch any local data if the user does not confirm", async () => {
+    confirmationDialogMock.getConfirmation.mockResolvedValue(false);
+    localStorage.setItem("someItem", "someValue");
+
+    await service.resetLocalDevice();
+
+    expect(localStorage.getItem("someItem")).toBe("someValue");
+    expect(sessionStorage.getItem(RESET_PENDING_KEY)).toBeNull();
+    expect(mockLocation.pathname).toBe("/support");
+  });
+});

--- a/src/app/core/database/local-device-reset.service.ts
+++ b/src/app/core/database/local-device-reset.service.ts
@@ -1,0 +1,61 @@
+import { inject, Injectable } from "@angular/core";
+import { ConfirmationDialogService } from "../common-components/confirmation-dialog/confirmation-dialog.service";
+import { LOCAL_STORAGE_TOKEN, LOCATION_TOKEN } from "../../utils/di-tokens";
+import { Logging } from "../logging/logging.service";
+import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
+
+/**
+ * Clear all data cached on the current device and re-synchronize it from the server.
+ *
+ * This only affects this device, not the server or other users,
+ * and is therefore also offered to normal users (e.g. in the support page)
+ * rather than being an admin action like the SystemResetService ones.
+ *
+ * This service only marks the reset as pending and reloads the page;
+ * the actual cleanup runs in `runPendingReset()` during the next bootstrap.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class LocalDeviceResetService {
+  private readonly localStorage = inject(LOCAL_STORAGE_TOKEN);
+  private readonly confirmationDialog = inject(ConfirmationDialogService);
+  private readonly location = inject(LOCATION_TOKEN);
+
+  /**
+   * Ask the user for confirmation and then wipe this device's local data.
+   */
+  async resetLocalDevice(): Promise<void> {
+    const choice = await this.confirmationDialog.getConfirmation(
+      $localize`:Reset Application Confirmation:Reset local data on this device?`,
+      $localize`:Reset Application Confirmation:Are you sure you want to clear all data cached on this device and re-synchronize from the server? This does not affect the server or other users. Any changes on this device that have not yet been synchronised will be lost.`,
+    );
+    if (!choice) {
+      return;
+    }
+
+    // deleting ALL local data (incl. possibly unsynced docs) - log for traceability of possible data loss
+    Logging.warn(
+      "Resetting application: user confirmed deletion of all local data",
+    );
+
+    this.localStorage.clear();
+    this.markResetPendingAndReload();
+  }
+
+  /**
+   * Trigger the actual reset of the local databases.
+   *
+   * The page is reloaded first to kill all PouchDB connections, in-flight sync,
+   * view indexing, and other async operations. The IDB databases are deleted on
+   * the fresh page by `runPendingReset()` (before Angular bootstraps) where no
+   * connections exist, avoiding race conditions with PouchDB's IDB transactions.
+   *
+   * Use this directly (instead of {@link resetLocalDevice}) where the reset is not
+   * triggered by the user asking for it, e.g. to recover from a corrupted database.
+   */
+  markResetPendingAndReload(): void {
+    sessionStorage.setItem(RESET_PENDING_KEY, "1");
+    this.location.pathname = "";
+  }
+}

--- a/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
+++ b/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
@@ -4,8 +4,7 @@ import {
   CustomYesNoButtons,
   OkButton,
 } from "#src/app/core/common-components/confirmation-dialog/confirmation-dialog/confirmation-dialog.component";
-import { LOCATION_TOKEN } from "#src/app/utils/di-tokens";
-import { RESET_PENDING_KEY } from "#src/bootstrap-reset";
+import { LocalDeviceResetService } from "../local-device-reset.service";
 import { Logging } from "../../logging/logging.service";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
@@ -17,7 +16,7 @@ import { SessionType } from "../../session/session-type";
 @Injectable({ providedIn: "root" })
 export class PouchdbCorruptionRecoveryService {
   private readonly confirmationDialog = inject(ConfirmationDialogService);
-  private readonly location = inject<Location>(LOCATION_TOKEN);
+  private readonly localDeviceReset = inject(LocalDeviceResetService);
   private warningDialogOpen = false;
   private resetDialogOpen = false;
 
@@ -89,8 +88,7 @@ This can happen after using multiple tabs in parallel.` +
     Logging.warn(
       "Resetting application data after suspected local database corruption (user confirmed)",
     );
-    sessionStorage.setItem(RESET_PENDING_KEY, "1");
-    this.location.pathname = "";
+    this.localDeviceReset.markResetPendingAndReload();
   }
 
   handleKnownMultiTabCorruption(err: unknown, logMessage: string): void {

--- a/src/app/core/entity/latest-entity-loader.ts
+++ b/src/app/core/entity/latest-entity-loader.ts
@@ -17,6 +17,14 @@ export abstract class LatestEntityLoader<T extends Entity> {
     private entityCtor: EntityConstructor<T>,
     private entityID: string,
     protected entityMapper: EntityMapperService,
+    /**
+     * Whether a deletion of the entity is emitted through `entityUpdated` as well.
+     *
+     * A deleted document holds no data, so the emitted entity is empty apart from its id.
+     * Set this to false if the subscriber cannot handle that (and instead should simply
+     * keep the last known state until the app is reloaded).
+     */
+    private readonly emitDeletions: boolean = true,
   ) {
     this.onInit();
   }
@@ -35,7 +43,10 @@ export abstract class LatestEntityLoader<T extends Entity> {
     // regardless of whether the initial load below succeeds or fails.
     this.entityMapper
       .receiveUpdates(this.entityCtor)
-      .pipe(filter(({ entity }) => entity.getId(true) === this.entityID))
+      .pipe(
+        filter(({ type }) => this.emitDeletions || type !== "remove"),
+        filter(({ entity }) => entity.getId(true) === this.entityID),
+      )
       .subscribe(({ entity }) => this.entityUpdated.next(entity));
 
     return this.loadOnce();

--- a/src/app/core/setup/context-aware-assistant/context-aware-assistant.component.spec.ts
+++ b/src/app/core/setup/context-aware-assistant/context-aware-assistant.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { ContextAwareAssistantComponent } from "./context-aware-assistant.component";
-import { BackupService } from "../../admin/backup/backup.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 
 describe("ContextAwareAssistantComponent", () => {
   let component: ContextAwareAssistantComponent;
@@ -10,7 +10,7 @@ describe("ContextAwareAssistantComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ContextAwareAssistantComponent],
-      providers: [{ provide: BackupService, useValue: null }],
+      providers: [{ provide: LocalDeviceResetService, useValue: null }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ContextAwareAssistantComponent);

--- a/src/app/core/setup/context-aware-assistant/context-aware-assistant.component.ts
+++ b/src/app/core/setup/context-aware-assistant/context-aware-assistant.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, ChangeDetectionStrategy } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
 import { environment } from "../../../../environments/environment";
 import { SessionType } from "../../session/session-type";
-import { BackupService } from "../../admin/backup/backup.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 
 /**
  * UI for some basic user guide,
@@ -26,11 +26,11 @@ export class ContextAwareAssistantComponent {
   isUserSupportEnabled: boolean = environment.userSupportEnabled;
   isSaaS: boolean = environment.SaaS;
 
-  private readonly backupService = inject(BackupService);
+  private readonly localDeviceResetService = inject(LocalDeviceResetService);
 
   async restartDemo() {
     if (environment.session_type !== SessionType.mock) {
-      await this.backupService.resetApplication();
+      await this.localDeviceResetService.resetLocalDevice();
     } else {
       window.location.href = "/";
     }

--- a/src/app/core/support/support/support.component.html
+++ b/src/app/core/support/support/support.component.html
@@ -137,7 +137,7 @@
   >
     Download Local Database
   </button>
-  <button mat-raised-button color="warn" (click)="resetApplication()" i18n>
+  <button mat-raised-button color="warn" (click)="resetLocalDevice()" i18n>
     Reset Application
   </button>
 </div>

--- a/src/app/core/support/support/support.component.spec.ts
+++ b/src/app/core/support/support/support.component.spec.ts
@@ -14,6 +14,7 @@ import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { PouchDatabase } from "../../database/pouchdb/pouch-database";
 import { BackupService } from "../../admin/backup/backup.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 import { DownloadService } from "../../export/download-service/download.service";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
 import { SyncStateSubject } from "../../session/session-type";
@@ -78,8 +79,12 @@ describe("SupportComponent", () => {
         {
           provide: BackupService,
           useValue: {
-            resetApplication: vi.fn(),
+            getDatabaseExport: vi.fn(),
           },
+        },
+        {
+          provide: LocalDeviceResetService,
+          useValue: { resetLocalDevice: vi.fn() },
         },
         { provide: DownloadService, useValue: null },
         {

--- a/src/app/core/support/support/support.component.ts
+++ b/src/app/core/support/support/support.component.ts
@@ -50,7 +50,7 @@ export class SupportComponent implements OnInit {
   private databaseResolver = inject(DatabaseResolverService);
   private http = inject(HttpClient);
   private backupService = inject(BackupService);
-  private localDeviceResetService = inject(LocalDeviceResetService);
+  private readonly localDeviceResetService = inject(LocalDeviceResetService);
   private downloadService = inject(DownloadService);
   private window = inject<Window>(WINDOW_TOKEN);
   protected readonly assistantService = inject(AssistantService);

--- a/src/app/core/support/support/support.component.ts
+++ b/src/app/core/support/support/support.component.ts
@@ -16,6 +16,7 @@ import { MatExpansionModule } from "@angular/material/expansion";
 import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BackupService } from "../../admin/backup/backup.service";
+import { LocalDeviceResetService } from "../../database/local-device-reset.service";
 import { DownloadService } from "../../export/download-service/download.service";
 import { SyncStateSubject } from "../../session/session-type";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
@@ -49,6 +50,7 @@ export class SupportComponent implements OnInit {
   private databaseResolver = inject(DatabaseResolverService);
   private http = inject(HttpClient);
   private backupService = inject(BackupService);
+  private localDeviceResetService = inject(LocalDeviceResetService);
   private downloadService = inject(DownloadService);
   private window = inject<Window>(WINDOW_TOKEN);
   protected readonly assistantService = inject(AssistantService);
@@ -209,8 +211,8 @@ export class SupportComponent implements OnInit {
     this.clipboard.copy(JSON.stringify(debugInfo, null, 2));
   }
 
-  async resetApplication() {
-    await this.backupService.resetApplication();
+  async resetLocalDevice() {
+    await this.localDeviceResetService.resetLocalDevice();
   }
 
   async downloadLocalDatabase() {


### PR DESCRIPTION
reset system and empty data functions
with clear separation and confirmations

- closes #4194

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate Technical Administration actions for emptying records, resetting the system, and resetting the local device.
  * Added keyword-protected confirmations for critical deletion actions.
  * Added local-device reset support that clears local data and reloads the application.
* **Bug Fixes**
  * System resets now preserve required configuration and the current user profile.
  * Improved recovery handling for corrupted local data.
  * Prevented configuration deletion from triggering false corruption alerts or reloads.
* **Improvements**
  * Reset and recovery actions now provide clearer confirmation and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->