### PR TITLE
chore(CI): fix tagging of latest / stable release image

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -93,6 +93,8 @@ jobs:
             ${{ env.DOCKERHUB_IMAGE }}
             ${{ env.GHCR_IMAGE }}
           tags: ${{ inputs.docker_tags }}
+          flavor: |
+            latest=false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/tag-published.yml
+++ b/.github/workflows/tag-published.yml
@@ -24,11 +24,14 @@ jobs:
       build_name: ${{ github.ref_name }}
       # - tag with git tag name
       # - tag with `:master` on pre-release tag builds (tag contains "-master")
-      # - tag with `:stable` for release tags (created via create-release.yml)
+      # - tag with `:stable` and `:latest` for release tags (created via create-release.yml)
+      # (docker/metadata-action's own auto-`latest` is disabled in _build.yaml so it doesn't
+      # apply `:latest` to every tag push regardless of this condition)
       docker_tags: |
         type=ref,event=tag
-        type=raw,value=master,enabled=${{ contains(github.ref_name, '-master') }}
-        type=raw,value=stable,enabled=${{ !contains(github.ref_name, '-') }}
+        type=raw,value=master,enable=${{ contains(github.ref_name, '-master') }}
+        type=raw,value=stable,enable=${{ !contains(github.ref_name, '-') }}
+        type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
   sentry-upload-sourcemaps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our docker images have been wrongly tagged for the general `latest` and `stable` tags always pointing at the most recent master build.

Should be: Latest official release done through semantic-release only