### PR TITLE
chore(build): migrate to esbuild application builder

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,96 +12,11 @@
       },
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
-          "options": {
-            "outputPath": "dist",
-            "index": "src/index.html",
-            "main": "src/main.ts",
-            "tsConfig": "tsconfig.app.json",
-            "polyfills": "src/polyfills.ts",
-            "i18nMissingTranslation": "warning",
-            "assets": [
-              "src/assets",
-              "src/manifest.webmanifest",
-              "src/firebase-messaging-sw.js",
-              {
-                "glob": "**/*",
-                "input": "node_modules/leaflet/dist/images/",
-                "output": "./assets"
-              }
-            ],
-            "styles": [
-              "src/styles/styles.scss",
-              "src/styles/themes/ndb-theme.scss",
-              "node_modules/leaflet/dist/leaflet.css",
-              "node_modules/leaflet.markercluster/dist/MarkerCluster.css",
-              "node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css"
-            ],
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "node_modules/",
-                "src/styles"
-              ]
-            },
-            "vendorChunk": true,
-            "extractLicenses": false,
-            "buildOptimizer": false,
-            "sourceMap": true,
-            "optimization": false,
-            "namedChunks": true
-          },
-          "configurations": {
-            "production": {
-              "budgets": [
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb"
-                }
-              ],
-              "optimization": {
-                "scripts": true,
-                "styles": {
-                  "minify": true,
-                  "inlineCritical": false
-                },
-                "fonts": true
-              },
-              "outputHashing": "all",
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.prod.ts"
-                }
-              ],
-              "serviceWorker": true,
-              "ngswConfigPath": "ngsw-config.json"
-            },
-            "development": {},
-            "testing": {
-              "aot": false,
-              "polyfills": [
-                "@angular/localize/init",
-                "src/polyfills.test.ts"
-              ],
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.spec.ts"
-                }
-              ]
-            }
-          },
-          "defaultConfiguration": "production"
-        },
-        "build-test": {
           "builder": "@angular/build:application",
           "options": {
             "outputPath": {
-              "base": "dist-test"
+              "base": "dist",
+              "browser": ""
             },
             "index": "src/index.html",
             "browser": "src/main.ts",
@@ -136,7 +51,29 @@
             "extractLicenses": false,
             "sourceMap": true,
             "optimization": false,
-            "namedChunks": true
+            "namedChunks": true,
+            "allowedCommonJsDependencies": [
+              "@aytek/material-color-picker",
+              "double-ended-queue",
+              "events",
+              "exceljs",
+              "hammerjs",
+              "json-query",
+              "leaflet",
+              "leaflet.markercluster",
+              "level-codec",
+              "levelup",
+              "ltgt",
+              "md5",
+              "memdown",
+              "moment",
+              "papaparse",
+              "readable-stream",
+              "reflect-metadata",
+              "spark-md5",
+              "through2",
+              "vuvuzela"
+            ]
           },
           "configurations": {
             "production": {
@@ -183,7 +120,7 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "options": {},
           "configurations": {
             "production": {
@@ -196,7 +133,7 @@
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "builder": "@angular/build:extract-i18n",
           "options": {
             "buildTarget": "ndb-core:build"
           }
@@ -204,7 +141,7 @@
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
-            "buildTarget": "ndb-core:build-test:testing",
+            "buildTarget": "ndb-core:build:testing",
             "tsConfig": "tsconfig.spec.json",
             "runner": "vitest",
             "runnerConfig": true,

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,3 +1,6 @@
+// provides the global $localize function for the app code imported below;
+// in the browser build this comes from the polyfills bundle instead
+import "@angular/localize/init";
 // eslint-disable-next-line no-restricted-imports
 import { Download, Page, test as base } from "@playwright/test";
 // eslint-disable-next-line no-restricted-imports

--- a/e2e/tests/attendance.spec.ts
+++ b/e2e/tests/attendance.spec.ts
@@ -109,8 +109,13 @@ test("View and download attendance report", async ({ page }) => {
   const downloadPromise = page.waitForEvent("download");
   await page.getByRole("button", { name: "Download", exact: true }).click();
   // export dialog: select CSV format and confirm
-  await page.getByRole("radio", { name: "CSV" }).click();
-  await page.getByRole("button", { name: "Download", exact: true }).click();
+  // (scoped to the dialog because the page's own "Download" button may still be
+  // exposed to the accessibility tree while the dialog is opening)
+  const exportDialog = page.getByRole("dialog");
+  await exportDialog.getByRole("radio", { name: "CSV" }).click();
+  await exportDialog
+    .getByRole("button", { name: "Download", exact: true })
+    .click();
   const filename = (await downloadPromise).suggestedFilename();
   expect(filename).toBe("Attendance Report 2025-01-12_2025-01-18.csv");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "serve": "^14.2.6",
+        "setimmediate": "^1.0.5",
         "stream-browserify": "^3.0.0",
         "tslib": "^2.8.1",
         "util": "^0.12.5",
@@ -13132,6 +13133,18 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-leveldown": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
@@ -16955,6 +16968,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -25884,29 +25906,21 @@
         "readable-stream": "1.1.14"
       }
     },
-    "node_modules/sublevel-pouchdb/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
     "node_modules/sublevel-pouchdb/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/sublevel-pouchdb/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13133,18 +13133,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/abstract-leveldown": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
@@ -16968,15 +16956,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -25904,22 +25883,6 @@
         "level-codec": "9.0.2",
         "ltgt": "2.2.1",
         "readable-stream": "1.1.14"
-      }
-    },
-    "node_modules/sublevel-pouchdb/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "rxjs": "^7.8.2",
         "serve": "^14.2.6",
         "setimmediate": "^1.0.5",
+        "stream": "npm:stream-browserify@^3.0.0",
         "stream-browserify": "^3.0.0",
         "tslib": "^2.8.1",
         "util": "^0.12.5",
@@ -25673,6 +25674,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stream": {
+      "name": "stream-browserify",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -25884,6 +25896,30 @@
         "ltgt": "2.2.1",
         "readable-stream": "1.1.14"
       }
+    },
+    "node_modules/sublevel-pouchdb/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/sublevel-pouchdb/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/sublevel-pouchdb/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   },
   "overrides": {
     "sublevel-pouchdb": {
-      "readable-stream": "^4.7.0"
+      "readable-stream": "^3.6.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "serve": "^14.2.6",
+    "setimmediate": "^1.0.5",
     "stream-browserify": "^3.0.0",
     "tslib": "^2.8.1",
     "util": "^0.12.5",
@@ -140,5 +141,10 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.66.0",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "sublevel-pouchdb": {
+      "readable-stream": "^4.7.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "rxjs": "^7.8.2",
     "serve": "^14.2.6",
     "setimmediate": "^1.0.5",
+    "stream": "npm:stream-browserify@^3.0.0",
     "stream-browserify": "^3.0.0",
     "tslib": "^2.8.1",
     "util": "^0.12.5",
@@ -141,10 +142,5 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.66.0",
     "vitest": "^4.1.10"
-  },
-  "overrides": {
-    "sublevel-pouchdb": {
-      "readable-stream": "^3.6.2"
-    }
   }
 }

--- a/src/app/core/entity/default-datatype/default.datatype.ts
+++ b/src/app/core/entity/default-datatype/default.datatype.ts
@@ -15,7 +15,6 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { $localize } from "@angular/localize/init"; // import needed to make this file work in e2e test fixtures also
 import { EntitySchemaField } from "../schema/entity-schema-field";
 import { Entity, EntityConstructor } from "../model/entity";
 import { asArray } from "../../../utils/asArray";

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -35,6 +35,10 @@ import "@angular/localize/init";
 import "hammerjs";
 import * as buffer from "buffer";
 import * as process from "process";
+// polyfills window.setImmediate, required by memdown (pouchdb-adapter-memory)
+// when the dev server's dependency prebundling skips memdown's package.json
+// "browser" field remapping to a browser-safe implementation
+import "setimmediate";
 
 // WARNING: workaround to allow PouchDB with Angular v6: https://github.com/pouchdb/pouchdb/issues/7263
 (window as any).global = window;


### PR DESCRIPTION
Migrates the app build from the deprecated webpack-based builder to the esbuild-based application builder for much faster builds (local production build: ~2m 15s webpack vs ~30-40s esbuild, identical total bundle size).

- The `build` target now uses `@angular/build:application` instead of `@angular-devkit/build-angular:browser`. The separate `build-test` target (added for the vitest setup) is merged into it, so unit tests now build through `ndb-core:build:testing` and the duplicated config is gone.
- Output stays flat in `dist/` via `"outputPath": {"base": "dist", "browser": ""}`, so the Dockerfile, service worker regeneration, sourcemap handling and the e2e static server all keep working unchanged.
- `serve` and `extract-i18n` switch to their `@angular/build` equivalents.
- Two small workarounds for PouchDB under the new bundler:
  - a scoped npm override lifting `sublevel-pouchdb`'s pinned `readable-stream@1.x` (which requires the Node `stream` builtin that esbuild does not polyfill) to v4, which is browser-safe; other packages keep their own `readable-stream` versions.
  - a `setimmediate` polyfill for `memdown`, needed when the dev server's dependency prebundling skips its package.json "browser" field remapping.
- `allowedCommonJsDependencies` now lists the known CommonJS packages so the build stays warning-free.

Verified locally: production bundle and `ng serve` both boot demo mode, generate demo data, build indexes, render lists and export XLSX without errors. Storybook also starts and renders stories as before (its one console error exists identically on master).

- closes #2298

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

## Manual Testing Steps

1. Open the demo app, choose a use case with "Generate demo data" enabled and create the system. The dashboard should fill with sample data as usual.
2. Open the Children list, filter and sort a bit, and open one record's details.
3. In the list menu, use "Download" once as CSV and once as XLSX (Excel). Both files should download and contain the displayed records.
4. Reload the page once. The app should start up again into the demo without errors.
5. Switch the language (if available on the deployment) to check translations still load.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Updated application build, development server, and localization tooling for improved Angular compatibility.
  - Added browser compatibility support for required runtime features.
  - Improved handling of supported CommonJS dependencies.

- **Bug Fixes**
  - Improved attendance report downloads by ensuring export actions target the correct dialog.
  - Ensured localization functionality is available during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->