### PR TITLE
fix(Admin UI): reset isArray when changing a field to a dataType without multi-value support

### DIFF
--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -125,10 +125,7 @@
               ></app-basic-autocomplete>
             </mat-form-field>
 
-            @if (
-              formDataType.value === "configurable-enum" ||
-              formDataType.value === "entity"
-            ) {
+            @if (supportsMultiValue(formDataType.value)) {
               <mat-checkbox
                 formControlName="isArray"
                 matTooltip="Check this to let users select more than just one entry in this field."

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -278,6 +278,25 @@ describe("AdminEntityFieldComponent", () => {
     expect(dialogData.entitySchemaField.isArray).toBe(true);
   });
 
+  it("should keep isArray when switching to a dataType that requires multiple values", async () => {
+    // "attendance" does not offer the checkbox but enforces isArray itself
+    await recreateComponentWithData({
+      label: "participants",
+      dataType: EntityDatatype.dataType,
+      additional: TestEntity.ENTITY_TYPE,
+      isArray: true,
+    } as EntitySchemaField);
+    await fixture.whenStable();
+
+    component.schemaFieldsForm
+      .get("dataType")
+      .setValue(AttendanceDatatype.dataType);
+    await fixture.whenStable();
+
+    expect(component.schemaFieldsForm.get("isArray").value).toBe(true);
+    expect(dialogData.entitySchemaField.isArray).toBe(true);
+  });
+
   it("should support array values for entity type additional", async () => {
     await recreateComponentWithData({
       label: "related records",

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -8,10 +8,12 @@ import { HarnessLoader } from "@angular/cdk/testing";
 import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
 import { MatFormFieldHarness } from "@angular/material/form-field/testing";
 import { MatInputHarness } from "@angular/material/input/testing";
+import { MatCheckboxHarness } from "@angular/material/checkbox/testing";
 import { Entity } from "../../../entity/model/entity";
 import { ConfigurableEnumDatatype } from "../../../basic-datatypes/configurable-enum/configurable-enum-datatype/configurable-enum.datatype";
 import { EntityDatatype } from "../../../basic-datatypes/entity/entity.datatype";
 import { StringDatatype } from "../../../basic-datatypes/string/string.datatype";
+import { LongTextDatatype } from "../../../basic-datatypes/string/long-text.datatype";
 import { ConfigurableEnumService } from "../../../basic-datatypes/configurable-enum/configurable-enum.service";
 import { generateIdFromLabel } from "../../../../utils/generate-id-from-label/generate-id-from-label";
 import { EntityRegistry } from "../../../entity/database-entity.decorator";
@@ -217,6 +219,63 @@ describe("AdminEntityFieldComponent", () => {
     await fixture.whenStable();
 
     expect(component.additionalForm.value).toBe(TestEntity.ENTITY_TYPE);
+  });
+
+  it("should offer the multi-value option only for dataTypes supporting it", async () => {
+    const dataTypeForm = component.schemaFieldsForm.get("dataType");
+    async function findMultiValueCheckbox() {
+      const checkboxes = await loader.getAllHarnesses(
+        MatCheckboxHarness.with({ label: /allow multiple values/ }),
+      );
+      return checkboxes[0];
+    }
+
+    dataTypeForm.setValue(ConfigurableEnumDatatype.dataType);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(await findMultiValueCheckbox()).toBeTruthy();
+
+    dataTypeForm.setValue(LongTextDatatype.dataType);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(await findMultiValueCheckbox()).toBeUndefined();
+  });
+
+  it("should remove isArray when switching to a dataType that does not support multiple values", async () => {
+    await recreateComponentWithData({
+      label: "interests",
+      dataType: ConfigurableEnumDatatype.dataType,
+      additional: "interests",
+      isArray: true,
+    } as EntitySchemaField);
+    await fixture.whenStable();
+
+    component.schemaFieldsForm
+      .get("dataType")
+      .setValue(LongTextDatatype.dataType);
+    await fixture.whenStable();
+
+    expect(component.schemaFieldsForm.get("isArray").value).toBeFalsy();
+    // the flag has to be removed entirely, not just set to false
+    expect(dialogData.entitySchemaField.isArray).toBeUndefined();
+  });
+
+  it("should keep isArray when switching between dataTypes that support multiple values", async () => {
+    await recreateComponentWithData({
+      label: "related records",
+      dataType: ConfigurableEnumDatatype.dataType,
+      additional: "interests",
+      isArray: true,
+    } as EntitySchemaField);
+    await fixture.whenStable();
+
+    component.schemaFieldsForm
+      .get("dataType")
+      .setValue(EntityDatatype.dataType);
+    await fixture.whenStable();
+
+    expect(component.schemaFieldsForm.get("isArray").value).toBe(true);
+    expect(dialogData.entitySchemaField.isArray).toBe(true);
   });
 
   it("should support array values for entity type additional", async () => {

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -140,6 +140,15 @@ export class AdminEntityFieldComponent implements OnInit {
   entityAdditionalMultiSelect: WritableSignal<boolean> = signal(false);
   attendanceParticipantTypesForm = new FormControl<string[]>([]);
 
+  /**
+   * dataTypes for which a field can hold multiple values (`isArray`),
+   * so that the "allow multiple values" option is offered to the user.
+   */
+  private static readonly MULTI_VALUE_DATATYPES: string[] = [
+    ConfigurableEnumDatatype.dataType,
+    EntityDatatype.dataType,
+  ];
+
   ngOnInit() {
     this.entityType = this.data.entityType;
     this.initSettings();
@@ -277,6 +286,7 @@ export class AdminEntityFieldComponent implements OnInit {
       .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((v) => {
         this.updateDataTypeAdditional(v);
+        this.resetIsArrayIfUnsupported(v);
       });
     this.updateForNewOrExistingField();
   }
@@ -346,6 +356,32 @@ export class AdminEntityFieldComponent implements OnInit {
   createNewAdditionalOption: (input: string) => SimpleDropdownValue;
   createNewAdditionalOptionAsync = async (input) =>
     this.createNewAdditionalOption(input);
+
+  /**
+   * Whether the given dataType can hold multiple values in one field,
+   * i.e. whether the `isArray` schema flag is applicable.
+   */
+  supportsMultiValue(dataType: string): boolean {
+    return AdminEntityFieldComponent.MULTI_VALUE_DATATYPES.includes(dataType);
+  }
+
+  /**
+   * Remove the `isArray` flag if the newly selected dataType does not support multiple values.
+   *
+   * The "allow multiple values" checkbox is only displayed for some dataTypes.
+   * Without this reset a previously set `isArray: true` silently remains in the config
+   * (e.g. when a multi-select "configurable-enum" field is changed to "long-text"),
+   * making the field's value an array that the dataType's display component cannot handle.
+   */
+  private resetIsArrayIfUnsupported(dataType: string) {
+    if (this.supportsMultiValue(dataType)) return;
+
+    const isArrayControl = this.schemaFieldsForm.get("isArray");
+    if (!isArrayControl?.value) return;
+
+    // `null` (rather than `false`) so that the flag is removed from the schema entirely
+    isArrayControl.setValue(null);
+  }
 
   private updateDataTypeAdditional(
     dataType: string,

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -358,15 +358,26 @@ export class AdminEntityFieldComponent implements OnInit {
     this.createNewAdditionalOption(input);
 
   /**
-   * Whether the given dataType can hold multiple values in one field,
-   * i.e. whether the `isArray` schema flag is applicable.
+   * Whether the user can choose to hold multiple values in one field of the given dataType,
+   * i.e. whether the "allow multiple values" option is offered.
    */
   supportsMultiValue(dataType: string): boolean {
     return AdminEntityFieldComponent.MULTI_VALUE_DATATYPES.includes(dataType);
   }
 
   /**
-   * Remove the `isArray` flag if the newly selected dataType does not support multiple values.
+   * Whether the dataType itself requires multiple values, independent of the user's choice
+   * (see {@link DefaultDatatype.normalizeSchemaField}, e.g. "attendance").
+   */
+  private enforcesMultiValue(dataType: string): boolean {
+    const datatype = (
+      this.allDataTypes as unknown as DefaultDatatype<any, any>[]
+    ).find((d) => d.dataType === dataType);
+    return !!datatype?.normalizeSchemaField({ dataType })?.isArray;
+  }
+
+  /**
+   * Remove the `isArray` flag if the newly selected dataType does not use multiple values.
    *
    * The "allow multiple values" checkbox is only displayed for some dataTypes.
    * Without this reset a previously set `isArray: true` silently remains in the config
@@ -374,7 +385,8 @@ export class AdminEntityFieldComponent implements OnInit {
    * making the field's value an array that the dataType's display component cannot handle.
    */
   private resetIsArrayIfUnsupported(dataType: string) {
-    if (this.supportsMultiValue(dataType)) return;
+    if (this.supportsMultiValue(dataType) || this.enforcesMultiValue(dataType))
+      return;
 
     const isArrayControl = this.schemaFieldsForm.get("isArray");
     if (!isArrayControl?.value) return;


### PR DESCRIPTION
## Problem

The "allow multiple values (multi-select)" checkbox in the field config dialog is only rendered for the `configurable-enum` and `entity` dataTypes, but its form control was never reset when the dataType changed.

So when an admin switches an existing multi-select field to a dataType that has no multi-value support (e.g. `long-text`), the checkbox disappears from the UI while `isArray: true` silently stays in the entity schema:

```json
{ "id": "someField", "dataType": "long-text", "isArray": true }
```

That combination is not just cosmetic. `EntitySchemaService.valueToEntityFormat()` maps over the value for `isArray` fields, so the entity property becomes an **array** while the dataType's display component expects a single value. For `long-text` this throws in `DisplayLongTextComponent` (`text.split("\n")` on an array) and, because it happens during change detection, it takes down the whole view — the record's details page as well as any other view showing that field.

Observed in production as Sentry `AAM-DIGITAL-74G`. Note this PR does **not** resolve that issue: it prevents the broken config from being produced, but already-affected configs still need to be corrected (and their stored array values migrated).

## Change

- Clear the `isArray` control whenever the newly selected dataType does not use multiple values. It is set to `null` rather than `false` so the flag is removed from the schema entirely instead of persisting a redundant `isArray: false`. (`AdminEntityService.updateSchemaField` replaces the schema entry wholesale, so the removal reaches the saved config.)
- Derive the checkbox's visibility from the same `supportsMultiValue()` predicate that the reset uses, so the displayed option and the reset logic cannot drift apart.
- Keep `isArray` for dataTypes that require multiple values on their own via `normalizeSchemaField()` (currently `attendance`), which enforce the flag without exposing the checkbox. Asking the datatype avoids hard-coding that exception a second time.

## Tests

Four specs added to `admin-entity-field.component.spec.ts`:

- the multi-value option is only offered for dataTypes supporting it
- switching to a dataType without multi-value support removes `isArray` from the schema field
- switching between two multi-value dataTypes keeps `isArray` untouched
- switching to `attendance` keeps `isArray`, since that datatype enforces it

The two removal/retention specs were each verified to fail when the corresponding guard is removed.

Two specs in `admin-entity-details/` fail on this branch, but they fail identically on a clean `origin/master` and are unrelated to this change. `qlty check` could not be run locally (its bundled ESLint 9.7.0 crashes on this machine's Node 26); the repo's own ESLint and Prettier pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)