### PR TITLE
feat(i18n): implement multi-lingual configuration support

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -664,9 +664,9 @@ test("Admin: edit general settings (label, tooltip, verify after save)", async (
   await expect(page.locator("[formcontrolname='label'] input")).toHaveValue(
     "Participant",
   );
-  await expect(page.locator("[formcontrolname='labelPlural'] input")).toHaveValue(
-    "Participants",
-  );
+  await expect(
+    page.locator("[formcontrolname='labelPlural'] input"),
+  ).toHaveValue("Participants");
 
   await argosScreenshot(page, "admin-general-settings-after-save");
 });

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -657,14 +657,14 @@ test("Admin: edit general settings (label, tooltip, verify after save)", async (
   await page.getByText("Configure Data Structure").click();
   await page.waitForLoadState("networkidle");
   await page.getByText("General Settings").click();
-  await expect(page.locator("[formcontrolname='label']")).toBeVisible({
+  await expect(page.locator("[formcontrolname='label'] input")).toBeVisible({
     timeout: 10000,
   });
 
-  await expect(page.locator("[formcontrolname='label']")).toHaveValue(
+  await expect(page.locator("[formcontrolname='label'] input")).toHaveValue(
     "Participant",
   );
-  await expect(page.locator("[formcontrolname='labelPlural']")).toHaveValue(
+  await expect(page.locator("[formcontrolname='labelPlural'] input")).toHaveValue(
     "Participants",
   );
 

--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -1,10 +1,4 @@
-import {
-  argosScreenshot,
-  expect,
-  loadApp,
-  test,
-  waitForDashboardWidgetsToLoad,
-} from "#e2e/fixtures.js";
+import { argosScreenshot, expect, loadApp, test } from "#e2e/fixtures.js";
 
 test("Changelog dialog shows latest release when version is clicked", async ({
   page,
@@ -37,63 +31,4 @@ test("Changelog dialog shows latest release when version is clicked", async ({
   await expect(changelogDialog.getByText("Release v1.5.0")).toBeVisible();
 
   await argosScreenshot(page, "changelog-dialog", { fullPage: false });
-});
-
-test("Translated and localized app versions (i18n)", async ({ page }) => {
-  await page.goto("/");
-
-  // Wait for dialog to be fully interactive before clicking mat-select
-  await expect(
-    page.getByRole("heading", { name: "Welcome to Aam Digital!" }),
-  ).toBeVisible();
-
-  await page.getByText("Choose your language").click();
-  await page.getByRole("option", { name: "Deutsch / German (de)" }).click();
-
-  await expect(
-    page.getByRole("heading", { name: "Willkommen bei Aam Digital!" }),
-  ).toBeVisible();
-
-  await page.getByRole("combobox", { name: "Anwendungsfall" }).click();
-  await page.getByRole("option", { name: "Bildungsprojekt" }).click();
-
-  // we're in a using mat-dialog, we need to scroll within the dialog container
-  await page
-    .getByRole("button", { name: "System erstellen" })
-    .scrollIntoViewIfNeeded();
-
-  await argosScreenshot(page, "i18n-de_init");
-
-  await page.getByRole("button", { name: "System erstellen" }).click();
-
-  await page
-    .getByRole("button", { name: "System erkunden" })
-    .click({ timeout: 10_000 });
-
-  await expect(
-    page.getByRole("button", { name: "System erkunden" }),
-  ).not.toBeVisible();
-
-  // FIXME: The dashboard may load before demo data is generated and not display
-  // it. As a workaround we move to a different view and back to the dashboard
-  await page.getByRole("navigation").getByText("Schüler:innen").click();
-
-  // Extract the count from the paginator (e.g., "1 – 10 von 99" in German)
-  // Wait for the paginator to load
-  await page.locator(".mat-mdc-paginator-range-label").waitFor();
-  const paginatorText = await page
-    .locator(".mat-mdc-paginator-range-label")
-    .textContent();
-  const countMatch = paginatorText?.match(/von (\d+)/);
-  const studentCount = countMatch ? countMatch[1] : "0";
-
-  await page.getByRole("navigation").getByText("Dashboard").click();
-  await expect(page.getByText(`${studentCount} Schüler:innen`)).toBeVisible({
-    timeout: 10_000,
-  });
-
-  // Wait for all dashboard widgets to finish loading before taking screenshot
-  await waitForDashboardWidgetsToLoad(page);
-
-  await argosScreenshot(page, "i18n-de_dashboard");
 });

--- a/e2e/tests/i18n-config.spec.ts
+++ b/e2e/tests/i18n-config.spec.ts
@@ -1,4 +1,11 @@
-import { expect, loadApp, Page, test } from "#e2e/fixtures.js";
+import {
+  argosScreenshot,
+  expect,
+  loadApp,
+  Page,
+  test,
+  waitForDashboardWidgetsToLoad,
+} from "#e2e/fixtures.js";
 
 const LOCALE_STORAGE_KEY = "locale";
 
@@ -26,20 +33,20 @@ async function openChildrenList(page: Page) {
   await page.waitForLoadState("networkidle");
 }
 
-test("shows a multi-lingual config label in the default language", async ({
+test("shows a multi-lingual config label in the default language, then in the user's own language after switching locale", async ({
   page,
 }) => {
+  // --- default (English) locale ---
+
   await loadApp(page, []);
   await openChildrenList(page);
 
   await expect(
     page.getByRole("columnheader", { name: "Project Number" }),
   ).toBeVisible();
-});
 
-test("shows a multi-lingual config label in the user's own language", async ({
-  page,
-}) => {
+  // --- user's own (German) locale ---
+
   await loadAppInLocale(page, "de");
   await openChildrenList(page);
 
@@ -49,4 +56,65 @@ test("shows a multi-lingual config label in the user's own language", async ({
   await expect(
     page.getByRole("columnheader", { name: "Project Number" }),
   ).toHaveCount(0);
+});
+
+test("translates the whole app when the user picks a language on the welcome screen", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // Wait for dialog to be fully interactive before clicking mat-select
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Aam Digital!" }),
+  ).toBeVisible();
+
+  await page.getByText("Choose your language").click();
+  await page.getByRole("option", { name: "Deutsch / German (de)" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Willkommen bei Aam Digital!" }),
+  ).toBeVisible();
+
+  await page.getByRole("combobox", { name: "Anwendungsfall" }).click();
+  await page.getByRole("option", { name: "Bildungsprojekt" }).click();
+
+  // we're in a using mat-dialog, we need to scroll within the dialog container
+  await page
+    .getByRole("button", { name: "System erstellen" })
+    .scrollIntoViewIfNeeded();
+
+  await argosScreenshot(page, "i18n-de_init");
+
+  await page.getByRole("button", { name: "System erstellen" }).click();
+
+  await page
+    .getByRole("button", { name: "System erkunden" })
+    .click({ timeout: 10_000 });
+
+  await expect(
+    page.getByRole("button", { name: "System erkunden" }),
+  ).not.toBeVisible();
+
+  // FIXME: The dashboard may load before demo data is generated and not display
+  // it. As a workaround we move to a different view and back to the dashboard
+  await page.getByRole("navigation").getByText("Schüler:innen").click();
+
+  // Extract the count from the paginator (e.g., "1 – 10 von 99" in German)
+  // Wait for the paginator to load
+  await page.locator(".mat-mdc-paginator-range-label").waitFor();
+  const paginatorText = await page
+    .locator(".mat-mdc-paginator-range-label")
+    .textContent();
+  const countMatch = paginatorText?.match(/von (\d+)/);
+  const studentCount = countMatch ? countMatch[1] : "0";
+
+  await page.getByRole("navigation").getByText("Dashboard").click();
+  await expect(page.getByText(`${studentCount} Schüler:innen`)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Wait for all dashboard widgets to finish loading before taking screenshot
+  await waitForDashboardWidgetsToLoad(page);
+
+  await argosScreenshot(page, "i18n-de_dashboard");
 });

--- a/e2e/tests/i18n-config.spec.ts
+++ b/e2e/tests/i18n-config.spec.ts
@@ -1,0 +1,52 @@
+import { expect, loadApp, Page, test } from "#e2e/fixtures.js";
+
+const LOCALE_STORAGE_KEY = "locale";
+
+/**
+ * Like `loadApp(page, [])`, but starts the app in the given locale.
+ *
+ * The welcome screen's button is localized, so it is located by its container
+ * rather than by its text - otherwise this could only ever run in English.
+ */
+async function loadAppInLocale(page: Page, locale: string) {
+  await page.addInitScript(
+    ({ key, value }) => {
+      localStorage.setItem(key, value);
+      window["e2eDemoData"] = [];
+    },
+    { key: LOCALE_STORAGE_KEY, value: locale },
+  );
+
+  await page.goto("/?useCase=all-features");
+  await page.locator(".demo-actions button").click({ timeout: 10_000 });
+}
+
+async function openChildrenList(page: Page) {
+  await page.getByRole("navigation").getByText("Children").click();
+  await page.waitForLoadState("networkidle");
+}
+
+test("shows a multi-lingual config label in the default language", async ({
+  page,
+}) => {
+  await loadApp(page, []);
+  await openChildrenList(page);
+
+  await expect(
+    page.getByRole("columnheader", { name: "Project Number" }),
+  ).toBeVisible();
+});
+
+test("shows a multi-lingual config label in the user's own language", async ({
+  page,
+}) => {
+  await loadAppInLocale(page, "de");
+  await openChildrenList(page);
+
+  await expect(
+    page.getByRole("columnheader", { name: "Projektnummer" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("columnheader", { name: "Project Number" }),
+  ).toHaveCount(0);
+});

--- a/e2e/tests/i18n-config.spec.ts
+++ b/e2e/tests/i18n-config.spec.ts
@@ -56,6 +56,8 @@ test("shows a multi-lingual config label in the default language, then in the us
   await expect(
     page.getByRole("columnheader", { name: "Project Number" }),
   ).toHaveCount(0);
+
+  await argosScreenshot(page, "i18n-de_children-list");
 });
 
 test("translates the whole app when the user picks a language on the welcome screen", async ({
@@ -68,7 +70,7 @@ test("translates the whole app when the user picks a language on the welcome scr
     page.getByRole("heading", { name: "Welcome to Aam Digital!" }),
   ).toBeVisible();
 
-  await page.getByText("Choose your language").click();
+  await page.getByRole("combobox", { name: "Choose your language" }).click();
   await page.getByRole("option", { name: "Deutsch / German (de)" }).click();
 
   await expect(

--- a/src/app/core/admin/admin-entity-details/admin-entity-details/admin-entity-details.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-details/admin-entity-details.component.html
@@ -13,6 +13,7 @@
 </app-view-title>
 
 <app-admin-tabs
+  [translatableTitle]="true"
   [tabs]="panels()"
   (tabsChange)="panels.set($event)"
   [newTabFactory]="newPanelFactory"
@@ -45,6 +46,7 @@
                 ></fa-icon>
                 <div class="section-header-content">
                   <app-admin-section-header
+                    [translatable]="true"
                     [(title)]="componentConfig.title"
                     (remove)="removeComponent(item, i)"
                     (keydown)="$event.stopPropagation()"

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -29,6 +29,16 @@
             <mat-form-field>
               <mat-label i18n>Label</mat-label>
               <input formControlName="label" matInput #formLabel />
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="openTranslations('label', $event)"
+                matTooltip="Configure this text in other languages"
+                i18n-matTooltip
+              >
+                <fa-icon icon="language"></fa-icon>
+              </button>
               @if (schemaFieldsForm.get("label").hasError("uniqueProperty")) {
                 <mat-error>
                   {{ schemaFieldsForm.get("label").getError("uniqueProperty") }}
@@ -59,6 +69,16 @@
                 matInput
                 [placeholder]="formLabel.value"
               />
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="openTranslations('labelShort', $event)"
+                matTooltip="Configure this text in other languages"
+                i18n-matTooltip
+              >
+                <fa-icon icon="language"></fa-icon>
+              </button>
             </mat-form-field>
 
             <mat-form-field>
@@ -75,6 +95,16 @@
                 matInput
                 rows="3"
               ></textarea>
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="openTranslations('description', $event)"
+                matTooltip="Configure this text in other languages"
+                i18n-matTooltip
+              >
+                <fa-icon icon="language"></fa-icon>
+              </button>
             </mat-form-field>
           </div>
 

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -1,6 +1,4 @@
-<h2 mat-dialog-title i18n>
-  Configure Field "{{ resolvedLabel }}"
-</h2>
+<h2 mat-dialog-title i18n>Configure Field "{{ resolvedLabel }}"</h2>
 <app-dialog-close mat-dialog-close></app-dialog-close>
 
 <mat-dialog-content>

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title i18n>
-  Configure Field "{{ data.entitySchemaField.label }}"
+  Configure Field "{{ resolvedLabel }}"
 </h2>
 <app-dialog-close mat-dialog-close></app-dialog-close>
 
@@ -28,17 +28,9 @@
           <div class="entity-form-cell">
             <mat-form-field>
               <mat-label i18n>Label</mat-label>
-              <input formControlName="label" matInput #formLabel />
-              <button
-                mat-icon-button
-                matSuffix
-                type="button"
-                (click)="openTranslations('label', $event)"
-                matTooltip="Configure this text in other languages"
-                i18n-matTooltip
-              >
-                <fa-icon icon="language"></fa-icon>
-              </button>
+              <app-translatable-text-input
+                formControlName="label"
+              ></app-translatable-text-input>
               @if (schemaFieldsForm.get("label").hasError("uniqueProperty")) {
                 <mat-error>
                   {{ schemaFieldsForm.get("label").getError("uniqueProperty") }}
@@ -64,21 +56,10 @@
                   i18n-matTooltip
                 ></fa-icon>
               </mat-label>
-              <input
+              <app-translatable-text-input
                 formControlName="labelShort"
-                matInput
-                [placeholder]="formLabel.value"
-              />
-              <button
-                mat-icon-button
-                matSuffix
-                type="button"
-                (click)="openTranslations('labelShort', $event)"
-                matTooltip="Configure this text in other languages"
-                i18n-matTooltip
-              >
-                <fa-icon icon="language"></fa-icon>
-              </button>
+                [placeholder]="resolvedLabel"
+              ></app-translatable-text-input>
             </mat-form-field>
 
             <mat-form-field>
@@ -90,21 +71,11 @@
                   i18n-matTooltip
                 ></fa-icon>
               </mat-label>
-              <textarea
+              <app-translatable-text-input
                 formControlName="description"
-                matInput
-                rows="3"
-              ></textarea>
-              <button
-                mat-icon-button
-                matSuffix
-                type="button"
-                (click)="openTranslations('description', $event)"
-                matTooltip="Configure this text in other languages"
-                i18n-matTooltip
-              >
-                <fa-icon icon="language"></fa-icon>
-              </button>
+                [multiline]="true"
+                [rows]="3"
+              ></app-translatable-text-input>
             </mat-form-field>
           </div>
 

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -491,7 +491,9 @@ describe("AdminEntityFieldComponent", () => {
 
       // editing any other setting writes the whole form back onto the schema
       // field - the translations must not be lost by that
-      component.schemaFieldsForm.get("description").setValue("Some description");
+      component.schemaFieldsForm
+        .get("description")
+        .setValue("Some description");
       await fixture.whenStable();
 
       await component.save();

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminEntityFieldComponent } from "./admin-entity-field.component";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { of } from "rxjs";
 import { CoreTestingModule } from "../../../../utils/core-testing.module";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -473,5 +474,92 @@ describe("AdminEntityFieldComponent", () => {
     component.fieldIdForm.setValue("valid_id");
     await fixture.whenStable();
     expect(component.fieldIdForm.errors).toBeNull();
+  });
+
+  describe("multi-lingual config (#3862)", () => {
+    const TRANSLATIONS = { "en-US": "Name", de: "Vorname" };
+
+    /** simulate the user configuring translations and confirming the dialog */
+    function configureTranslations(
+      property: string,
+      result: Record<string, string> | string,
+    ) {
+      // the component gets MatDialog from its own injector (it imports
+      // MatDialogModule), so spying on the TestBed instance would not apply
+      vi.spyOn(component["dialog"], "open").mockReturnValue({
+        afterClosed: () => of(result),
+      } as any);
+
+      component.openTranslations(property, {
+        stopPropagation: () => undefined,
+      } as Event);
+    }
+
+    it("should show the active language's text in the plain input", async () => {
+      await recreateComponentWithData({
+        id: "name",
+        label: "Name",
+        dataType: "string",
+      } as EntitySchemaField);
+
+      configureTranslations("label", TRANSLATIONS);
+      await fixture.whenStable();
+
+      // tests run in the default language
+      expect(component.schemaFieldsForm.get("label").value).toBe("Name");
+    });
+
+    it("should keep configured translations when other settings are edited afterwards", async () => {
+      await recreateComponentWithData({
+        id: "name",
+        label: "Name",
+        dataType: "string",
+      } as EntitySchemaField);
+
+      configureTranslations("label", TRANSLATIONS);
+      await fixture.whenStable();
+
+      // editing any other setting writes the whole form back onto the schema
+      // field - the translations must not be lost by that
+      component.schemaFieldsForm
+        .get("description")
+        .setValue("Some description");
+      await fixture.whenStable();
+
+      component.save();
+
+      expect(dialogData.entitySchemaField.label).toEqual(TRANSLATIONS);
+      expect(dialogData.entitySchemaField.description).toBe("Some description");
+    });
+
+    it("should store a plain string when only one language is configured", async () => {
+      await recreateComponentWithData({
+        id: "name",
+        label: "Name",
+        dataType: "string",
+      } as EntitySchemaField);
+
+      configureTranslations("label", "Full Name");
+      await fixture.whenStable();
+
+      await component.save();
+
+      expect(dialogData.entitySchemaField.label).toBe("Full Name");
+    });
+
+    it("should not change anything when the translations dialog is cancelled", async () => {
+      await recreateComponentWithData({
+        id: "name",
+        label: "Name",
+        dataType: "string",
+      } as EntitySchemaField);
+
+      configureTranslations("label", undefined);
+      await fixture.whenStable();
+
+      component.save();
+
+      expect(dialogData.entitySchemaField.label).toBe("Name");
+    });
   });
 });

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminEntityFieldComponent } from "./admin-entity-field.component";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
-import { of } from "rxjs";
 import { CoreTestingModule } from "../../../../utils/core-testing.module";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -476,38 +475,8 @@ describe("AdminEntityFieldComponent", () => {
     expect(component.fieldIdForm.errors).toBeNull();
   });
 
-  describe("multi-lingual config (#3862)", () => {
+  describe("multi-lingual config", () => {
     const TRANSLATIONS = { "en-US": "Name", de: "Vorname" };
-
-    /** simulate the user configuring translations and confirming the dialog */
-    function configureTranslations(
-      property: string,
-      result: Record<string, string> | string,
-    ) {
-      // the component gets MatDialog from its own injector (it imports
-      // MatDialogModule), so spying on the TestBed instance would not apply
-      vi.spyOn(component["dialog"], "open").mockReturnValue({
-        afterClosed: () => of(result),
-      } as any);
-
-      component.openTranslations(property, {
-        stopPropagation: () => undefined,
-      } as Event);
-    }
-
-    it("should show the active language's text in the plain input", async () => {
-      await recreateComponentWithData({
-        id: "name",
-        label: "Name",
-        dataType: "string",
-      } as EntitySchemaField);
-
-      configureTranslations("label", TRANSLATIONS);
-      await fixture.whenStable();
-
-      // tests run in the default language
-      expect(component.schemaFieldsForm.get("label").value).toBe("Name");
-    });
 
     it("should keep configured translations when other settings are edited afterwards", async () => {
       await recreateComponentWithData({
@@ -516,50 +485,48 @@ describe("AdminEntityFieldComponent", () => {
         dataType: "string",
       } as EntitySchemaField);
 
-      configureTranslations("label", TRANSLATIONS);
+      // the translatable input writes the full value (all languages) to the control
+      component.schemaFieldsForm.get("label").setValue(TRANSLATIONS);
       await fixture.whenStable();
 
       // editing any other setting writes the whole form back onto the schema
       // field - the translations must not be lost by that
-      component.schemaFieldsForm
-        .get("description")
-        .setValue("Some description");
+      component.schemaFieldsForm.get("description").setValue("Some description");
       await fixture.whenStable();
 
-      component.save();
+      await component.save();
 
       expect(dialogData.entitySchemaField.label).toEqual(TRANSLATIONS);
       expect(dialogData.entitySchemaField.description).toBe("Some description");
     });
 
-    it("should store a plain string when only one language is configured", async () => {
+    it("should show the text of the active language outside the form field", async () => {
       await recreateComponentWithData({
         id: "name",
         label: "Name",
         dataType: "string",
       } as EntitySchemaField);
 
-      configureTranslations("label", "Full Name");
+      component.schemaFieldsForm.get("label").setValue(TRANSLATIONS);
       await fixture.whenStable();
 
-      await component.save();
-
-      expect(dialogData.entitySchemaField.label).toBe("Full Name");
+      // tests run in the default language
+      expect(component.resolvedLabel).toBe("Name");
     });
 
-    it("should not change anything when the translations dialog is cancelled", async () => {
+    it("should generate the field id from the text, not from a translation map", async () => {
       await recreateComponentWithData({
-        id: "name",
-        label: "Name",
         dataType: "string",
       } as EntitySchemaField);
 
-      configureTranslations("label", undefined);
+      component.schemaFieldsForm
+        .get("label")
+        .setValue({ "en-US": "My New Field", de: "Mein neues Feld" });
       await fixture.whenStable();
 
-      component.save();
-
-      expect(dialogData.entitySchemaField.label).toBe("Name");
+      expect(component.fieldIdForm.value).toBe(
+        generateIdFromLabel("My New Field"),
+      );
     });
   });
 });

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   DestroyRef,
   inject,
+  LOCALE_ID,
   OnInit,
   signal,
   viewChild,
@@ -42,6 +43,15 @@ import { ConfigurableEnumService } from "../../../basic-datatypes/configurable-e
 import { EntityRegistry } from "../../../entity/database-entity.decorator";
 import { ConfigureEnumPopupComponent } from "../../../basic-datatypes/configurable-enum/configure-enum-popup/configure-enum-popup.component";
 import { ConfigurableEnum } from "../../../basic-datatypes/configurable-enum/configurable-enum";
+import { EntityConfig } from "../../../entity/entity-config";
+import { EntityConfigService } from "../../../entity/entity-config.service";
+import { ConfigureTranslationsPopupComponent } from "../../../config/configure-translations-popup/configure-translations-popup.component";
+import {
+  resolveTranslatableText,
+  TranslatableText,
+} from "../../../config/multi-lingual-config";
+import { availableLocales } from "../../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../../language/language-statics";
 import { generateIdFromLabel } from "../../../../utils/generate-id-from-label/generate-id-from-label";
 import { merge } from "rxjs";
 import { filter } from "rxjs/operators";
@@ -121,6 +131,20 @@ export class AdminEntityFieldComponent implements OnInit {
   private dialog = inject(MatDialog);
   private readonly confirmationDialog = inject(ConfirmationDialogService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly entityConfigService = inject(EntityConfigService);
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
+
+  /**
+   * Translation maps edited through the "Configure translations" dialog,
+   * keyed by schema field property (e.g. "label").
+   *
+   * These are only written onto the schema field in `save()`: the form's
+   * `valueChanges` writes every control back onto the schema field, so a map
+   * stored earlier would be overwritten by the plain text of the form control.
+   */
+  private pendingTranslations: Record<string, TranslatableText | undefined> =
+    {};
 
   private readonly validatorConfig = viewChild(
     ConfigureEntityFieldValidatorComponent,
@@ -190,7 +214,8 @@ export class AdminEntityFieldComponent implements OnInit {
     );
 
     const labelFormControl = this.fb.control(
-      this.data.entitySchemaField.label,
+      // may hold a translation map if translations were configured but not saved yet
+      this.resolveForDisplay(this.data.entitySchemaField.label),
       {
         validators: [Validators.required],
         asyncValidators: [
@@ -203,7 +228,8 @@ export class AdminEntityFieldComponent implements OnInit {
               ] of this.data.entityType.schema.entries()) {
                 if (key === this.data.entitySchemaField.id) continue;
                 if (field.label) {
-                  labels.push(field.label);
+                  // compare the texts of the active language, not raw maps
+                  labels.push(this.resolveForDisplay(field.label));
                 }
               }
               return labels;
@@ -218,14 +244,18 @@ export class AdminEntityFieldComponent implements OnInit {
     this.schemaFieldsForm = this.fb.group({
       id: this.fieldIdForm,
       label: labelFormControl,
-      labelShort: [this.data.entitySchemaField.labelShort],
+      labelShort: [
+        this.resolveForDisplay(this.data.entitySchemaField.labelShort),
+      ],
       displayFullLengthLabel: [
         this.data.entitySchemaField.displayFullLengthLabel ?? false,
       ],
       displayFullLengthOptionLabel: [
         this.data.entitySchemaField.displayFullLengthOptionLabel ?? false,
       ],
-      description: [this.data.entitySchemaField.description],
+      description: [
+        this.resolveForDisplay(this.data.entitySchemaField.description),
+      ],
 
       dataType: [this.data.entitySchemaField.dataType, Validators.required],
       isArray: [this.data.entitySchemaField.isArray],
@@ -515,6 +545,7 @@ export class AdminEntityFieldComponent implements OnInit {
 
     if (this.form.invalid || validatorForm?.invalid) return;
     this.data.entitySchemaField.id = this.fieldIdForm.getRawValue();
+    this.applyPendingTranslations();
     this.dialogRef.close(this.data.entitySchemaField);
   }
 
@@ -536,5 +567,82 @@ export class AdminEntityFieldComponent implements OnInit {
 
   resetToBaseFieldSettings() {
     this.dialogRef.close(this.fieldIdForm.getRawValue());
+  }
+
+  /**
+   * Open the dialog to configure this text in multiple languages (#3862).
+   *
+   * Edits the *raw* config value, so translations of languages other than the
+   * currently active one are never lost.
+   */
+  openTranslations(property: string, event: Event) {
+    event.stopPropagation();
+
+    this.dialog
+      .open(ConfigureTranslationsPopupComponent, {
+        data: {
+          value: this.getRawSchemaValue(property),
+          fieldLabel: this.schemaFieldsForm.get("label")?.value,
+        },
+        disableClose: true,
+      })
+      .afterClosed()
+      .subscribe((result?: TranslatableText) => {
+        if (result === undefined) {
+          // dialog cancelled: keep whatever was configured before
+          return;
+        }
+
+        this.pendingTranslations[property] = result;
+        // the plain form field keeps showing the text of the active language
+        this.schemaFieldsForm
+          .get(property)
+          ?.setValue(this.resolveForDisplay(result) ?? "");
+      });
+  }
+
+  /**
+   * The raw, unresolved value of a schema field property, read from the config
+   * document (the runtime schema only holds values of the active language).
+   */
+  private getRawSchemaValue(property: string): TranslatableText | undefined {
+    if (this.pendingTranslations[property] !== undefined) {
+      return this.pendingTranslations[property];
+    }
+
+    const entityConfig: EntityConfig =
+      this.entityConfigService.getRawEntityConfig(this.entityType);
+    const rawValue =
+      entityConfig?.attributes?.[this.data.entitySchemaField.id]?.[property];
+
+    // a field that is not in the config yet (newly added) has no raw value
+    return rawValue ?? this.schemaFieldsForm.get(property)?.value;
+  }
+
+  private resolveForDisplay(value: TranslatableText): string | undefined {
+    return resolveTranslatableText(
+      value,
+      this.locale,
+      DEFAULT_LANGUAGE,
+      this.validLocaleIds,
+    );
+  }
+
+  /**
+   * Write the configured translation maps onto the schema field.
+   *
+   * This has to happen last, when no further form updates can occur:
+   * `schemaFieldsForm.valueChanges` writes every control back onto the schema
+   * field, so a map written earlier would be replaced by the plain text of the
+   * form control as soon as any other setting is edited.
+   */
+  private applyPendingTranslations() {
+    for (const [property, value] of Object.entries(this.pendingTranslations)) {
+      if (value === undefined) {
+        delete this.data.entitySchemaField[property];
+      } else {
+        this.data.entitySchemaField[property] = value;
+      }
+    }
   }
 }

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -45,7 +45,7 @@ import { ConfigureEnumPopupComponent } from "../../../basic-datatypes/configurab
 import { ConfigurableEnum } from "../../../basic-datatypes/configurable-enum/configurable-enum";
 import { EntityConfig } from "../../../entity/entity-config";
 import { EntityConfigService } from "../../../entity/entity-config.service";
-import { ConfigureTranslationsPopupComponent } from "../../../config/configure-translations-popup/configure-translations-popup.component";
+import { TranslatableTextInputComponent } from "../../../config/translatable-text-input/translatable-text-input.component";
 import {
   resolveTranslatableText,
   TranslatableText,
@@ -119,6 +119,7 @@ export interface AdminEntityFieldData {
     AdminDefaultValueComponent,
     EntityTypeSelectComponent,
     AdminSearchableCheckboxComponent,
+    TranslatableTextInputComponent,
   ],
 })
 export class AdminEntityFieldComponent implements OnInit {
@@ -135,16 +136,6 @@ export class AdminEntityFieldComponent implements OnInit {
   private readonly locale = inject(LOCALE_ID);
   private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
 
-  /**
-   * Translation maps edited through the "Configure translations" dialog,
-   * keyed by schema field property (e.g. "label").
-   *
-   * These are only written onto the schema field in `save()`: the form's
-   * `valueChanges` writes every control back onto the schema field, so a map
-   * stored earlier would be overwritten by the plain text of the form control.
-   */
-  private pendingTranslations: Record<string, TranslatableText | undefined> =
-    {};
 
   private readonly validatorConfig = viewChild(
     ConfigureEntityFieldValidatorComponent,
@@ -214,8 +205,9 @@ export class AdminEntityFieldComponent implements OnInit {
     );
 
     const labelFormControl = this.fb.control(
-      // may hold a translation map if translations were configured but not saved yet
-      this.resolveForDisplay(this.data.entitySchemaField.label),
+      // the raw value (plain string or per-language map) - the input component
+      // displays only the active language of it
+      this.rawSchemaValue("label"),
       {
         validators: [Validators.required],
         asyncValidators: [
@@ -244,18 +236,14 @@ export class AdminEntityFieldComponent implements OnInit {
     this.schemaFieldsForm = this.fb.group({
       id: this.fieldIdForm,
       label: labelFormControl,
-      labelShort: [
-        this.resolveForDisplay(this.data.entitySchemaField.labelShort),
-      ],
+      labelShort: [this.rawSchemaValue("labelShort")],
       displayFullLengthLabel: [
         this.data.entitySchemaField.displayFullLengthLabel ?? false,
       ],
       displayFullLengthOptionLabel: [
         this.data.entitySchemaField.displayFullLengthOptionLabel ?? false,
       ],
-      description: [
-        this.resolveForDisplay(this.data.entitySchemaField.description),
-      ],
+      description: [this.rawSchemaValue("description")],
 
       dataType: [this.data.entitySchemaField.dataType, Validators.required],
       isArray: [this.data.entitySchemaField.isArray],
@@ -355,9 +343,10 @@ export class AdminEntityFieldComponent implements OnInit {
 
   private autoGenerateId() {
     // prefer labelShort if it exists, as this makes less verbose IDs
-    const label =
+    const label = this.resolveForDisplay(
       this.schemaFieldsForm.get("labelShort").value ??
-      this.schemaFieldsForm.get("label").value;
+        this.schemaFieldsForm.get("label").value,
+    );
     const generatedId = generateIdFromLabel(label);
     this.fieldIdForm.setValue(generatedId, { emitEvent: false });
   }
@@ -545,7 +534,6 @@ export class AdminEntityFieldComponent implements OnInit {
 
     if (this.form.invalid || validatorForm?.invalid) return;
     this.data.entitySchemaField.id = this.fieldIdForm.getRawValue();
-    this.applyPendingTranslations();
     this.dialogRef.close(this.data.entitySchemaField);
   }
 
@@ -570,44 +558,14 @@ export class AdminEntityFieldComponent implements OnInit {
   }
 
   /**
-   * Open the dialog to configure this text in multiple languages (#3862).
-   *
-   * Edits the *raw* config value, so translations of languages other than the
-   * currently active one are never lost.
+   * The raw, unresolved value of a schema field property, taken from the config
+   * document so that all configured languages are available for editing.
+   * The runtime schema only holds the text of the currently active language.
    */
-  openTranslations(property: string, event: Event) {
-    event.stopPropagation();
-
-    this.dialog
-      .open(ConfigureTranslationsPopupComponent, {
-        data: {
-          value: this.getRawSchemaValue(property),
-          fieldLabel: this.schemaFieldsForm.get("label")?.value,
-        },
-        disableClose: true,
-      })
-      .afterClosed()
-      .subscribe((result?: TranslatableText) => {
-        if (result === undefined) {
-          // dialog cancelled: keep whatever was configured before
-          return;
-        }
-
-        this.pendingTranslations[property] = result;
-        // the plain form field keeps showing the text of the active language
-        this.schemaFieldsForm
-          .get(property)
-          ?.setValue(this.resolveForDisplay(result) ?? "");
-      });
-  }
-
-  /**
-   * The raw, unresolved value of a schema field property, read from the config
-   * document (the runtime schema only holds values of the active language).
-   */
-  private getRawSchemaValue(property: string): TranslatableText | undefined {
-    if (this.pendingTranslations[property] !== undefined) {
-      return this.pendingTranslations[property];
+  private rawSchemaValue(property: string): TranslatableText | undefined {
+    if (this.data.overwriteLocally) {
+      // editing a single view's field config, which carries its own texts
+      return this.data.entitySchemaField[property];
     }
 
     const entityConfig: EntityConfig =
@@ -616,7 +574,12 @@ export class AdminEntityFieldComponent implements OnInit {
       entityConfig?.attributes?.[this.data.entitySchemaField.id]?.[property];
 
     // a field that is not in the config yet (newly added) has no raw value
-    return rawValue ?? this.schemaFieldsForm.get(property)?.value;
+    return rawValue ?? this.data.entitySchemaField[property];
+  }
+
+  /** the label text of the active language, for display outside the form field */
+  get resolvedLabel(): string {
+    return this.resolveForDisplay(this.schemaFieldsForm?.get("label")?.value) ?? "";
   }
 
   private resolveForDisplay(value: TranslatableText): string | undefined {
@@ -626,23 +589,5 @@ export class AdminEntityFieldComponent implements OnInit {
       DEFAULT_LANGUAGE,
       this.validLocaleIds,
     );
-  }
-
-  /**
-   * Write the configured translation maps onto the schema field.
-   *
-   * This has to happen last, when no further form updates can occur:
-   * `schemaFieldsForm.valueChanges` writes every control back onto the schema
-   * field, so a map written earlier would be replaced by the plain text of the
-   * form control as soon as any other setting is edited.
-   */
-  private applyPendingTranslations() {
-    for (const [property, value] of Object.entries(this.pendingTranslations)) {
-      if (value === undefined) {
-        delete this.data.entitySchemaField[property];
-      } else {
-        this.data.entitySchemaField[property] = value;
-      }
-    }
   }
 }

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -136,7 +136,6 @@ export class AdminEntityFieldComponent implements OnInit {
   private readonly locale = inject(LOCALE_ID);
   private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
 
-
   private readonly validatorConfig = viewChild(
     ConfigureEntityFieldValidatorComponent,
   );
@@ -579,7 +578,9 @@ export class AdminEntityFieldComponent implements OnInit {
 
   /** the label text of the active language, for display outside the form field */
   get resolvedLabel(): string {
-    return this.resolveForDisplay(this.schemaFieldsForm?.get("label")?.value) ?? "";
+    return (
+      this.resolveForDisplay(this.schemaFieldsForm?.get("label")?.value) ?? ""
+    );
   }
 
   private resolveForDisplay(value: TranslatableText): string | undefined {

--- a/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-field/admin-entity-field.component.ts
@@ -405,7 +405,8 @@ export class AdminEntityFieldComponent implements OnInit {
     } else if (this.schemaFieldsForm.get("label").value) {
       // when switching to enum datatype in the form, if unset generate a suggested enum-id immediately
       const newOption = this.createNewAdditionalOption(
-        this.schemaFieldsForm.get("label").value,
+        // resolve first: `generateIdFromLabel` returns undefined for a per-language map
+        this.resolveForDisplay(this.schemaFieldsForm.get("label").value),
       );
       this.typeAdditionalOptions.push(newOption);
       this.additionalForm.setValue(newOption.value);

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.html
@@ -21,6 +21,7 @@
             <!-- GROUP HEADER -->
             <app-admin-section-header
               class="flex-grow"
+              [translatable]="true"
               [title]="group.header"
               (titleChange)="updateGroupHeader(i, $event)"
               (remove)="removeGroup(i)"

--- a/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
+++ b/src/app/core/admin/admin-entity-details/admin-entity-form/admin-entity-form.component.ts
@@ -1,4 +1,5 @@
 import { EntityForm } from "#src/app/core/common-components/entity-form/entity-form";
+import { TranslatableText } from "../../../config/multi-lingual-config";
 import {
   CdkDragDrop,
   DragDropModule,
@@ -560,7 +561,7 @@ export class AdminEntityFormComponent {
     );
   }
 
-  updateGroupHeader(i: number, header: string) {
+  updateGroupHeader(i: number, header: TranslatableText) {
     this.fieldGroups.update((groups) =>
       groups.map((g, idx) => (idx === i ? { ...g, header } : g)),
     );

--- a/src/app/core/admin/admin-entity.service.ts
+++ b/src/app/core/admin/admin-entity.service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, inject, Injectable } from "@angular/core";
+import { EventEmitter, inject, Injectable, LOCALE_ID } from "@angular/core";
 import { EntityConstructor } from "../entity/model/entity";
 import { Config } from "../config/config";
 import { EntityConfig } from "../entity/entity-config";
@@ -8,6 +8,9 @@ import { EntityListConfig } from "../entity-list/EntityListConfig";
 import { EntityDetailsConfig } from "../entity-details/EntityDetailsConfig";
 import { DynamicComponentConfig } from "../config/dynamic-components/dynamic-component-config.interface";
 import { NoteDetailsConfig } from "#src/app/child-dev-project/notes/note-details/note-details-config.interface";
+import { mergeTranslatableValues } from "../config/multi-lingual-config";
+import { DEFAULT_LANGUAGE } from "../language/language-statics";
+import { availableLocales } from "../language/languages";
 
 /**
  * Simply service to centralize updates between various admin components in the form builder.
@@ -18,6 +21,9 @@ import { NoteDetailsConfig } from "#src/app/child-dev-project/notes/note-details
 export class AdminEntityService {
   public entitySchemaUpdated = new EventEmitter<void>();
   private entityMapper = inject(EntityMapperService);
+
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
 
   /**
    * Set a new schema field to the given entity and trigger update event for related admin components.
@@ -100,13 +106,38 @@ export class AdminEntityService {
       if (field.isInternalField) {
         continue;
       }
-      entitySchemaConfig.attributes[fieldId] = field;
+      // the runtime schema holds values resolved to the active language, so merge
+      // onto the raw config to keep translations of other languages (#3862)
+      entitySchemaConfig.attributes[fieldId] = this.mergeTranslations(
+        entitySchemaConfig.attributes[fieldId],
+        field,
+      );
     }
 
     // Add additional general settings if available
     if (configEntitySettings) {
-      Object.assign(entitySchemaConfig, configEntitySettings);
+      Object.assign(
+        entitySchemaConfig,
+        this.mergeTranslations(entitySchemaConfig, configEntitySettings),
+      );
     }
+  }
+
+  /**
+   * Merge an edited (language-resolved) config part onto its raw counterpart from
+   * the config document, so that translations for other languages are preserved.
+   */
+  private mergeTranslations<T extends Record<string, any>>(
+    raw: Record<string, any> | undefined,
+    edited: T,
+  ): T {
+    return mergeTranslatableValues(
+      raw,
+      edited,
+      this.locale,
+      DEFAULT_LANGUAGE,
+      this.validLocaleIds,
+    );
   }
 
   private getEntitySchemaFromConfig(

--- a/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.html
+++ b/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.html
@@ -12,7 +12,9 @@
         <div class="entity-form-cell">
           <mat-form-field>
             <mat-label i18n>Label</mat-label>
-            <input formControlName="label" matInput #formLabel />
+            <app-translatable-text-input
+              formControlName="label"
+            ></app-translatable-text-input>
           </mat-form-field>
 
           <mat-form-field floatLabel="always">
@@ -25,11 +27,10 @@
                 i18n-matTooltip
               ></fa-icon>
             </mat-label>
-            <input
+            <app-translatable-text-input
               formControlName="labelPlural"
-              matInput
-              [placeholder]="formLabel.value"
-            />
+              [placeholder]="resolvedLabel"
+            ></app-translatable-text-input>
           </mat-form-field>
 
           <app-icon-input [control]="iconControl"></app-icon-input>

--- a/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity-general-settings/admin-entity-general-settings.component.ts
@@ -1,4 +1,5 @@
 import {
+  LOCALE_ID,
   Component,
   inject,
   input,
@@ -31,6 +32,13 @@ import { MatOptionModule } from "@angular/material/core";
 import { MatSelectModule } from "@angular/material/select";
 import { EntitySchemaField } from "app/core/entity/schema/entity-schema-field";
 import { AdminEntityService } from "../../admin-entity.service";
+import {
+  resolveTranslatableText,
+  TranslatableText,
+} from "../../../config/multi-lingual-config";
+import { TranslatableTextInputComponent } from "../../../config/translatable-text-input/translatable-text-input.component";
+import { availableLocales } from "../../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../../language/language-statics";
 import { StringDatatype } from "../../../basic-datatypes/string/string.datatype";
 import { HelpButtonComponent } from "../../../common-components/help-button/help-button.component";
 import { AnonymizeOptionsComponent } from "../../admin-entity-details/admin-entity-field/anonymize-options/anonymize-options.component";
@@ -71,11 +79,29 @@ import { NumberDatatype } from "#src/app/core/basic-datatypes/number/number.data
     ConditionalColorConfigComponent,
     HintBoxComponent,
     EntityFieldSelectComponent,
+    TranslatableTextInputComponent,
   ],
 })
 export class AdminEntityGeneralSettingsComponent {
   private fb = inject(FormBuilder);
   private adminEntityService = inject(AdminEntityService);
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
+
+  /** resolve a possibly multi-lingual text to the currently active language */
+  protected resolveText(value: TranslatableText): string | undefined {
+    return resolveTranslatableText(
+      value,
+      this.locale,
+      DEFAULT_LANGUAGE,
+      this.validLocaleIds,
+    );
+  }
+
+  /** the entity label of the active language, used as the plural's placeholder */
+  protected get resolvedLabel(): string {
+    return this.resolveText(this.basicSettingsForm?.get("label")?.value) ?? "";
+  }
 
   entityConstructor = input.required<EntityConstructor>();
   generalSettings = input.required<EntityConfig>();
@@ -120,7 +146,10 @@ export class AdminEntityGeneralSettingsComponent {
             DateOnlyDatatype.dataType,
           ].includes(field.dataType) && field.label,
       )
-      .map(([key, field]) => ({ value: key, label: field.label }));
+      .map(([key, field]) => ({
+        value: key,
+        label: this.resolveText(field.label),
+      }));
 
     return [
       ...selectedKeys
@@ -134,13 +163,18 @@ export class AdminEntityGeneralSettingsComponent {
     if (!this.showPIIDetails()) return undefined;
     const fields = Array.from(this.entityConstructor().schema.entries())
       .filter(([, field]) => !field.isInternalField)
-      .map(([key, field]) => ({ key, label: field.label, field }));
+      .map(([key, field]) => ({
+        key,
+        label: this.resolveText(field.label),
+        field,
+      }));
     return new MatTableDataSource(fields);
   });
 
   readonly basicSettingsForm = this.fb.group({
-    label: [null as string | null, Validators.required],
-    labelPlural: [null as string | null],
+    // hold the raw value: a plain string or a per-language map
+    label: [null as TranslatableText | null, Validators.required],
+    labelPlural: [null as TranslatableText | null],
     icon: [null as string | null],
     color: [null as any],
     toStringAttributes: [null as string[] | null],

--- a/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
@@ -72,7 +72,9 @@ describe("AdminEntityComponent", () => {
     };
     mockConfigService.getConfig.mockReturnValue(config[viewConfigId]);
     // the raw config is read to keep multi-lingual labels editable
-    mockConfigService.getRawConfig.mockImplementation((id: string) => config[id]);
+    mockConfigService.getRawConfig.mockImplementation(
+      (id: string) => config[id],
+    );
 
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.spec.ts
@@ -68,8 +68,11 @@ describe("AdminEntityComponent", () => {
     };
     mockConfigService = {
       getConfig: vi.fn(),
+      getRawConfig: vi.fn(),
     };
     mockConfigService.getConfig.mockReturnValue(config[viewConfigId]);
+    // the raw config is read to keep multi-lingual labels editable
+    mockConfigService.getRawConfig.mockImplementation((id: string) => config[id]);
 
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/core/admin/admin-entity/admin-entity.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.ts
@@ -57,6 +57,7 @@ export class AdminEntityComponent {
   private configService = inject(ConfigService);
   private location = inject(Location);
   private adminEntityService = inject(AdminEntityService);
+  private entityConfigService = inject(EntityConfigService);
   private entityActionsService = inject(EntityActionsService);
   private routes = inject(ActivatedRoute);
   private readonly queryParams = toSignal(this.routes.queryParams, {
@@ -104,9 +105,12 @@ export class AdminEntityComponent {
   private getEntitySettingsFromConstructor(
     entityCtr: EntityConstructor,
   ): EntityConfig {
+    // labels come from the raw config (not the resolved constructor statics)
+    // so that all configured languages remain editable
+    const rawConfig = this.entityConfigService.getRawEntityConfig(entityCtr);
     const config: EntityConfig = {
-      label: entityCtr.label,
-      labelPlural: entityCtr.labelPlural,
+      label: rawConfig?.label ?? entityCtr.label,
+      labelPlural: rawConfig?.labelPlural ?? entityCtr.labelPlural,
       icon: entityCtr.icon,
       color: entityCtr.color,
       toStringAttributes: [...entityCtr.toStringAttributes],
@@ -136,8 +140,10 @@ export class AdminEntityComponent {
       viewType === "details"
         ? EntityConfigService.getDetailsViewId(entityType)
         : EntityConfigService.getListViewId(entityType);
+    // raw, because this editor saves the view config back to the config
+    // document - resolving here would drop all other languages
     const viewConfig: DynamicComponentConfig =
-      this.configService.getConfig(viewId);
+      this.configService.getRawConfig(viewId);
 
     if (!viewConfig) {
       // return default view config

--- a/src/app/core/admin/admin-entity/admin-entity.component.ts
+++ b/src/app/core/admin/admin-entity/admin-entity.component.ts
@@ -160,14 +160,23 @@ export class AdminEntityComponent {
       }
     }
 
-    viewConfig.config = viewConfig.config ?? { entityType: this.entityType() };
+    // `getRawConfig` hands back the config document's own object - edit a copy
+    const editableConfig: DynamicComponentConfig = JSON.parse(
+      JSON.stringify(viewConfig),
+    );
+
+    editableConfig.config = editableConfig.config ?? {
+      entityType: this.entityType(),
+    };
 
     // cleanup note details config, which should not have an entity instance assigned
-    if (viewConfig.config.entity && viewConfig.component === "NoteDetails") {
-      delete viewConfig.config.entity;
+    if (
+      editableConfig.config.entity &&
+      editableConfig.component === "NoteDetails"
+    ) {
+      delete editableConfig.config.entity;
     }
-    // work on a deep copy as we are editing in place (for titles, sections, etc.)
-    return JSON.parse(JSON.stringify(viewConfig));
+    return editableConfig;
   }
 
   cancel() {

--- a/src/app/core/admin/admin-menu/admin-menu-item-details/admin-menu-item-details.component.ts
+++ b/src/app/core/admin/admin-menu/admin-menu-item-details/admin-menu-item-details.component.ts
@@ -15,6 +15,7 @@ import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatButtonModule } from "@angular/material/button";
 import { EntityMenuItem, MenuItem } from "app/core/ui/navigation/menu-item";
+import { EditableMenuItem } from "../menu-item-for-admin-ui";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { EntityTypeSelectComponent } from "../../../entity/entity-type-select/entity-type-select.component";
 import { MenuItemFormComponent } from "#src/app/core/admin/admin-menu/menu-item-form/menu-item-form.component";
@@ -59,7 +60,7 @@ export class AdminMenuItemDetailsComponent implements OnInit {
     allowEntityLinks?: boolean;
   }>(MAT_DIALOG_DATA);
 
-  item: MenuItem | EntityMenuItem;
+  item: EditableMenuItem | EntityMenuItem;
   availableRoutes: { value: string; label: string }[];
   isNew: boolean;
   /** Whether entity type links are allowed (false for shortcuts, true for admin menu) */

--- a/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.ts
+++ b/src/app/core/admin/admin-menu/admin-menu-item/admin-menu-item.component.ts
@@ -1,4 +1,5 @@
 import {
+  LOCALE_ID,
   Component,
   input,
   computed,
@@ -7,6 +8,9 @@ import {
   output,
   ChangeDetectionStrategy,
 } from "@angular/core";
+import { resolveTranslatableText } from "../../../config/multi-lingual-config";
+import { availableLocales } from "../../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../../language/language-statics";
 import { EntityMenuItem, MenuItem } from "app/core/ui/navigation/menu-item";
 import { MenuItemComponent } from "app/core/ui/navigation/menu-item/menu-item.component";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
@@ -50,6 +54,8 @@ import { MatTooltipModule } from "@angular/material/tooltip";
 })
 export class AdminMenuItemComponent {
   private readonly dialog = inject(MatDialog);
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
   private readonly menuService = inject(MenuService);
 
   item = model.required<MenuItemForAdminUi>();
@@ -62,7 +68,18 @@ export class AdminMenuItemComponent {
     if (!item) {
       return undefined;
     }
-    const plainItem = this.menuService.generateMenuItemForEntityType(item);
+    // subMenu is dropped below anyway and its items are not plain MenuItems
+    const { subMenu: _subMenu, ...itemWithoutSubMenu } = item;
+    const plainItem = this.menuService.generateMenuItemForEntityType({
+      ...itemWithoutSubMenu,
+      // this preview displays the label, so show the active language's text
+      label: resolveTranslatableText(
+        item.label,
+        this.locale,
+        DEFAULT_LANGUAGE,
+        this.validLocaleIds,
+      ),
+    });
     delete plainItem.link;
     delete plainItem.subMenu;
     return plainItem;

--- a/src/app/core/admin/admin-menu/admin-menu.component.ts
+++ b/src/app/core/admin/admin-menu/admin-menu.component.ts
@@ -6,6 +6,7 @@ import {
   ChangeDetectionStrategy,
 } from "@angular/core";
 import { NavigationMenuConfig } from "app/core/ui/navigation/menu-item";
+import { MenuItem } from "../../ui/navigation/menu-item";
 import { EntityMapperService } from "app/core/entity/entity-mapper/entity-mapper.service";
 import { Config } from "app/core/config/config";
 import { MatButton } from "@angular/material/button";
@@ -56,8 +57,12 @@ export class AdminMenuComponent implements OnInit {
       Config<{ navigationMenu: NavigationMenuConfig }>,
       Config.CONFIG_KEY,
     );
+    // the edited items keep their raw labels (a plain string or a per-language
+    // map); NavigationMenuConfig describes the resolved shape the menu renders
     currentConfig.data.navigationMenu.items =
-      MenuItemListEditorComponent.toPlainMenuItems(this.menuItems());
+      MenuItemListEditorComponent.toPlainMenuItems(
+        this.menuItems(),
+      ) as MenuItem[];
     await this.entityMapper.save(currentConfig);
 
     this.resetChangeTracking();

--- a/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
+++ b/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
@@ -19,8 +19,7 @@ export type EditableMenuItem = Omit<MenuItem, "label" | "subMenu"> & {
  * Extension of MenuItem that includes additional properties
  * for the admin drag&drop logic.
  */
-export interface MenuItemForAdminUi
-  extends Omit<EditableMenuItem, "subMenu"> {
+export interface MenuItemForAdminUi extends Omit<EditableMenuItem, "subMenu"> {
   uniqueId: string;
   subMenu: MenuItemForAdminUi[];
 }

--- a/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
+++ b/src/app/core/admin/admin-menu/menu-item-for-admin-ui.ts
@@ -1,11 +1,26 @@
 import { FlatTreeAdapter } from "#src/app/utils/flat-tree/flat-tree";
 import { EntityMenuItem, MenuItem } from "../../ui/navigation/menu-item";
+import { TranslatableText } from "../../config/multi-lingual-config";
+
+/**
+ * A menu item as edited in the Admin UI, where the label may be configured in
+ * several languages.
+ *
+ * The displayed {@link MenuItem} keeps `label: string`, because the navigation
+ * only ever receives config that ConfigService already resolved to the active
+ * language.
+ */
+export type EditableMenuItem = Omit<MenuItem, "label" | "subMenu"> & {
+  label?: TranslatableText;
+  subMenu?: EditableMenuItem[];
+};
 
 /**
  * Extension of MenuItem that includes additional properties
  * for the admin drag&drop logic.
  */
-export interface MenuItemForAdminUi extends MenuItem {
+export interface MenuItemForAdminUi
+  extends Omit<EditableMenuItem, "subMenu"> {
   uniqueId: string;
   subMenu: MenuItemForAdminUi[];
 }
@@ -24,7 +39,7 @@ export class MenuItemForAdminUiNew implements MenuItemForAdminUi {
   constructor(public uniqueId: string) {}
 
   subMenu = [];
-  label: string = "";
+  label: TranslatableText = "";
   icon?: string;
   link?: string;
 
@@ -35,7 +50,7 @@ export class MenuItemForAdminUiNew implements MenuItemForAdminUi {
  * True when an item is in manual mode (no entity type) and no link has been set.
  */
 export function isManualItemWithoutLink(
-  item: MenuItem | EntityMenuItem,
+  item: EditableMenuItem | EntityMenuItem,
 ): boolean {
   return !item.link?.trim() && !(item as EntityMenuItem).entityType?.trim();
 }

--- a/src/app/core/admin/admin-menu/menu-item-form/menu-item-form.component.html
+++ b/src/app/core/admin/admin-menu/menu-item-form/menu-item-form.component.html
@@ -2,11 +2,10 @@
   @if (!hideLabel()) {
     <mat-form-field appearance="fill" class="full-width">
       <mat-label i18n>Label</mat-label>
-      <input
-        matInput
-        [ngModel]="itemLabel()"
-        (ngModelChange)="itemLabel.set($event)"
-      />
+      <app-translatable-text-input
+        [value]="itemLabel()"
+        (valueChange)="itemLabel.set($event)"
+      ></app-translatable-text-input>
     </mat-form-field>
   }
 

--- a/src/app/core/admin/admin-menu/menu-item-form/menu-item-form.component.ts
+++ b/src/app/core/admin/admin-menu/menu-item-form/menu-item-form.component.ts
@@ -8,6 +8,8 @@ import {
   effect,
 } from "@angular/core";
 import { MenuItem } from "../../../ui/navigation/menu-item";
+import { EditableMenuItem } from "../menu-item-for-admin-ui";
+import { TranslatableTextInputComponent } from "../../../config/translatable-text-input/translatable-text-input.component";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { FormControl, FormsModule } from "@angular/forms";
@@ -28,6 +30,7 @@ import { ConfirmationDialogService } from "#src/app/core/common-components/confi
   selector: "app-menu-item-form",
   standalone: true,
   imports: [
+    TranslatableTextInputComponent,
     MatFormFieldModule,
     MatInputModule,
     FormsModule,
@@ -44,7 +47,7 @@ import { ConfirmationDialogService } from "#src/app/core/common-components/confi
 export class MenuItemFormComponent {
   private readonly confirmationDialog = inject(ConfirmationDialogService);
 
-  item = model.required<MenuItem>();
+  item = model.required<EditableMenuItem>();
   hideLabel = input<boolean>(false);
   hideLink = input<boolean>(false);
   isNew = input<boolean>(false);

--- a/src/app/core/admin/admin-primary-action/admin-primary-action.component.ts
+++ b/src/app/core/admin/admin-primary-action/admin-primary-action.component.ts
@@ -13,6 +13,7 @@ import { PrimaryActionService } from "./primary-action.service";
 import { EntityTypeSelectComponent } from "../../entity/entity-type-select/entity-type-select.component";
 import { EntityConstructor } from "../../entity/model/entity";
 import { MenuItem } from "../../ui/navigation/menu-item";
+import { EditableMenuItem } from "../admin-menu/menu-item-for-admin-ui";
 import { FormsModule } from "@angular/forms";
 import { ViewTitleComponent } from "../../common-components/view-title/view-title.component";
 import { ViewActionsComponent } from "../../common-components/view-actions/view-actions.component";
@@ -47,7 +48,7 @@ export class AdminPrimaryActionComponent {
     return this.primaryActionService.getCurrentConfig();
   }
 
-  menuItem: MenuItem;
+  menuItem: EditableMenuItem;
 
   routeOptions: { value: string; label: string }[] = [];
 

--- a/src/app/core/admin/building-blocks/admin-section-header/admin-section-header.component.html
+++ b/src/app/core/admin/building-blocks/admin-section-header/admin-section-header.component.html
@@ -1,13 +1,22 @@
 <div class="flex-row align-baseline">
   <mat-form-field floatLabel="always" class="flex-grow no-field-margin">
     <mat-label>{{ label() }}</mat-label>
-    <input
-      matInput
-      [ngModel]="title()"
-      (ngModelChange)="title.set($event)"
-      placeholder="(no title)"
-      i18n-placeholder="Placeholder for entering a title"
-    />
+    @if (translatable()) {
+      <app-translatable-text-input
+        [value]="title()"
+        (valueChange)="title.set($event)"
+        placeholder="(no title)"
+        i18n-placeholder="Placeholder for entering a title"
+      ></app-translatable-text-input>
+    } @else {
+      <input
+        matInput
+        [ngModel]="title()"
+        (ngModelChange)="title.set($event)"
+        placeholder="(no title)"
+        i18n-placeholder="Placeholder for entering a title"
+      />
+    }
   </mat-form-field>
 
   <button (click)="removeSection()" mat-icon-button class="group-remove-button">

--- a/src/app/core/admin/building-blocks/admin-section-header/admin-section-header.component.ts
+++ b/src/app/core/admin/building-blocks/admin-section-header/admin-section-header.component.ts
@@ -12,6 +12,8 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { ConfirmationDialogService } from "../../../common-components/confirmation-dialog/confirmation-dialog.service";
+import { TranslatableText } from "../../../config/multi-lingual-config";
+import { TranslatableTextInputComponent } from "../../../config/translatable-text-input/translatable-text-input.component";
 
 /**
  * Simple building block for UI Builder for a section title including button to remove the section.
@@ -32,6 +34,7 @@ import { ConfirmationDialogService } from "../../../common-components/confirmati
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
+    TranslatableTextInputComponent,
   ],
   templateUrl: "./admin-section-header.component.html",
   styleUrl: "./admin-section-header.component.scss",
@@ -39,13 +42,22 @@ import { ConfirmationDialogService } from "../../../common-components/confirmati
 export class AdminSectionHeaderComponent {
   private confirmationDialog = inject(ConfirmationDialogService);
 
-  title = model<string>("");
+  title = model<TranslatableText>("");
 
   /** supports two-way data binding for the editable title: `<app-admin-section-header [(title)]="section.title"` */
   remove = output();
 
   /** disable the confirmation dialog displayed before a remove output is emitted */
   disableConfirmation = input<boolean>(false);
+
+  /**
+   * Whether this title may be configured in several languages.
+   *
+   * Off by default: some titles double as identifiers (e.g. a list view's column
+   * group name is referenced by `columnGroups.default`), and those must stay
+   * plain strings.
+   */
+  translatable = input<boolean>(false);
 
   /** overwrite the label (default: "title") displayed for the form field */
   label = input<string>(

--- a/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.html
+++ b/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.html
@@ -22,6 +22,7 @@
             ></fa-icon>
             @if (tabIndex === matTabGroup.selectedIndex) {
               <app-admin-section-header
+                [translatable]="translatableTitle()"
                 [(title)]="tab[tabTitleProperty()]"
                 (remove)="removeTab(tabIndex)"
               ></app-admin-section-header>

--- a/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.html
+++ b/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.html
@@ -28,7 +28,7 @@
               ></app-admin-section-header>
             } @else {
               <!-- only current tab can be renamed -->
-              {{ tab[tabTitleProperty()] }}
+              {{ tabTitle(tab) }}
             }
           </div>
         </div>

--- a/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.ts
+++ b/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.ts
@@ -62,6 +62,12 @@ export class AdminTabsComponent<
   E extends { title: string } | { name: string },
 > {
   tabs = model<E[]>([]);
+
+  /**
+   * Whether tab titles may be configured in several languages.
+   * Off by default - a list view's column group name doubles as its identifier.
+   */
+  translatableTitle = input<boolean>(false);
   newTabFactory = input<() => E>(
     () => ({ [this.tabTitleProperty()]: "" }) as E,
   );

--- a/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.ts
+++ b/src/app/core/admin/building-blocks/admin-tabs/admin-tabs.component.ts
@@ -1,10 +1,12 @@
 import {
   Component,
   ContentChild,
+  LOCALE_ID,
   TemplateRef,
   ViewChild,
   computed,
   ChangeDetectionStrategy,
+  inject,
   input,
   model,
 } from "@angular/core";
@@ -25,6 +27,12 @@ import {
   DragDropModule,
   moveItemInArray,
 } from "@angular/cdk/drag-drop";
+import {
+  resolveTranslatableText,
+  TranslatableText,
+} from "../../../config/multi-lingual-config";
+import { availableLocales } from "../../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../../language/language-statics";
 
 /**
  * Building block for drag&drop form builder to let an admin user manage multiple tabs.
@@ -59,8 +67,11 @@ import {
   styleUrl: "./admin-tabs.component.scss",
 })
 export class AdminTabsComponent<
-  E extends { title: string } | { name: string },
+  E extends { title: TranslatableText } | { name: TranslatableText },
 > {
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
+
   tabs = model<E[]>([]);
 
   /**
@@ -71,6 +82,18 @@ export class AdminTabsComponent<
   newTabFactory = input<() => E>(
     () => ({ [this.tabTitleProperty()]: "" }) as E,
   );
+
+  tabTitle(tab: E): string {
+    const title: TranslatableText = tab[this.tabTitleProperty()];
+    return (
+      resolveTranslatableText(
+        title,
+        this.locale,
+        DEFAULT_LANGUAGE,
+        this.validLocaleIds,
+      ) ?? ""
+    );
+  }
 
   tabTitleProperty = computed<"title" | "name">(() => {
     const tabs = this.tabs();

--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -1,4 +1,10 @@
-import { DestroyRef, EventEmitter, inject, Injectable } from "@angular/core";
+import {
+  DestroyRef,
+  EventEmitter,
+  inject,
+  Injectable,
+  LOCALE_ID,
+} from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, FormControlOptions } from "@angular/forms";
 import { ColumnConfig, FormFieldConfig, toFormFieldConfig } from "./FormConfig";
@@ -20,6 +26,9 @@ import {
   TypedFormGroup,
 } from "#src/app/core/common-components/entity-form/entity-form";
 import { asArray } from "app/utils/asArray";
+import { resolveTranslatableText } from "../../config/multi-lingual-config";
+import { availableLocales } from "../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../language/language-statics";
 
 /**
  * This service provides helper functions for creating tables or forms for an entity as well as saving
@@ -37,6 +46,8 @@ export class EntityFormService {
   private ability = inject(EntityAbility);
   private unsavedChanges = inject(UnsavedChangesService);
   private defaultValueService = inject(DefaultValueService);
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
 
   /**
    * Uses schema information to fill missing fields in the FormFieldConfig.
@@ -94,7 +105,28 @@ export class EntityFormService {
         fullField.label || fullField.label || fullField.labelShort;
     }
 
+    this.resolveTranslatableLabels(fullField);
+
     return fullField;
+  }
+
+  /**
+   * Config loaded through ConfigService is already resolved, but the runtime
+   * schema can hold a translation map while an admin has configured
+   * translations that are not saved to the config document yet.
+   */
+  private resolveTranslatableLabels(field: FormFieldConfig) {
+    for (const property of ["label", "labelShort", "description"]) {
+      if (field[property] === undefined) {
+        continue;
+      }
+      field[property] = resolveTranslatableText(
+        field[property],
+        this.locale,
+        DEFAULT_LANGUAGE,
+        this.validLocaleIds,
+      );
+    }
   }
 
   /**

--- a/src/app/core/config/config.service.spec.ts
+++ b/src/app/core/config/config.service.spec.ts
@@ -868,6 +868,58 @@ describe("ConfigService", () => {
     testConfigMigration(oldConfig, expectedConfig);
   });
 
+  describe("multi-lingual config (#3862)", () => {
+    it("resolves multi-lingual values to the active locale for getConfig, but keeps raw maps in getRawConfig and exportConfig", async () => {
+      vi.useFakeTimers();
+      try {
+        const config = new Config();
+        config.data = {
+          "entity:X": { label: { "en-US": "Name", de: "Vorname" } },
+        };
+        entityMapper.load.mockResolvedValue(config);
+        service.loadOnce();
+        await vi.advanceTimersByTimeAsync(0);
+
+        // resolved display view (active locale defaults to en-US in tests)
+        expect(service.getConfig<any>("entity:X").label).toBe("Name");
+
+        // raw view keeps the full translation map for read-modify-save flows
+        expect(service.getRawConfig<any>("entity:X").label).toEqual({
+          "en-US": "Name",
+          de: "Vorname",
+        });
+
+        // export stays raw so no language is lost on a round-trip save
+        expect((service.exportConfig(true) as any)["entity:X"]).toEqual({
+          label: { "en-US": "Name", de: "Vorname" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("exposes resolved strings via getAllConfigs and raw maps via getAllRawConfigs", async () => {
+      vi.useFakeTimers();
+      try {
+        const config = new Config();
+        config.data = {
+          "entity:A": { label: { "en-US": "Alpha", de: "Alpha DE" } },
+        };
+        entityMapper.load.mockResolvedValue(config);
+        service.loadOnce();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(service.getAllConfigs<any>("entity:")[0].label).toBe("Alpha");
+        expect(service.getAllRawConfigs<any>("entity:")[0].label).toEqual({
+          "en-US": "Alpha",
+          de: "Alpha DE",
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("undefined config handling", () => {
     /**
      * Sets up window.location/alert/Logging.error mocks for testing

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { inject, Injectable, LOCALE_ID } from "@angular/core";
 import { HttpStatusCode } from "@angular/common/http";
 import { shareReplay } from "rxjs/operators";
 import { addDefaultNoteDetailsConfig } from "../../child-dev-project/notes/add-default-note-views";
@@ -9,6 +9,14 @@ import { Logging } from "../logging/logging.service";
 import { Config } from "./config";
 import { ConfigMigration } from "./config-migration";
 import { applyConfigMigrations } from "./config-migrations";
+import {
+  CONFIG_ENTITY_ROUTE_PREFIX,
+  normalizeRoutePath,
+} from "./dynamic-routing/route-paths";
+import { PREFIX_VIEW_CONFIG } from "./dynamic-routing/view-config.interface";
+import { resolveTranslatableConfig } from "./multi-lingual-config";
+import { DEFAULT_LANGUAGE } from "../language/language-statics";
+import { availableLocales } from "../language/languages";
 
 /**
  * Access dynamic app configuration retrieved from the database
@@ -28,6 +36,17 @@ export class ConfigService extends LatestEntityLoader<Config> {
    * Subscribe to receive the current config and get notified whenever the config is updated.
    */
   private currentConfig: Config;
+
+  /**
+   * The current config with all multi-lingual values resolved to the active
+   * locale (see #3862). This is the display view returned by
+   * getConfig()/getAllConfigs(); currentConfig stays raw (translation maps
+   * intact) as the persisted source of truth.
+   */
+  private resolvedConfigData: Record<string, any>;
+
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
 
   configUpdates = this.entityUpdated.pipe(shareReplay(1));
 
@@ -51,6 +70,12 @@ export class ConfigService extends LatestEntityLoader<Config> {
       }
       sessionStorage.removeItem(ConfigService.RELOAD_ATTEMPTS_KEY);
       this.currentConfig = this.applyMigrations(config);
+      this.resolvedConfigData = resolveTranslatableConfig(
+        this.currentConfig.data,
+        this.locale,
+        DEFAULT_LANGUAGE,
+        this.validLocaleIds,
+      );
       this.logConfigRev();
     });
 
@@ -138,25 +163,61 @@ export class ConfigService extends LatestEntityLoader<Config> {
     return rawObject ? JSON.parse(value) : value;
   }
 
+  /**
+   * Get a config item, with any multi-lingual values resolved to the active locale.
+   *
+   * Use getRawConfig() instead if you will edit the value and save it back to the
+   * config document, otherwise translations for other languages would be lost (#3862).
+   */
   public getConfig<T>(id: string): T | undefined {
+    return this.resolvedConfigData?.[id];
+  }
+
+  /**
+   * Get a config item with its raw values (multi-lingual maps left intact).
+   * Required for any read-modify-save flow (see #3862).
+   */
+  public getRawConfig<T>(id: string): T | undefined {
     return this.currentConfig?.data?.[id];
   }
 
   /**
    * Return all config items of the given "type"
-   * (determined by the given prefix of their id).
+   * (determined by the given prefix of their id),
+   * with any multi-lingual values resolved to the active locale.
    *
    * @param prefix The prefix of config items to return (e.g. "view:" or "entity:")
    */
   public getAllConfigs<T>(prefix: string): T[] {
-    if (!this.currentConfig?.data) {
+    return ConfigService.collectConfigsByPrefix<T>(
+      this.resolvedConfigData,
+      prefix,
+    );
+  }
+
+  /**
+   * Like getAllConfigs(), but with raw values (multi-lingual maps left intact).
+   * Required for any read-modify-save flow (see #3862).
+   */
+  public getAllRawConfigs<T>(prefix: string): T[] {
+    return ConfigService.collectConfigsByPrefix<T>(
+      this.currentConfig?.data,
+      prefix,
+    );
+  }
+
+  private static collectConfigsByPrefix<T>(
+    data: Record<string, any> | undefined,
+    prefix: string,
+  ): T[] {
+    if (!data) {
       return [];
     }
-    const matchingConfigs = [];
-    for (const id of Object.keys(this.currentConfig.data)) {
+    const matchingConfigs: T[] = [];
+    for (const id of Object.keys(data)) {
       if (id.startsWith(prefix)) {
-        this.currentConfig.data[id]._id = id;
-        matchingConfigs.push(this.currentConfig.data[id]);
+        data[id]._id = id;
+        matchingConfigs.push(data[id]);
       }
     }
     return matchingConfigs;

--- a/src/app/core/config/config.service.ts
+++ b/src/app/core/config/config.service.ts
@@ -9,11 +9,6 @@ import { Logging } from "../logging/logging.service";
 import { Config } from "./config";
 import { ConfigMigration } from "./config-migration";
 import { applyConfigMigrations } from "./config-migrations";
-import {
-  CONFIG_ENTITY_ROUTE_PREFIX,
-  normalizeRoutePath,
-} from "./dynamic-routing/route-paths";
-import { PREFIX_VIEW_CONFIG } from "./dynamic-routing/view-config.interface";
 import { resolveTranslatableConfig } from "./multi-lingual-config";
 import { DEFAULT_LANGUAGE } from "../language/language-statics";
 import { availableLocales } from "../language/languages";

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.html
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.html
@@ -1,0 +1,26 @@
+<h1 matDialogTitle i18n="title of the translations popup dialog">
+  Configure translations
+</h1>
+<app-dialog-close (click)="onCancel()"></app-dialog-close>
+
+<mat-dialog-content class="dialog-content">
+  @if (data.fieldLabel) {
+    <p i18n>Translations for "{{ data.fieldLabel }}"</p>
+  }
+
+  @for (row of rows; track row.locale) {
+    <mat-form-field class="full-width">
+      <mat-label>{{ row.localeLabel }}</mat-label>
+      <input matInput [(ngModel)]="row.text" [name]="row.locale" />
+    </mat-form-field>
+  }
+
+  <p class="hint-text" i18n>
+    Languages left empty fall back to the text of the default language.
+  </p>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-raised-button color="accent" (click)="onSave()" i18n>Save</button>
+  <button mat-raised-button (click)="onCancel()" i18n>Cancel</button>
+</mat-dialog-actions>

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.scss
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.scss
@@ -1,0 +1,8 @@
+.dialog-content {
+  min-width: 350px;
+  padding-top: 5px;
+}
+
+.hint-text {
+  opacity: 0.7;
+}

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.spec.ts
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
+
+import {
+  ConfigureTranslationsDialogData,
+  ConfigureTranslationsPopupComponent,
+} from "./configure-translations-popup.component";
+
+describe("ConfigureTranslationsPopupComponent", () => {
+  let component: ConfigureTranslationsPopupComponent;
+  let fixture: ComponentFixture<ConfigureTranslationsPopupComponent>;
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+
+  async function createComponent(data: ConfigureTranslationsDialogData) {
+    dialogRef = { close: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ConfigureTranslationsPopupComponent,
+        FontAwesomeTestingModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfigureTranslationsPopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  function setText(locale: string, text: string) {
+    component.rows.find((r) => r.locale === locale).text = text;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it("should create a row for every available language", async () => {
+    await createComponent({ value: undefined });
+
+    expect(component.rows.length).toBeGreaterThan(1);
+    expect(component.rows.map((r) => r.locale)).toContain("en-US");
+    expect(component.rows.map((r) => r.locale)).toContain("de");
+  });
+
+  it("should pre-fill each language from an existing translation map", async () => {
+    await createComponent({ value: { "en-US": "Name", de: "Vorname" } });
+
+    expect(component.rows.find((r) => r.locale === "en-US").text).toBe("Name");
+    expect(component.rows.find((r) => r.locale === "de").text).toBe("Vorname");
+    expect(component.rows.find((r) => r.locale === "fr").text).toBe("");
+  });
+
+  it("should put an existing plain string into the default language", async () => {
+    await createComponent({ value: "Name" });
+
+    expect(component.rows.find((r) => r.locale === "en-US").text).toBe("Name");
+    expect(component.rows.find((r) => r.locale === "de").text).toBe("");
+  });
+
+  it("should return a translation map once several languages are filled in", async () => {
+    await createComponent({ value: "Name" });
+    setText("de", "Vorname");
+
+    component.onSave();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      "en-US": "Name",
+      de: "Vorname",
+    });
+  });
+
+  it("should return a plain string while only one language is filled in", async () => {
+    await createComponent({ value: { "en-US": "Name", de: "Vorname" } });
+    setText("de", "");
+
+    component.onSave();
+
+    expect(dialogRef.close).toHaveBeenCalledWith("Name");
+  });
+
+  it("should ignore languages that only contain whitespace", async () => {
+    await createComponent({ value: "Name" });
+    setText("de", "   ");
+
+    component.onSave();
+
+    expect(dialogRef.close).toHaveBeenCalledWith("Name");
+  });
+
+  it("should close without a value when cancelled, leaving the config untouched", async () => {
+    await createComponent({ value: { "en-US": "Name", de: "Vorname" } });
+    setText("de", "changed");
+
+    component.onCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.spec.ts
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.spec.ts
@@ -83,6 +83,23 @@ describe("ConfigureTranslationsPopupComponent", () => {
     expect(dialogRef.close).toHaveBeenCalledWith("Name");
   });
 
+  it("should keep a single non-default translation as a one-entry map", async () => {
+    await createComponent({ value: undefined });
+    setText("de", "Vorname");
+
+    component.onSave();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({ de: "Vorname" });
+  });
+
+  it("should read a single non-default translation back into its own language", async () => {
+    // a plain string would be read back as the default language's text
+    await createComponent({ value: { de: "Vorname" } });
+
+    expect(component.rows.find((r) => r.locale === "de").text).toBe("Vorname");
+    expect(component.rows.find((r) => r.locale === "en-US").text).toBe("");
+  });
+
   it("should ignore languages that only contain whitespace", async () => {
     await createComponent({ value: "Name" });
     setText("de", "   ");

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.ts
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.ts
@@ -1,0 +1,105 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from "@angular/material/dialog";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatButtonModule } from "@angular/material/button";
+import { FormsModule } from "@angular/forms";
+import { DialogCloseComponent } from "../../common-components/dialog-close/dialog-close.component";
+import { availableLocales } from "../../language/languages";
+import { DEFAULT_LANGUAGE } from "../../language/language-statics";
+import { isTranslatableText, TranslatableText } from "../multi-lingual-config";
+
+export interface ConfigureTranslationsDialogData {
+  /** the raw configured value: a plain string or a per-language map */
+  value?: TranslatableText;
+  /** name of the setting being translated, shown in the dialog */
+  fieldLabel?: string;
+}
+
+interface TranslationRow {
+  locale: string;
+  localeLabel: string;
+  text: string;
+}
+
+/**
+ * Edit the translations of one configurable text
+ *
+ * Works on the *raw* config value (plain string or per-language map) and returns
+ * a new raw value - it never resolves anything, so no language can be lost here.
+ * A value that ends up with only one language is returned as a plain string
+ * again, keeping configs that don't need multiple languages simple.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: "app-configure-translations-popup",
+  templateUrl: "./configure-translations-popup.component.html",
+  styleUrls: ["./configure-translations-popup.component.scss"],
+  imports: [
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    FormsModule,
+    DialogCloseComponent,
+  ],
+})
+export class ConfigureTranslationsPopupComponent {
+  readonly data = inject<ConfigureTranslationsDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef =
+    inject<MatDialogRef<ConfigureTranslationsPopupComponent>>(MatDialogRef);
+
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
+
+  rows: TranslationRow[] = availableLocales.values.map((locale) => ({
+    locale: locale.id,
+    localeLabel: locale.label,
+    text: this.initialTextFor(locale.id),
+  }));
+
+  private initialTextFor(locale: string): string {
+    const value = this.data?.value;
+    if (isTranslatableText(value, this.validLocaleIds)) {
+      return value[locale] ?? "";
+    }
+    // a plain string so far: it is the text everyone sees today, so it becomes
+    // the default language's translation
+    return locale === DEFAULT_LANGUAGE && typeof value === "string"
+      ? value
+      : "";
+  }
+
+  onSave() {
+    this.dialogRef.close(this.buildValue());
+  }
+
+  onCancel() {
+    // closing without a result leaves the existing value untouched
+    this.dialogRef.close(undefined);
+  }
+
+  /**
+   * Build the new raw value: a plain string while only one language is filled in,
+   * a per-language map as soon as there are several.
+   */
+  private buildValue(): TranslatableText | undefined {
+    const filled = this.rows.filter((row) => !!row.text?.trim());
+
+    if (filled.length === 0) {
+      return undefined;
+    }
+    if (filled.length === 1) {
+      return filled[0].text.trim();
+    }
+
+    const map: Record<string, string> = {};
+    for (const row of filled) {
+      map[row.locale] = row.text.trim();
+    }
+    return map;
+  }
+}

--- a/src/app/core/config/configure-translations-popup/configure-translations-popup.component.ts
+++ b/src/app/core/config/configure-translations-popup/configure-translations-popup.component.ts
@@ -83,8 +83,8 @@ export class ConfigureTranslationsPopupComponent {
   }
 
   /**
-   * Build the new raw value: a plain string while only one language is filled in,
-   * a per-language map as soon as there are several.
+   * Build the new raw value. Only the default language on its own collapses to a
+   * plain string: {@link initialTextFor} reads one back as that language's text.
    */
   private buildValue(): TranslatableText | undefined {
     const filled = this.rows.filter((row) => !!row.text?.trim());
@@ -92,7 +92,7 @@ export class ConfigureTranslationsPopupComponent {
     if (filled.length === 0) {
       return undefined;
     }
-    if (filled.length === 1) {
+    if (filled.length === 1 && filled[0].locale === DEFAULT_LANGUAGE) {
       return filled[0].text.trim();
     }
 

--- a/src/app/core/config/multi-lingual-config.spec.ts
+++ b/src/app/core/config/multi-lingual-config.spec.ts
@@ -1,0 +1,277 @@
+import {
+  isTranslatableText,
+  mergeTranslatableValues,
+  resolveTranslatableConfig,
+  resolveTranslatableText,
+} from "./multi-lingual-config";
+
+describe("multi-lingual-config", () => {
+  // mirrors the app's real locale ids (see languages.ts): en-US, de, fr
+  const LOCALES = ["en-US", "de", "fr"];
+  const DEFAULT = "en-US";
+
+  describe("isTranslatableText", () => {
+    it("detects a proper translation map (all keys locales, all values strings)", () => {
+      expect(
+        isTranslatableText({ "en-US": "Name", de: "Vorname" }, LOCALES),
+      ).toBe(true);
+    });
+
+    it("rejects a plain string", () => {
+      expect(isTranslatableText("Name", LOCALES)).toBe(false);
+    });
+
+    it("rejects null, arrays and empty objects", () => {
+      expect(isTranslatableText(null, LOCALES)).toBe(false);
+      expect(isTranslatableText(["en-US"], LOCALES)).toBe(false);
+      expect(isTranslatableText({}, LOCALES)).toBe(false);
+    });
+
+    it("rejects an object with a non-locale key", () => {
+      expect(
+        isTranslatableText({ "en-US": "Name", component: "X" }, LOCALES),
+      ).toBe(false);
+    });
+
+    it("rejects an object with a non-string value (e.g. nested config)", () => {
+      expect(
+        isTranslatableText({ "en-US": { dataType: "string" } }, LOCALES),
+      ).toBe(false);
+    });
+
+    it("rejects a map whose keys are not in the configured locales", () => {
+      // "en" is not a configured locale id (the app uses "en-US")
+      expect(isTranslatableText({ en: "Name", de: "Vorname" }, LOCALES)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("resolveTranslatableText", () => {
+    it("returns a plain string unchanged", () => {
+      expect(resolveTranslatableText("Name", "de", DEFAULT, LOCALES)).toBe(
+        "Name",
+      );
+    });
+
+    it("returns undefined for null/undefined", () => {
+      expect(
+        resolveTranslatableText(undefined, "de", DEFAULT, LOCALES),
+      ).toBeUndefined();
+      expect(
+        resolveTranslatableText(null, "de", DEFAULT, LOCALES),
+      ).toBeUndefined();
+    });
+
+    it("resolves the exact active locale", () => {
+      const value = { "en-US": "Name", de: "Vorname" };
+      expect(resolveTranslatableText(value, "de", DEFAULT, LOCALES)).toBe(
+        "Vorname",
+      );
+    });
+
+    it("falls back to the default locale when the active locale is missing", () => {
+      const value = { "en-US": "Name", de: "Vorname" };
+      expect(resolveTranslatableText(value, "fr", DEFAULT, LOCALES)).toBe(
+        "Name",
+      );
+    });
+
+    it("falls back to the first non-empty value when neither active nor default match", () => {
+      const value = { de: "Vorname", fr: "Prénom" };
+      expect(resolveTranslatableText(value, "es", "es", LOCALES)).toBe(
+        "Vorname",
+      );
+    });
+
+    it("matches by language subtag across region variants (en-GB -> en-US)", () => {
+      const regionLocales = ["en-US", "en-GB", "de"];
+      const value = { "en-US": "Color", de: "Farbe" };
+      expect(
+        resolveTranslatableText(value, "en-GB", "en-US", regionLocales),
+      ).toBe("Color");
+    });
+
+    it("skips an empty-string slot and falls back", () => {
+      const value = { "en-US": "Name", de: "" };
+      expect(resolveTranslatableText(value, "de", DEFAULT, LOCALES)).toBe(
+        "Name",
+      );
+    });
+  });
+
+  describe("mergeTranslatableValues", () => {
+    it("keeps the full translation map when the admin did not change the text", () => {
+      const raw = {
+        dataType: "string",
+        label: { "en-US": "Name", de: "Vorname" },
+      };
+      // what an en-US admin was shown and saved back unchanged
+      const edited = { dataType: "string", label: "Name" };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toEqual({ "en-US": "Name", de: "Vorname" });
+    });
+
+    it("updates only the active locale when the admin changed the text", () => {
+      const raw = { label: { "en-US": "Name", de: "Vorname" } };
+      const edited = { label: "Full Name" };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toEqual({ "en-US": "Full Name", de: "Vorname" });
+    });
+
+    it("adds a translation for the active locale when it was missing (edited via fallback)", () => {
+      const raw = { label: { "en-US": "Name" } };
+      // a French admin saw the en-US fallback and typed the French text
+      const edited = { label: "Nom" };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "fr",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toEqual({ "en-US": "Name", fr: "Nom" });
+    });
+
+    it("keeps plain strings as plain strings (configs that never opted in)", () => {
+      const raw = { label: "Name" };
+      const edited = { label: "Full Name" };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toBe("Full Name");
+    });
+
+    it("carries over non-translatable properties from the edited value", () => {
+      const raw = {
+        dataType: "string",
+        label: { "en-US": "Name", de: "Vorname" },
+      };
+      const edited = { dataType: "long-text", label: "Name" };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.dataType).toBe("long-text");
+      expect(merged.label).toEqual({ "en-US": "Name", de: "Vorname" });
+    });
+
+    it("keeps a map that was edited directly as a map (translations dialog)", () => {
+      const raw = { label: { "en-US": "Name", de: "Vorname" } };
+      const edited = { label: { "en-US": "Name", de: "Nachname", fr: "Nom" } };
+
+      const merged = mergeTranslatableValues(
+        raw,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toEqual({
+        "en-US": "Name",
+        de: "Nachname",
+        fr: "Nom",
+      });
+    });
+
+    it("handles a missing raw counterpart (newly added field)", () => {
+      const edited = { label: "New Field" };
+
+      const merged = mergeTranslatableValues(
+        undefined,
+        edited,
+        "en-US",
+        DEFAULT,
+        LOCALES,
+      );
+
+      expect(merged.label).toBe("New Field");
+    });
+  });
+
+  describe("resolveTranslatableConfig", () => {
+    it("resolves nested maps and leaves ids and non-translatable objects untouched", () => {
+      const raw = {
+        "entity:Child": {
+          label: { "en-US": "Child", de: "Kind" },
+          attributes: {
+            name: {
+              dataType: "string",
+              label: { "en-US": "Name", de: "Vorname" },
+            },
+          },
+        },
+        "view:child": {
+          component: "EntityList",
+          config: { title: { "en-US": "Children", de: "Kinder" } },
+        },
+      };
+
+      const resolved = resolveTranslatableConfig(raw, "de", DEFAULT, LOCALES);
+
+      expect(resolved).toEqual({
+        "entity:Child": {
+          label: "Kind",
+          attributes: {
+            name: { dataType: "string", label: "Vorname" },
+          },
+        },
+        "view:child": {
+          component: "EntityList",
+          config: { title: "Kinder" },
+        },
+      });
+    });
+
+    it("resolves maps inside arrays", () => {
+      const raw = {
+        items: [{ label: { "en-US": "One", de: "Eins" } }, { label: "Two" }],
+      };
+
+      const resolved = resolveTranslatableConfig(raw, "de", DEFAULT, LOCALES);
+
+      expect(resolved).toEqual({
+        items: [{ label: "Eins" }, { label: "Two" }],
+      });
+    });
+
+    it("does not mutate the input (raw stays the source of truth)", () => {
+      const raw = { label: { "en-US": "Name", de: "Vorname" } };
+
+      const resolved = resolveTranslatableConfig(raw, "de", DEFAULT, LOCALES);
+
+      expect(resolved.label).toBe("Vorname");
+      expect(raw.label).toEqual({ "en-US": "Name", de: "Vorname" });
+    });
+  });
+});

--- a/src/app/core/config/multi-lingual-config.ts
+++ b/src/app/core/config/multi-lingual-config.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure helpers for resolving multi-lingual config values
+ *
+ * A translatable config text can be stored either as a plain `string` (the
+ * original, still-supported format) or as a per-language map keyed by locale id,
+ * e.g. `{ "en-US": "My Field X", "de": "Mein Feld X" }`. At load time the config
+ * is resolved down to the single string for the currently active locale, so that
+ * every other part of the app keeps seeing the plain-string format it always has.
+ *
+ * IMPORTANT: this module is intentionally **node-safe** (no `@angular/*` imports),
+ * mirroring `config-migrations.ts`, so it stays pure, unit-testable, and reusable
+ * outside the Angular app. The list of valid locale ids is passed in by the caller
+ * (e.g. `ConfigService` derives it from `availableLocales`) rather than imported,
+ * to keep this file dependency-free.
+ *
+ * These helpers only ever produce the *resolved* (display) view. The raw maps must
+ * remain the persisted source of truth — callers must never write a resolved value
+ * back to the config document, or all other languages would be lost.
+ */
+
+/** A config text that may be a plain string or a per-locale translation map. */
+export type TranslatableText = string | Record<string, string>;
+
+/** Reduce a locale id to its language subtag, e.g. `en-US` -> `en`. */
+function baseLanguage(locale: string): string {
+  return locale.split("-")[0].toLowerCase();
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Detect whether a value is a translation map: a plain object with at least one
+ * entry, where *every* key is a recognized locale id and *every* value is a string.
+ *
+ * Requiring all keys to be known locales (and all values to be strings) keeps the
+ * check conservative, so ordinary config objects that merely contain a locale-like
+ * key are not misclassified.
+ */
+export function isTranslatableText(
+  value: unknown,
+  validLocaleIds: readonly string[],
+): value is Record<string, string> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(
+    ([key, val]) => validLocaleIds.includes(key) && typeof val === "string",
+  );
+}
+
+/**
+ * Pick the best non-empty text for `locale` from a translation map:
+ * exact locale id first, then any entry that shares the same language subtag
+ * (e.g. active `en-GB` falling back to a stored `en-US`).
+ */
+function pickForLocale(
+  map: Record<string, string>,
+  locale: string,
+): string | undefined {
+  if (isNonEmptyString(map[locale])) {
+    return map[locale];
+  }
+  const base = baseLanguage(locale);
+  if (isNonEmptyString(map[base])) {
+    return map[base];
+  }
+  const sharedKey = Object.keys(map).find(
+    (key) => baseLanguage(key) === base && isNonEmptyString(map[key]),
+  );
+  return sharedKey !== undefined ? map[sharedKey] : undefined;
+}
+
+/**
+ * Resolve a translatable value to a single string for the active locale.
+ *
+ * - a plain string (or `null`/`undefined`) is returned unchanged
+ * - a translation map is resolved: active locale -> its language subtag ->
+ *   default locale -> default's subtag -> the first non-empty value present
+ * - any other (non-map) object is returned unchanged
+ */
+export function resolveTranslatableText(
+  value: TranslatableText | null | undefined,
+  activeLocale: string,
+  defaultLocale: string,
+  validLocaleIds: readonly string[],
+): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!isTranslatableText(value, validLocaleIds)) {
+    return value as unknown as string;
+  }
+  return (
+    pickForLocale(value, activeLocale) ??
+    pickForLocale(value, defaultLocale) ??
+    Object.values(value).find(isNonEmptyString)
+  );
+}
+
+/**
+ * Config keys that hold user-facing text and may therefore be multi-lingual.
+ * Keys not present on a given object are simply skipped.
+ */
+export const TRANSLATABLE_CONFIG_KEYS = [
+  "label",
+  "labelShort",
+  "labelPlural",
+  "description",
+] as const;
+
+/**
+ * Merge an edited, locale-resolved config object back onto its raw counterpart,
+ * preserving the translations of all other languages.
+ *
+ * Admin UIs read config through the *resolved* view (plain strings) and write the
+ * whole object back. Without this merge, saving would replace a translation map
+ * with the single string of the editing admin's language and silently drop every
+ * other language (#3862).
+ *
+ * For each translatable key, if the raw value is a translation map:
+ * - unchanged (the edited text still equals what the admin was shown) -> keep the map
+ * - changed -> update only the active locale's entry, keeping the other languages
+ *
+ * Raw plain strings keep the previous simple-string behaviour, so configs that never
+ * opted into multiple languages are untouched.
+ */
+export function mergeTranslatableValues<T extends Record<string, any>>(
+  raw: Record<string, any> | undefined,
+  edited: T,
+  activeLocale: string,
+  defaultLocale: string,
+  validLocaleIds: readonly string[],
+  translatableKeys: readonly string[] = TRANSLATABLE_CONFIG_KEYS,
+): T {
+  const merged: Record<string, any> = { ...edited };
+  if (!raw) {
+    return merged as T;
+  }
+
+  for (const key of translatableKeys) {
+    const rawValue = raw[key];
+    if (!isTranslatableText(rawValue, validLocaleIds)) {
+      // never was multi-lingual -> keep the edited value unchanged
+      continue;
+    }
+
+    const editedValue = merged[key];
+    if (isTranslatableText(editedValue, validLocaleIds)) {
+      // already edited as a full map (e.g. via the translations dialog)
+      continue;
+    }
+    if (typeof editedValue !== "string") {
+      // nothing usable was edited -> do not lose the existing translations
+      merged[key] = rawValue;
+      continue;
+    }
+
+    const shownValue = resolveTranslatableText(
+      rawValue,
+      activeLocale,
+      defaultLocale,
+      validLocaleIds,
+    );
+    merged[key] =
+      editedValue === shownValue
+        ? rawValue
+        : { ...rawValue, [activeLocale]: editedValue };
+  }
+
+  return merged as T;
+}
+
+/**
+ * Deep-clone a config tree, replacing every translation map with its resolved
+ * string for the active locale and leaving everything else untouched.
+ *
+ * Returns a new structure; the input is not mutated (the raw config must stay
+ * intact as the persisted source of truth).
+ */
+export function resolveTranslatableConfig<T>(
+  config: T,
+  activeLocale: string,
+  defaultLocale: string,
+  validLocaleIds: readonly string[],
+): T {
+  const walk = (node: unknown): unknown => {
+    if (isTranslatableText(node, validLocaleIds)) {
+      return resolveTranslatableText(
+        node,
+        activeLocale,
+        defaultLocale,
+        validLocaleIds,
+      );
+    }
+    if (Array.isArray(node)) {
+      return node.map(walk);
+    }
+    if (node !== null && typeof node === "object") {
+      const resolved: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(node)) {
+        resolved[key] = walk(val);
+      }
+      return resolved;
+    }
+    return node;
+  };
+
+  return walk(config) as T;
+}

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.html
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.html
@@ -1,0 +1,33 @@
+@if (multiline()) {
+  <textarea
+    class="text-field"
+    [rows]="rows()"
+    [value]="displayText()"
+    [placeholder]="placeholder ?? ''"
+    [disabled]="!enabled()"
+    (input)="onTextInput($any($event.target).value)"
+    (blur)="onTouched()"
+  ></textarea>
+} @else {
+  <input
+    class="text-field"
+    [value]="displayText()"
+    [placeholder]="placeholder ?? ''"
+    [disabled]="!enabled()"
+    (input)="onTextInput($any($event.target).value)"
+    (blur)="onTouched()"
+  />
+}
+
+<button
+  mat-icon-button
+  type="button"
+  class="translations-button"
+  [class.is-multi-lingual]="isMultiLingual()"
+  [disabled]="!enabled()"
+  (click)="openTranslations($event)"
+  matTooltip="Configure this text in other languages"
+  i18n-matTooltip
+>
+  <fa-icon icon="language"></fa-icon>
+</button>

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.html
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.html
@@ -1,6 +1,7 @@
 @if (multiline()) {
   <textarea
     class="text-field"
+    [id]="id"
     [rows]="rows()"
     [value]="displayText()"
     [placeholder]="placeholder ?? ''"
@@ -11,6 +12,7 @@
 } @else {
   <input
     class="text-field"
+    [id]="id"
     [value]="displayText()"
     [placeholder]="placeholder ?? ''"
     [disabled]="!enabled()"

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.scss
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.scss
@@ -1,0 +1,41 @@
+@use "variables/colors";
+
+:host {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+// a textarea is taller than the button, so keep the button at the top
+:host(.is-multiline) {
+  align-items: flex-start;
+}
+
+.text-field {
+  flex: 1 1 auto;
+  border: none;
+  background: transparent;
+  // `inherit` would pick up the form field's muted label colour
+  color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87));
+  font: inherit;
+  padding: 0;
+  outline: none;
+}
+
+textarea.text-field {
+  resize: vertical;
+}
+
+.translations-button {
+  flex: 0 0 auto;
+  // keep the button from dictating the height of the form field
+  --mdc-icon-button-state-layer-size: 24px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
+
+// highlight the button when translations for several languages exist
+.is-multi-lingual {
+  color: colors.$accent;
+}

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.spec.ts
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
+import { of } from "rxjs";
+
+import { TranslatableTextInputComponent } from "./translatable-text-input.component";
+
+describe("TranslatableTextInputComponent", () => {
+  let component: TranslatableTextInputComponent;
+  let fixture: ComponentFixture<TranslatableTextInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslatableTextInputComponent,
+        FontAwesomeTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TranslatableTextInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  /** simulate the translations dialog being confirmed with the given result */
+  function confirmDialogWith(result: unknown) {
+    vi.spyOn(component["dialog"], "open").mockReturnValue({
+      afterClosed: () => of(result),
+    } as any);
+    component.openTranslations({ stopPropagation: () => undefined } as Event);
+  }
+
+  it("should show the active language's text for a multi-lingual value", () => {
+    component.value = { "en-US": "Name", de: "Vorname" };
+
+    // tests run in the default language
+    expect(component.displayText()).toBe("Name");
+    expect(component.isMultiLingual()).toBe(true);
+  });
+
+  it("should show a plain string as-is", () => {
+    component.value = "Name";
+
+    expect(component.displayText()).toBe("Name");
+    expect(component.isMultiLingual()).toBe(false);
+  });
+
+  it("should keep other languages when the text field is edited", () => {
+    component.value = { "en-US": "Name", de: "Vorname" };
+
+    component.onTextInput("Full Name");
+
+    expect(component.value).toEqual({ "en-US": "Full Name", de: "Vorname" });
+  });
+
+  it("should keep a plain string plain when the text field is edited", () => {
+    component.value = "Name";
+
+    component.onTextInput("Full Name");
+
+    expect(component.value).toBe("Full Name");
+  });
+
+  it("should take the value configured in the translations dialog", () => {
+    component.value = "Name";
+
+    confirmDialogWith({ "en-US": "Name", de: "Vorname" });
+
+    expect(component.value).toEqual({ "en-US": "Name", de: "Vorname" });
+  });
+
+  it("should keep the previous value when the dialog is cancelled", () => {
+    component.value = { "en-US": "Name", de: "Vorname" };
+
+    confirmDialogWith(undefined);
+
+    expect(component.value).toEqual({ "en-US": "Name", de: "Vorname" });
+  });
+});

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.spec.ts
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialog } from "@angular/material/dialog";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { of } from "rxjs";
@@ -8,14 +9,18 @@ import { TranslatableTextInputComponent } from "./translatable-text-input.compon
 describe("TranslatableTextInputComponent", () => {
   let component: TranslatableTextInputComponent;
   let fixture: ComponentFixture<TranslatableTextInputComponent>;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
+    mockDialog = { open: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [
         TranslatableTextInputComponent,
         FontAwesomeTestingModule,
         NoopAnimationsModule,
       ],
+      providers: [{ provide: MatDialog, useValue: mockDialog }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TranslatableTextInputComponent);
@@ -25,9 +30,7 @@ describe("TranslatableTextInputComponent", () => {
 
   /** simulate the translations dialog being confirmed with the given result */
   function confirmDialogWith(result: unknown) {
-    vi.spyOn(component["dialog"], "open").mockReturnValue({
-      afterClosed: () => of(result),
-    } as any);
+    mockDialog.open.mockReturnValue({ afterClosed: () => of(result) });
     component.openTranslations({ stopPropagation: () => undefined } as Event);
   }
 

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
@@ -1,0 +1,115 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  LOCALE_ID,
+  computed,
+  inject,
+  input,
+} from "@angular/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialog } from "@angular/material/dialog";
+import { MatFormFieldControl } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
+import { CustomFormControlDirective } from "../../common-components/basic-autocomplete/custom-form-control.directive";
+import { DEFAULT_LANGUAGE } from "../../language/language-statics";
+import { availableLocales } from "../../language/languages";
+import { ConfigureTranslationsPopupComponent } from "../configure-translations-popup/configure-translations-popup.component";
+import {
+  isTranslatableText,
+  resolveTranslatableText,
+  TranslatableText,
+} from "../multi-lingual-config";
+
+/**
+ * Input for a configurable text that can be translated into multiple languages.
+ *
+ * The bound form control holds the *raw* value - either a plain string or a
+ * per-language map - while the text field itself only shows and edits the text of
+ * the currently active language. Editing the text field therefore never drops the
+ * translations of other languages, and the button opens a dialog to edit them all.
+ *
+ * Use inside a `mat-form-field`, so the caller keeps control over label and errors:
+ * ```html
+ * <mat-form-field>
+ *   <mat-label i18n>Label</mat-label>
+ *   <app-translatable-text-input formControlName="label"></app-translatable-text-input>
+ * </mat-form-field>
+ * ```
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: "app-translatable-text-input",
+  host: {
+    "[class.is-multiline]": "multiline()",
+  },
+  templateUrl: "./translatable-text-input.component.html",
+  styleUrls: ["./translatable-text-input.component.scss"],
+  imports: [
+    MatInputModule,
+    MatButtonModule,
+    MatTooltipModule,
+    FontAwesomeModule,
+  ],
+  providers: [
+    { provide: MatFormFieldControl, useExisting: TranslatableTextInputComponent },
+  ],
+})
+export class TranslatableTextInputComponent extends CustomFormControlDirective<TranslatableText> {
+  override controlType = "translatable-text-input";
+
+  /** show a multi-line textarea instead of a single-line input */
+  multiline = input(false);
+  rows = input(3);
+
+  private readonly dialog = inject(MatDialog);
+  private readonly locale = inject(LOCALE_ID);
+  private readonly validLocaleIds = availableLocales.values.map((v) => v.id);
+
+  /** the text of the currently active language, shown in the text field */
+  readonly displayText = computed(
+    () =>
+      resolveTranslatableText(
+        this.valueSignal(),
+        this.locale,
+        DEFAULT_LANGUAGE,
+        this.validLocaleIds,
+      ) ?? "",
+  );
+
+  /** whether this text is currently configured in more than one language */
+  readonly isMultiLingual = computed(() =>
+    isTranslatableText(this.valueSignal(), this.validLocaleIds),
+  );
+
+  /**
+   * Apply text typed by the user to the active language only,
+   * keeping any other languages of a multi-lingual value untouched.
+   */
+  onTextInput(text: string) {
+    const current = this.valueSignal();
+    this.value = isTranslatableText(current, this.validLocaleIds)
+      ? { ...current, [this.locale]: text }
+      : text;
+  }
+
+  openTranslations(event: Event) {
+    event.stopPropagation();
+
+    this.dialog
+      .open(ConfigureTranslationsPopupComponent, {
+        data: { value: this.valueSignal() },
+        disableClose: true,
+      })
+      .afterClosed()
+      .subscribe((result?: TranslatableText) => {
+        if (result === undefined) {
+          // dialog cancelled: keep the previously configured value
+          return;
+        }
+        this.value = result;
+        this.onTouched();
+      });
+  }
+}

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
@@ -43,6 +43,9 @@ import {
   selector: "app-translatable-text-input",
   host: {
     "[class.is-multiline]": "multiline()",
+    // the placeholder belongs on the inner text field only - leaving it on
+    // the host too would make it match twice when queried by placeholder
+    "[attr.placeholder]": "null",
   },
   templateUrl: "./translatable-text-input.component.html",
   styleUrls: ["./translatable-text-input.component.scss"],

--- a/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
+++ b/src/app/core/config/translatable-text-input/translatable-text-input.component.ts
@@ -53,7 +53,10 @@ import {
     FontAwesomeModule,
   ],
   providers: [
-    { provide: MatFormFieldControl, useExisting: TranslatableTextInputComponent },
+    {
+      provide: MatFormFieldControl,
+      useExisting: TranslatableTextInputComponent,
+    },
   ],
 })
 export class TranslatableTextInputComponent extends CustomFormControlDirective<TranslatableText> {

--- a/src/app/core/entity-details/EntityDetailsConfig.ts
+++ b/src/app/core/entity-details/EntityDetailsConfig.ts
@@ -1,4 +1,5 @@
 import { Entity } from "../entity/model/entity";
+import { TranslatableText } from "../config/multi-lingual-config";
 
 /**
  * The configuration for an entity details page
@@ -23,7 +24,7 @@ export interface Panel {
   /**
    * The title of this panel. This should group the contained components.
    */
-  title: string;
+  title: TranslatableText;
 
   /**
    * The configurations for the components in this panel.
@@ -43,7 +44,7 @@ export interface PanelComponent {
   /**
    * An optional second title for only this component.
    */
-  title?: string;
+  title?: TranslatableText;
 
   /**
    * The name of the component. When registered, this usually is the name of the

--- a/src/app/core/entity-details/form/field-group.ts
+++ b/src/app/core/entity-details/form/field-group.ts
@@ -1,9 +1,11 @@
 import { ColumnConfig } from "../../common-components/entity-form/FormConfig";
+import { TranslatableText } from "../../config/multi-lingual-config";
 
 /**
  * A group of related form fields displayed within a Form component.
  */
 export interface FieldGroup {
-  header?: string;
+  /** may be configured per language; resolved before it is rendered */
+  header?: TranslatableText;
   fields: ColumnConfig[];
 }

--- a/src/app/core/entity/entity-config.service.ts
+++ b/src/app/core/entity/entity-config.service.ts
@@ -205,6 +205,18 @@ export class EntityConfigService {
     return this.configService.getConfig<EntityConfig>(configName);
   }
 
+  /**
+   * Like {@link getEntityConfig}, but with raw values: any multi-lingual texts
+   * are returned as their full per-language map rather than resolved to the
+   * active language. Required when editing config values that are saved back
+   * to the config document (see #3862).
+   */
+  public getRawEntityConfig(entityType: EntityConstructor): EntityConfig {
+    const configName =
+      EntityConfigService.PREFIX_ENTITY_CONFIG + entityType.ENTITY_TYPE;
+    return this.configService.getRawConfig<EntityConfig>(configName);
+  }
+
   getDetailsViewConfig(
     entityType: EntityConstructor,
   ): ViewConfig<EntityDetailsConfig> {

--- a/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
+++ b/src/app/core/ui/menu-item-list-editor/menu-item-list-editor.component.ts
@@ -21,6 +21,7 @@ import {
 import { MenuItem } from "../navigation/menu-item";
 import { AdminMenuItemComponent } from "../../admin/admin-menu/admin-menu-item/admin-menu-item.component";
 import {
+  EditableMenuItem,
   menuItemTree,
   MenuItemForAdminUi,
   MenuItemForAdminUiNew,
@@ -152,7 +153,7 @@ export class MenuItemListEditorComponent {
   static toPlainMenuItem(
     item: MenuItemForAdminUi,
     opts?: { forceLinkOnly?: boolean },
-  ): MenuItem | null {
+  ): EditableMenuItem | null {
     if ("entityType" in item && item.entityType) {
       if (opts?.forceLinkOnly) {
         // For shortcuts, entity items should not be included
@@ -207,7 +208,7 @@ export class MenuItemListEditorComponent {
   static toPlainMenuItems(
     items: MenuItemForAdminUi[],
     opts?: { forceLinkOnly?: boolean },
-  ): MenuItem[] {
+  ): EditableMenuItem[] {
     return items
       .map((item) => MenuItemListEditorComponent.toPlainMenuItem(item, opts))
       .filter((item): item is MenuItem => item !== null);

--- a/src/app/features/dashboard-widgets/shortcut-dashboard-widget/shortcut-dashboard-settings.component/shortcut-dashboard-settings.component.ts
+++ b/src/app/features/dashboard-widgets/shortcut-dashboard-widget/shortcut-dashboard-settings.component/shortcut-dashboard-settings.component.ts
@@ -10,6 +10,7 @@ import { ShortcutDashboardConfig } from "../shortcut-dashboard-config";
 import { DynamicFormControlComponent } from "#src/app/core/admin/admin-widget-dialog/dynamic-form-control.interface";
 import { MenuItemListEditorComponent } from "../../../../core/ui/menu-item-list-editor/menu-item-list-editor.component";
 import { MenuItemForAdminUi } from "../../../../core/admin/admin-menu/menu-item-for-admin-ui";
+import { MenuItem } from "#src/app/core/ui/navigation/menu-item";
 
 @DynamicComponent("ShortcutDashboardSettings")
 @Component({
@@ -38,7 +39,8 @@ export class ShortcutDashboardSettingsComponent implements DynamicFormControlCom
     );
     this.formControl().setValue({
       ...(this.formControl().value ?? ({} as ShortcutDashboardConfig)),
-      shortcuts: plainMenuItems,
+      // the shortcuts keep their raw labels (plain string or per-language map)
+      shortcuts: plainMenuItems as MenuItem[],
     });
     this.formControl().markAsDirty();
   }

--- a/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/all-features/Config_CONFIG_ENTITY.json
@@ -1319,7 +1319,10 @@
         },
         "projectNumber": {
           "dataType": "string",
-          "label": "Project Number",
+          "label": {
+            "en-US": "Project Number",
+            "de": "Projektnummer"
+          },
           "labelShort": "PN",
           "searchable": true,
           "anonymize": "retain",

--- a/src/assets/base-configs/education/Config_CONFIG_ENTITY.json
+++ b/src/assets/base-configs/education/Config_CONFIG_ENTITY.json
@@ -30,7 +30,11 @@
     "navigationMenu": {
       "items": [
         {
-          "label": "Dashboard",
+          "label": {
+            "en-US": "Dashboard",
+            "de": "Dashboard",
+            "fr": "Tableau de bord"
+          },
           "icon": "home",
           "link": "/"
         },
@@ -38,7 +42,11 @@
           "entityType": "Child"
         },
         {
-          "label": "Attendance",
+          "label": {
+            "en-US": "Attendance",
+            "de": "Anwesenheit",
+            "fr": "Présence"
+          },
           "icon": "calendar-check",
           "link": "/attendance",
           "subMenu": [
@@ -57,7 +65,11 @@
           "entityType": "Todo"
         },
         {
-          "label": "More ...",
+          "label": {
+            "en-US": "More ...",
+            "de": "Mehr ...",
+            "fr": "Plus ..."
+          },
           "subMenu": [
             {
               "entityType": "School"
@@ -66,7 +78,11 @@
               "entityType": "User"
             },
             {
-              "label": "Reports",
+              "label": {
+                "en-US": "Reports",
+                "de": "Berichte",
+                "fr": "Rapports"
+              },
               "icon": "line-chart",
               "link": "/report"
             }
@@ -83,22 +99,38 @@
             "config": {
               "shortcuts": [
                 {
-                  "label": "Record Attendance",
+                  "label": {
+                    "en-US": "Record Attendance",
+                    "de": "Anwesenheiten aufnehmen",
+                    "fr": "Faire l'appel"
+                  },
                   "icon": "calendar-check",
                   "link": "/attendance/add-day"
                 },
                 {
-                  "label": "Add Child",
+                  "label": {
+                    "en-US": "Add Child",
+                    "de": "Kind hinzufügen",
+                    "fr": "Ajouter un enfant"
+                  },
                   "icon": "plus",
                   "link": "/c/child/new"
                 },
                 {
-                  "label": "Public Registration Form",
+                  "label": {
+                    "en-US": "Public Registration Form",
+                    "de": "Öffentliches Anmelde-Formular",
+                    "fr": "Formulaire d'inscription publique"
+                  },
                   "icon": "file-circle-check",
                   "link": "/public-form/form/example"
                 },
                 {
-                  "label": "Import from file",
+                  "label": {
+                    "en-US": "Import from file",
+                    "de": "Import aus Datei",
+                    "fr": "Importer des données"
+                  },
                   "icon": "file-upload",
                   "link": "/import"
                 }
@@ -154,12 +186,24 @@
       "toStringAttributes": [
         "subject"
       ],
-      "label": "Note",
-      "labelPlural": "Notes",
+      "label": {
+        "en-US": "Note",
+        "de": "Notiz",
+        "fr": "Observation"
+      },
+      "labelPlural": {
+        "en-US": "Notes",
+        "de": "Notizen",
+        "fr": "Observations"
+      },
       "hasPII": true,
       "attributes": {
         "date": {
-          "label": "Date",
+          "label": {
+            "en-US": "Date",
+            "de": "Datum",
+            "fr": "Date"
+          },
           "dataType": "date-only",
           "defaultValue": {
             "mode": "dynamic",
@@ -171,14 +215,26 @@
         },
         "subject": {
           "dataType": "string",
-          "label": "Subject"
+          "label": {
+            "en-US": "Subject",
+            "de": "Betreff",
+            "fr": "Sujet"
+          }
         },
         "text": {
           "dataType": "long-text",
-          "label": "Notes"
+          "label": {
+            "en-US": "Notes",
+            "de": "Notizen",
+            "fr": "Observations"
+          }
         },
         "authors": {
-          "label": "Team involved",
+          "label": {
+            "en-US": "Team involved",
+            "de": "Beteiligtes Team",
+            "fr": "Equipe impliquée"
+          },
           "dataType": "entity",
           "isArray": true,
           "additional": "User",
@@ -191,17 +247,29 @@
           "anonymize": "retain"
         },
         "category": {
-          "label": "Category",
+          "label": {
+            "en-US": "Category",
+            "de": "Kategorie",
+            "fr": "Categorie"
+          },
           "dataType": "configurable-enum",
           "additional": "interaction-type",
           "anonymize": "retain"
         },
         "attachment": {
-          "label": "Attachment",
+          "label": {
+            "en-US": "Attachment",
+            "de": "Anhang",
+            "fr": "Pièce jointe"
+          },
           "dataType": "file"
         },
         "relatedEntities": {
-          "label": "Related Records",
+          "label": {
+            "en-US": "Related Records",
+            "de": "Verknüpfte Datensätze",
+            "fr": "Enregistrements associés"
+          },
           "dataType": "entity",
           "additional": [
             "Child",
@@ -212,7 +280,11 @@
           "anonymize": "retain"
         },
         "warningLevel": {
-          "label": "Status",
+          "label": {
+            "en-US": "Status",
+            "de": "Status im Projekt",
+            "fr": "Statut"
+          },
           "dataType": "configurable-enum",
           "additional": "warning-levels",
           "anonymize": "retain"
@@ -224,7 +296,11 @@
       "config": {
         "entityType": "Note",
         "clickMode": "popup-details",
-        "title": "Notes & Reports",
+        "title": {
+          "en-US": "Notes & Reports",
+          "de": "Notizen",
+          "fr": "Observations & Rapports"
+        },
         "columnGroups": {
           "default": "Standard",
           "mobile": "Mobile",
@@ -258,7 +334,11 @@
             "default": 1,
             "options": [
               {
-                "label": "Today"
+                "label": {
+                  "en-US": "Today",
+                  "de": "Heute",
+                  "fr": "Aujourd'hui"
+                }
               },
               {
                 "startOffsets": [
@@ -273,7 +353,11 @@
                     "unit": "weeks"
                   }
                 ],
-                "label": "This week"
+                "label": {
+                  "en-US": "This week",
+                  "de": "Diese Woche",
+                  "fr": "Cette semaine"
+                }
               },
               {
                 "startOffsets": [
@@ -282,7 +366,11 @@
                     "unit": "weeks"
                   }
                 ],
-                "label": "Since last week"
+                "label": {
+                  "en-US": "Since last week",
+                  "de": "Seit letzter Woche",
+                  "fr": "Depuis la semaine dernière"
+                }
               },
               {
                 "startOffsets": [
@@ -297,7 +385,11 @@
                     "unit": "months"
                   }
                 ],
-                "label": "This month"
+                "label": {
+                  "en-US": "This month",
+                  "de": "Diesen Monat",
+                  "fr": "Ce mois-ci"
+                }
               },
               {
                 "startOffsets": [
@@ -312,7 +404,11 @@
                     "unit": "months"
                   }
                 ],
-                "label": "Last month"
+                "label": {
+                  "en-US": "Last month",
+                  "de": "Letzten Monat",
+                  "fr": "Mois dernier"
+                }
               }
             ]
           },
@@ -349,23 +445,39 @@
         "columns": [
           {
             "viewComponent": "EntityBlock",
-            "label": "Name",
+            "label": {
+              "en-US": "Name",
+              "de": "Name",
+              "fr": "Nom"
+            },
             "id": "name"
           },
           {
             "viewComponent": "DisplayAge",
-            "label": "Age",
+            "label": {
+              "en-US": "Age",
+              "de": "Alter",
+              "fr": "Âge"
+            },
             "id": "age",
             "additional": "dateOfBirth"
           },
           {
             "viewComponent": "DisplayText",
-            "label": "Class",
+            "label": {
+              "en-US": "Class",
+              "de": "Klasse",
+              "fr": "Classe"
+            },
             "id": "schoolClass"
           },
           {
             "viewComponent": "DisplayEntity",
-            "label": "School",
+            "label": {
+              "en-US": "School",
+              "de": "Schule",
+              "fr": "École"
+            },
             "id": "schoolId",
             "additional": "School",
             "noSorting": true
@@ -414,7 +526,11 @@
           {
             "id": "schoolId",
             "type": "School",
-            "label": "School"
+            "label": {
+              "en-US": "School",
+              "de": "Schule",
+              "fr": "École"
+            }
           }
         ],
         "loaderMethod": "ChildrenService"
@@ -427,7 +543,11 @@
         "entityType": "Child",
         "panels": [
           {
-            "title": "Basic Information",
+            "title": {
+              "en-US": "Basic Information",
+              "de": "Übersicht",
+              "fr": "Informations de base"
+            },
             "components": [
               {
                 "title": "",
@@ -446,7 +566,11 @@
                         "admissionDate",
                         "riskStatus"
                       ],
-                      "header": "Personal Information"
+                      "header": {
+                        "en-US": "Personal Information",
+                        "de": "Persönlich",
+                        "fr": "Renseignements personnels"
+                      }
                     },
                     {
                       "fields": [
@@ -454,7 +578,11 @@
                         "phone",
                         "address"
                       ],
-                      "header": "Contact Details"
+                      "header": {
+                        "en-US": "Contact Details",
+                        "de": "Kontaktdaten",
+                        "fr": "Coordonnées"
+                      }
                     },
                     {
                       "fields": [
@@ -463,7 +591,11 @@
                         "birth_certificate",
                         "motherTongue"
                       ],
-                      "header": "Demographics"
+                      "header": {
+                        "en-US": "Demographics",
+                        "de": "Demografische Angaben",
+                        "fr": "Données démographiques"
+                      }
                     }
                   ]
                 }
@@ -471,10 +603,18 @@
             ]
           },
           {
-            "title": "Education",
+            "title": {
+              "en-US": "Education",
+              "de": "Bildung",
+              "fr": "Éducation"
+            },
             "components": [
               {
-                "title": "School History",
+                "title": {
+                  "en-US": "School History",
+                  "de": "Schullaufbahn",
+                  "fr": "Parcours scolaire"
+                },
                 "component": "ChildSchoolOverview",
                 "config": {
                   "single": true,
@@ -494,7 +634,11 @@
                 }
               },
               {
-                "title": "Literacy Test Results",
+                "title": {
+                  "en-US": "Literacy Test Results",
+                  "de": "Abschneiden beim Lese-Tests",
+                  "fr": "Résultats du test d'alphabétisation"
+                },
                 "component": "RelatedEntities",
                 "config": {
                   "entityType": "Aser",
@@ -530,7 +674,11 @@
             ]
           },
           {
-            "title": "Attendance",
+            "title": {
+              "en-US": "Attendance",
+              "de": "Anwesenheit",
+              "fr": "Présence"
+            },
             "components": [
               {
                 "title": "",
@@ -539,7 +687,11 @@
             ]
           },
           {
-            "title": "Notes & Tasks",
+            "title": {
+              "en-US": "Notes & Tasks",
+              "de": "Notizen & Aufgaben",
+              "fr": "Notes et tâches"
+            },
             "components": [
               {
                 "title": "",
@@ -552,7 +704,11 @@
             ]
           },
           {
-            "title": "Educational Materials",
+            "title": {
+              "en-US": "Educational Materials",
+              "de": "Schulmaterialien",
+              "fr": "Matériels scolaires"
+            },
             "components": [
               {
                 "title": "",
@@ -589,7 +745,11 @@
             ]
           },
           {
-            "title": "Exit & Dropout",
+            "title": {
+              "en-US": "Exit & Dropout",
+              "de": "Ausscheiden aus dem Projekt",
+              "fr": "Fin de scolarité"
+            },
             "components": [
               {
                 "title": "",
@@ -621,8 +781,16 @@
       "_id": "view:child/:id"
     },
     "entity:EducationalMaterial": {
-      "label": "Educational Material",
-      "labelPlural": "Educational Materials",
+      "label": {
+        "en-US": "Educational Material",
+        "de": "Schulmaterial",
+        "fr": "Matériel éducatif"
+      },
+      "labelPlural": {
+        "en-US": "Educational Materials",
+        "de": "Schulmaterialien",
+        "fr": "Matériels éducatifs"
+      },
       "attributes": {
         "child": {
           "dataType": "entity",
@@ -631,7 +799,11 @@
         },
         "date": {
           "dataType": "date",
-          "label": "Date",
+          "label": {
+            "en-US": "Date",
+            "de": "Datum",
+            "fr": "Date"
+          },
           "defaultValue": {
             "mode": "dynamic",
             "config": {
@@ -640,7 +812,11 @@
           }
         },
         "materialType": {
-          "label": "Material",
+          "label": {
+            "en-US": "Material",
+            "de": "Material",
+            "fr": "Materiél"
+          },
           "dataType": "configurable-enum",
           "additional": "materials",
           "validators": {
@@ -649,7 +825,11 @@
         },
         "materialAmount": {
           "dataType": "number",
-          "label": "Amount",
+          "label": {
+            "en-US": "Amount",
+            "de": "Anzahl",
+            "fr": "Quantité"
+          },
           "defaultValue": {
             "mode": "static",
             "config": {
@@ -662,7 +842,11 @@
         },
         "description": {
           "dataType": "string",
-          "label": "Description"
+          "label": {
+            "en-US": "Description",
+            "de": "Beschreibung",
+            "fr": "Description"
+          }
         }
       }
     },
@@ -670,38 +854,70 @@
       "toStringAttributes": [
         "title"
       ],
-      "label": "Activity",
-      "labelPlural": "Activities",
+      "label": {
+        "en-US": "Activity",
+        "de": "Aktivität",
+        "fr": "Activité"
+      },
+      "labelPlural": {
+        "en-US": "Activities",
+        "de": "Aktivitäten",
+        "fr": "Activités"
+      },
       "icon": "calendar-days",
       "color": "#00838F",
       "route": "recurring-activity",
       "attributes": {
         "title": {
           "dataType": "string",
-          "label": "Title",
+          "label": {
+            "en-US": "Title",
+            "de": "Titel",
+            "fr": "Titre"
+          },
           "validators": {
             "required": true
           }
         },
         "type": {
-          "label": "Type",
+          "label": {
+            "en-US": "Type",
+            "de": "Typ",
+            "fr": "Taper"
+          },
           "dataType": "configurable-enum",
           "additional": "interaction-type"
         },
         "status": {
-          "label": "Status of activity",
-          "description": "This status can be used to automatically update participants' status also.",
+          "label": {
+            "en-US": "Status of activity",
+            "de": "Status der Aktivität",
+            "fr": "Statut de l'activité"
+          },
+          "description": {
+            "en-US": "This status can be used to automatically update participants' status also.",
+            "de": "Dieser Status kann genutzt werden, um automatisch den Status der Teilnehmer:innen mit zu aktualisieren.",
+            "fr": "Ce statut peut également être utilisé pour mettre à jour automatiquement le statut des participants."
+          },
           "dataType": "configurable-enum",
           "additional": "activity-status"
         },
         "participants": {
-          "label": "Participants",
+          "label": {
+            "en-US": "Participants",
+            "de": "Teilnehmer:innen",
+            "fr": "Participants"
+          },
           "dataType": "entity",
           "isArray": true,
           "additional": "Child"
         },
         "assignedTo": {
-          "label": "Assigned user(s)",
+          "label": {
+            "en-US": "Assigned user(s)",
+            "de": "Verantwortliche:r",
+            "fr": "Utilisateur(s) affecté(e)(s)"
+          },
           "dataType": "entity",
           "isArray": true,
           "additional": "User"
@@ -727,7 +943,11 @@
         "entityType": "RecurringActivity",
         "panels": [
           {
-            "title": "Basic Information",
+            "title": {
+              "en-US": "Basic Information",
+              "de": "Übersicht",
+              "fr": "Informations de base"
+            },
             "components": [
               {
                 "component": "Form",
@@ -755,7 +975,11 @@
             ]
           },
           {
-            "title": "Participants",
+            "title": {
+              "en-US": "Participants",
+              "de": "Teilnehmer:innen",
+              "fr": "Participants"
+            },
             "components": [
               {
                 "component": "Form",
@@ -772,7 +996,11 @@
             ]
           },
           {
-            "title": "Events & Attendance",
+            "title": {
+              "en-US": "Events & Attendance",
+              "de": "Aktivitäten & Anwesenheit",
+              "fr": "Évènements & présence"
+            },
             "components": [
               {
                 "component": "ActivityAttendanceSection"
@@ -788,8 +1016,16 @@
       "_id": "view:report"
     },
     "entity:Child": {
-      "label": "Student",
-      "labelPlural": "Students",
+      "label": {
+        "en-US": "Student",
+        "de": "Schüler:in",
+        "fr": "Étudiante"
+      },
+      "labelPlural": {
+        "en-US": "Students",
+        "de": "Schüler:innen",
+        "fr": "Étudiantes"
+      },
       "toStringAttributes": [
         "name"
       ],
@@ -808,86 +1044,162 @@
       "attributes": {
         "name": {
           "dataType": "string",
-          "label": "Name",
+          "label": {
+            "en-US": "Name",
+            "de": "Name",
+            "fr": "Nom"
+          },
           "validators": {
             "required": true
           }
         },
         "projectNumber": {
           "dataType": "string",
-          "label": "Student ID",
+          "label": {
+            "en-US": "Student ID",
+            "de": "Schüler-ID",
+            "fr": "ID de l'étudiante"
+          },
           "labelShort": "ID",
-          "description": "A unique ID for internal use of the organization",
+          "description": {
+            "en-US": "A unique ID for internal use of the organization",
+            "de": "Eine eindeutige Kennnummer für die interne Nutzung",
+            "fr": "Un identifiant unique à usage interne à l'organisation"
+          },
           "searchable": true,
           "anonymize": "retain"
         },
         "dateOfBirth": {
           "dataType": "date-with-age",
-          "label": "Date of birth",
-          "labelShort": "DoB",
+          "label": {
+            "en-US": "Date of birth",
+            "de": "Geburtsdatum",
+            "fr": "Date de naissance"
+          },
+          "labelShort": {
+            "en-US": "DoB",
+            "de": "Geburtsdatum",
+            "fr": "DDN"
+          },
           "anonymize": "retain-anonymized"
         },
         "gender": {
           "dataType": "configurable-enum",
-          "label": "Gender",
+          "label": {
+            "en-US": "Gender",
+            "de": "Geschlecht",
+            "fr": "Genre"
+          },
           "additional": "genders",
           "anonymize": "retain"
         },
         "admissionDate": {
           "dataType": "date-only",
-          "label": "Admission",
+          "label": {
+            "en-US": "Admission",
+            "de": "Aufnahmedatum",
+            "fr": "Admission"
+          },
           "anonymize": "retain-anonymized"
         },
         "riskStatus": {
           "dataType": "configurable-enum",
-          "label": "Risk Status",
+          "label": {
+            "en-US": "Risk Status",
+            "de": "Risiko-Status",
+            "fr": "Statut de risque"
+          },
           "additional": "riskStatus"
         },
         "dropoutDate": {
           "dataType": "date-only",
-          "label": "Dropout Date",
+          "label": {
+            "en-US": "Dropout Date",
+            "de": "Datum des Ausscheidens",
+            "fr": "Date de fin de scolarité"
+          },
           "anonymize": "retain-anonymized"
         },
         "dropoutType": {
           "dataType": "string",
-          "label": "Dropout Type",
+          "label": {
+            "en-US": "Dropout Type",
+            "de": "Grund des Ausscheidens",
+            "fr": "Type de fin de scolarité"
+          },
           "anonymize": "retain"
         },
         "dropoutRemarks": {
           "dataType": "string",
-          "label": "Dropout remarks"
+          "label": {
+            "en-US": "Dropout remarks",
+            "de": "Bermekungen zum Ausscheiden",
+            "fr": "Commentaires sur la fin de scolarité"
+          }
         },
         "photo": {
           "dataType": "photo",
-          "label": "Photo"
+          "label": {
+            "en-US": "Photo",
+            "de": "Foto",
+            "fr": "Photo"
+          }
         },
         "phone": {
           "dataType": "string",
-          "label": "Phone Number"
+          "label": {
+            "en-US": "Phone Number",
+            "de": "Telefonnummer",
+            "fr": "Numéro de téléphone"
+          }
         },
         "address": {
           "dataType": "location",
-          "label": "Address"
+          "label": {
+            "en-US": "Address",
+            "de": "Adresse",
+            "fr": "Adresse"
+          }
         },
         "health_bloodGroup": {
           "dataType": "string",
-          "label": "Blood Group"
+          "label": {
+            "en-US": "Blood Group",
+            "de": "Blutgruppe",
+            "fr": "Groupe sanguin"
+          }
         },
         "motherTongue": {
           "dataType": "string",
-          "label": "Mother Tongue",
-          "description": "The primary language spoken at home"
+          "label": {
+            "en-US": "Mother Tongue",
+            "de": "Muttersprache",
+            "fr": "Langue maternelle"
+          },
+          "description": {
+            "en-US": "The primary language spoken at home",
+            "de": "Die hauptsächlich zu Hause gesprochene Sprache",
+            "fr": "La langue principale parlée à la maison"
+          }
         },
         "birth_certificate": {
           "dataType": "file",
-          "label": "Birth certificate",
+          "label": {
+            "en-US": "Birth certificate",
+            "de": "Geburtsurkunde",
+            "fr": "Acte de naissance"
+          },
           "additional": {
             "acceptedFileTypes": ".pdf"
           }
         },
         "email": {
           "dataType": "email",
-          "label": "Email"
+          "label": {
+            "en-US": "Email",
+            "de": "E-Mail",
+            "fr": "Email"
+          }
         }
       }
     },
@@ -896,49 +1208,93 @@
         "name"
       ],
       "icon": "university",
-      "label": "Partner",
-      "labelPlural": "Partners",
+      "label": {
+        "en-US": "Partner",
+        "de": "Partner",
+        "fr": "Partenaire"
+      },
+      "labelPlural": {
+        "en-US": "Partners",
+        "de": "Partner",
+        "fr": "Partenaires"
+      },
       "color": "#9E9D24",
       "attributes": {
         "name": {
           "dataType": "string",
-          "label": "Name",
+          "label": {
+            "en-US": "Name",
+            "de": "Name",
+            "fr": "Nom"
+          },
           "validators": {
             "required": true
           }
         },
         "privateSchool": {
           "dataType": "boolean",
-          "label": "Private School"
+          "label": {
+            "en-US": "Private School",
+            "de": "Privatschule",
+            "fr": "École privée"
+          }
         },
         "language": {
           "dataType": "string",
-          "label": "Language"
+          "label": {
+            "en-US": "Language",
+            "de": "Sprache",
+            "fr": "Langue"
+          }
         },
         "address": {
           "dataType": "location",
-          "label": "Address"
+          "label": {
+            "en-US": "Address",
+            "de": "Adresse",
+            "fr": "Adresse"
+          }
         },
         "phone": {
           "dataType": "string",
-          "label": "Phone Number"
+          "label": {
+            "en-US": "Phone Number",
+            "de": "Telefonnummer",
+            "fr": "Numéro de téléphone"
+          }
         },
         "timing": {
           "dataType": "string",
-          "label": "School Timing"
+          "label": {
+            "en-US": "School Timing",
+            "de": "Unterrichtszeiten",
+            "fr": "Horaires scolaires"
+          }
         },
         "remarks": {
           "dataType": "string",
-          "label": "Remarks"
+          "label": {
+            "en-US": "Remarks",
+            "de": "Vermerk",
+            "fr": "Observations"
+          }
         },
         "website": {
           "dataType": "url",
-          "label": "Website"
+          "label": {
+            "en-US": "Website",
+            "de": "Webseite",
+            "fr": "Site web"
+          }
         },
         "contactPerson": {
           "dataType": "entity",
           "additional": "User",
-          "label": "Contact Person"
+          "label": {
+            "en-US": "Contact Person",
+            "de": "Kontaktperson",
+            "fr": "Personne de contact"
+          }
         }
       }
     },
@@ -951,7 +1307,11 @@
           {
             "id": "DisplayParticipantsCount",
             "viewComponent": "DisplayParticipantsCount",
-            "label": "Children"
+            "label": {
+              "en-US": "Children",
+              "de": "Schüler:innen",
+              "fr": "Enfants"
+            }
           },
           "privateSchool",
           "language",
@@ -974,7 +1334,11 @@
         "entityType": "School",
         "panels": [
           {
-            "title": "Basic Information",
+            "title": {
+              "en-US": "Basic Information",
+              "de": "Übersicht",
+              "fr": "Informations de base"
+            },
             "components": [
               {
                 "title": "",
@@ -1012,7 +1376,11 @@
             ]
           },
           {
-            "title": "Students",
+            "title": {
+              "en-US": "Students",
+              "de": "Schüler:innen",
+              "fr": "Élèves"
+            },
             "components": [
               {
                 "title": "",
@@ -1021,7 +1389,11 @@
             ]
           },
           {
-            "title": "Activities",
+            "title": {
+              "en-US": "Activities",
+              "de": "Aktivitäten",
+              "fr": "Activités"
+            },
             "components": [
               {
                 "title": "",
@@ -1039,30 +1411,62 @@
         "lastname"
       ],
       "icon": "user",
-      "label": "Staff Member",
-      "labelPlural": "Staff Members",
+      "label": {
+        "en-US": "Staff Member",
+        "de": "Mitarbeiter:in",
+        "fr": "Personnel"
+      },
+      "labelPlural": {
+        "en-US": "Staff Members",
+        "de": "Mitarbeiter:innen",
+        "fr": "Personnel"
+      },
       "hasPII": true,
       "attributes": {
         "firstname": {
           "dataType": "string",
-          "label": "First Name"
+          "label": {
+            "en-US": "First Name",
+            "de": "Vorname",
+            "fr": "Prénom"
+          }
         },
         "lastname": {
           "dataType": "string",
-          "label": "Last Name"
+          "label": {
+            "en-US": "Last Name",
+            "de": "Nachname",
+            "fr": "Nom de famille"
+          }
         },
         "phone": {
           "dataType": "string",
-          "label": "Contact Number"
+          "label": {
+            "en-US": "Contact Number",
+            "de": "Telefonnummer",
+            "fr": "Numéro de contact"
+          }
         },
         "role": {
           "dataType": "string",
-          "label": "Role",
-          "description": "Current role in the organisation"
+          "label": {
+            "en-US": "Role",
+            "de": "Rolle",
+            "fr": "Rôle"
+          },
+          "description": {
+            "en-US": "Current role in the organisation",
+            "de": "Aktuelle Rolle in der Organisation",
+            "fr": "Rôle actuel au sein de l'organisation"
+          }
         },
         "dateOfJoining": {
           "dataType": "date-only",
-          "label": "Date of Joining"
+          "label": {
+            "en-US": "Date of Joining",
+            "de": "Eintrittsdatum",
+            "fr": "Date d'entrée"
+          }
         }
       }
     },
@@ -1093,7 +1497,11 @@
         "entityType": "User",
         "panels": [
           {
-            "title": "User Information",
+            "title": {
+              "en-US": "User Information",
+              "de": "Übersicht",
+              "fr": "Informations sur l'utilisateur"
+            },
             "components": [
               {
                 "title": "",
@@ -1123,10 +1531,18 @@
             ]
           },
           {
-            "title": "Responsible for",
+            "title": {
+              "en-US": "Responsible for",
+              "de": "Verantwortlich für",
+              "fr": "Responsable de"
+            },
             "components": [
               {
-                "title": "Contact Person for Partners",
+                "title": {
+                  "en-US": "Contact Person for Partners",
+                  "de": "Kontaktperson für Partner",
+                  "fr": "Personne de contact pour les partenaires"
+                },
                 "component": "RelatedEntities",
                 "config": {
                   "entityType": "School",
@@ -1144,7 +1560,11 @@
                 }
               },
               {
-                "title": "Managing Activities ",
+                "title": {
+                  "en-US": "Managing Activities ",
+                  "de": "Verantwortete Aktivitäten",
+                  "fr": "Gestion des activités"
+                },
                 "component": "RelatedEntities",
                 "config": {
                   "entityType": "RecurringActivity",
@@ -1168,8 +1588,16 @@
       "_id": "view:user/:id"
     },
     "entity:Aser": {
-      "label": "Literacy Test",
-      "labelPlural": "Literacy Tests",
+      "label": {
+        "en-US": "Literacy Test",
+        "de": "Lese-Test",
+        "fr": "Test d'alphabétisation"
+      },
+      "labelPlural": {
+        "en-US": "Literacy Tests",
+        "de": "Lese-Tests",
+        "fr": "Tests d'alphabétisation"
+      },
       "hasPII": true,
       "attributes": {
         "child": {
@@ -1179,7 +1607,11 @@
         },
         "date": {
           "dataType": "date",
-          "label": "Date",
+          "label": {
+            "en-US": "Date",
+            "de": "Datum",
+            "fr": "Date"
+          },
           "defaultValue": {
             "mode": "dynamic",
             "config": {
@@ -1199,18 +1631,30 @@
           "additional": "reading-levels"
         },
         "english": {
-          "label": "English",
+          "label": {
+            "en-US": "English",
+            "de": "Englisch",
+            "fr": "Anglais"
+          },
           "dataType": "configurable-enum",
           "additional": "reading-levels"
         },
         "math": {
-          "label": "Math",
+          "label": {
+            "en-US": "Math",
+            "de": "Mathe",
+            "fr": "Mathématiques"
+          },
           "dataType": "configurable-enum",
           "additional": "math-levels"
         },
         "remarks": {
           "dataType": "string",
-          "label": "Remarks"
+          "label": {
+            "en-US": "Remarks",
+            "de": "Vermerk",
+            "fr": "Observations"
+          }
         }
       }
     },
@@ -1225,7 +1669,11 @@
             "required": true
           },
           "anonymize": "retain",
-          "label": "Child"
+          "label": {
+            "en-US": "Child",
+            "de": "Kind",
+            "fr": "Enfant"
+          }
         },
         "schoolId": {
           "dataType": "entity",
@@ -1235,28 +1683,56 @@
             "required": true
           },
           "anonymize": "retain",
-          "label": "School"
+          "label": {
+            "en-US": "School",
+            "de": "Schule",
+            "fr": "École"
+          }
         },
         "schoolClass": {
           "dataType": "string",
-          "label": "Class",
+          "label": {
+            "en-US": "Class",
+            "de": "Klasse",
+            "fr": "Classe"
+          },
           "anonymize": "retain"
         },
         "start": {
           "dataType": "date-only",
-          "label": "Start date",
-          "description": "The date a child joins a school",
+          "label": {
+            "en-US": "Start date",
+            "de": "Anfang",
+            "fr": "Date de début"
+          },
+          "description": {
+            "en-US": "The date a child joins a school",
+            "de": "Das Datum, an dem das Kind der Schule beigetreten ist",
+            "fr": "Date où l'enfant rejoint une école"
+          },
           "anonymize": "retain"
         },
         "end": {
           "dataType": "date-only",
-          "label": "End date",
-          "description": "The date of a child leaving the school",
+          "label": {
+            "en-US": "End date",
+            "de": "Ende",
+            "fr": "Date de fin"
+          },
+          "description": {
+            "en-US": "The date of a child leaving the school",
+            "de": "Das Datum, an dem das Kind die Schule verlassen hat",
+            "fr": "Date de départ d'un enfant de l'école"
+          },
           "anonymize": "retain"
         },
         "result": {
           "dataType": "percentage",
-          "label": "Result",
+          "label": {
+            "en-US": "Result",
+            "de": "Ergebnis",
+            "fr": "Résultat"
+          },
           "validators": {
             "min": 0,
             "max": 100
@@ -1268,13 +1744,25 @@
       "toStringAttributes": [
         "subject"
       ],
-      "label": "Event",
-      "labelPlural": "Events",
+      "label": {
+        "en-US": "Event",
+        "de": "Veranstaltung",
+        "fr": "Évènement"
+      },
+      "labelPlural": {
+        "en-US": "Events",
+        "de": "Veranstaltungen",
+        "fr": "Évènements"
+      },
       "icon": "calendar-day",
       "hasPII": true,
       "attributes": {
         "date": {
-          "label": "Date",
+          "label": {
+            "en-US": "Date",
+            "de": "Datum",
+            "fr": "Date"
+          },
           "dataType": "date-only",
           "defaultValue": {
             "mode": "dynamic",
@@ -1285,7 +1773,11 @@
           "anonymize": "retain"
         },
         "participants": {
-          "label": "Participants",
+          "label": {
+            "en-US": "Participants",
+            "de": "Teilnehmer:innen",
+            "fr": "Participants"
+          },
           "dataType": "attendance",
           "isArray": true,
           "additional": {
@@ -1301,14 +1793,26 @@
         },
         "subject": {
           "dataType": "string",
-          "label": "Title"
+          "label": {
+            "en-US": "Title",
+            "de": "Titel",
+            "fr": "Sujet"
+          }
         },
         "text": {
           "dataType": "long-text",
-          "label": "Notes"
+          "label": {
+            "en-US": "Notes",
+            "de": "Notizen",
+            "fr": "Observations"
+          }
         },
         "authors": {
-          "label": "Team involved",
+          "label": {
+            "en-US": "Team involved",
+            "de": "Beteiligtes Team",
+            "fr": "Equipe impliquée"
+          },
           "dataType": "entity",
           "isArray": true,
           "additional": "User",
@@ -1321,17 +1825,29 @@
           "anonymize": "retain"
         },
         "category": {
-          "label": "Category",
+          "label": {
+            "en-US": "Category",
+            "de": "Kategorie",
+            "fr": "Categorie"
+          },
           "dataType": "configurable-enum",
           "additional": "interaction-type",
           "anonymize": "retain"
         },
         "attachment": {
-          "label": "Attachment",
+          "label": {
+            "en-US": "Attachment",
+            "de": "Anhang",
+            "fr": "Pièce jointe"
+          },
           "dataType": "file"
         },
         "parentActivity": {
-          "label": "Parent Activity",
+          "label": {
+            "en-US": "Parent Activity",
+            "de": "Übergeordnete Aktivität",
+            "fr": "Activité parente"
+          },
           "dataType": "entity",
           "additional": "RecurringActivity",
           "anonymize": "retain"
@@ -1363,7 +1879,11 @@
         "entityType": "Event",
         "panels": [
           {
-            "title": "Details",
+            "title": {
+              "en-US": "Details",
+              "de": "Details",
+              "fr": "Détails"
+            },
             "components": [
               {
                 "component": "Form",


### PR DESCRIPTION
- closes #3862

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---
## Manual Testing

Test A — the dialog works

1. Left nav → Children
2. Click the ⋮ at top right → Configure Data Structure
3. Click Details View & Fields
4. Hover the Name field → click the Edit Field button
5. Next to the Label input you should now see a language icon. Click it
6. The "Configure translations" dialog opens with one row per language. English should be pre-filled with Name
7. Type Vorname into the German row → click Save
8. Back in the field dialog, the Label input should still show Name — not [object Object]
9. Click Apply, then Save at the bottom → you should see "Configuration updated"

Test B — the translation actually persisted

1. Re-open the same field (hover Name → Edit Field) → click the language icon again
2. German should still read Vorname, English Name

Test C — the important one: other languages survive an unrelated edit

1. With the field dialog open, change the Label to Full Name 
2.. Also toggle something unrelated — e.g. type anything in Description
3.. Apply → Save
4. Re-open the field → language icon

Expected: English = Full Name (your edit), German = Vorname still intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multilingual editing for entity labels, field labels, descriptions, group headers, tabs, and menu items.
  * Added a translations dialog for entering and managing values across supported languages.
  * Added locale-aware display with fallback to the default language.
  * Preserved translations in other languages when updating configuration values.
  * Added localized English, German, and French content to the education configuration.

* **Tests**
  * Expanded unit and end-to-end coverage for multilingual configuration and localization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->