### PR TITLE
fix: allow configuring which origins may embed the app in an iframe

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,10 +20,15 @@ ENV CSP_REPORT_URI="https://o167951.ingest.sentry.io/api/1242399/security/"
 ENV CSP="default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob: https://*.tile.openstreetmap.org/ https://matomo.aam-digital.org https://fcmregistrations.googleapis.com/v1/projects/* https://www.gstatic.com/firebasejs/* https://*.aam-digital.com https://*.aam-digital.net https://*.aam-digital.app https://api.github.com/repos/Aam-Digital/ https://aam-digital.github.io https://sentry.io https://raw.githubusercontent.com $CSP_REPORT_URI; style-src 'self' 'unsafe-inline'"
 # 'unsafe-eval' required for pouchdb https://github.com/pouchdb/pouchdb/issues/7853#issuecomment-535020600
 
+# additional origins that are allowed to embed the app in an iframe (space-separated),
+# e.g. "https://example.com https://www.example.com" to embed the app in another website.
+# The app's own origin is always allowed; empty (default) means only that origin.
+ENV CSP_EXTRA_FRAME_ANCESTORS=""
+
 # variables are inserted into the nginx config
 # RESOLVER is all IPv4 nameservers from /etc/resolv.conf, joined by spaces, used so nginx can
 # re-resolve the Nominatim upstream at runtime with IPv6 disabled (see default.conf).
 CMD export RESOLVER=$(awk '$$1=="nameserver" && $$2 !~ /:/ {print $$2}' /etc/resolv.conf | xargs) &&\
     if [ -z "$RESOLVER" ]; then export RESOLVER=8.8.8.8; fi &&\
-    envsubst '$$PORT $$COUCHDB_URL $$QUERY_URL $$NOMINATIM_URL $$RESOLVER $$CSP $$CSP_REPORT_URI' < /etc/nginx/templates/default.conf > /etc/nginx/conf.d/default.conf &&\
+    envsubst '$$PORT $$COUCHDB_URL $$QUERY_URL $$NOMINATIM_URL $$RESOLVER $$CSP $$CSP_REPORT_URI $$CSP_EXTRA_FRAME_ANCESTORS' < /etc/nginx/templates/default.conf > /etc/nginx/conf.d/default.conf &&\
     nginx -g 'daemon off;'

--- a/build/default.conf
+++ b/build/default.conf
@@ -14,7 +14,13 @@ server {
     # ?ngsw-bypass prevents angular serviceworker to intercept and break CSP reporting (https://github.com/angular/angular/issues/31477)
 
     # TODO: consider adding `trusted-types angular angular#unsafe-bypass; require-trusted-types-for 'script';` CSP in future
-    add_header X-Frame-Options SAMEORIGIN; # only applies in older browsers, CSP frame-ancestors takes prevalence https://stackoverflow.com/a/40417609/1473411
+    # Who may embed this app in an iframe (supersedes the deprecated X-Frame-Options).
+    # This policy is enforcing, unlike the report-only one above: `frame-ancestors` is
+    # ignored in a report-only policy. As this policy contains no other directive, it
+    # restricts nothing but framing - the policy above stays report-only.
+    # The default is equivalent to the previous `X-Frame-Options SAMEORIGIN`. Set
+    # CSP_EXTRA_FRAME_ANCESTORS to also allow specific other origins to embed the app.
+    add_header Content-Security-Policy "frame-ancestors 'self' ${CSP_EXTRA_FRAME_ANCESTORS}";
     add_header X-Content-Type-Options nosniff;
 
     # Catch requests to the assets folder

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -16,6 +16,16 @@ The whitelisted CSP sources can be overwritten and adapted using a docker enviro
 > CSP is currently running in "report-only" mode for testing.
 > Scripts and connections are not yet blocked by default.
 
+### Embedding the app in an iframe (`frame-ancestors`)
+
+Which sites are allowed to embed the app in an iframe is controlled by a second, _enforcing_ CSP header: `Content-Security-Policy: frame-ancestors 'self' ...`.
+This has to be a separate header because `frame-ancestors` is ignored in a "report-only" policy.
+As that policy contains no other directive, it does not restrict anything but framing and the whitelist above stays report-only.
+
+By default only the app's own origin can embed it.
+To let other sites embed an instance (e.g. a demo system embedded into a project website), set the docker environment variable `CSP_EXTRA_FRAME_ANCESTORS` to a space-separated list of origins, e.g. `https://example.com https://www.example.com`.
+Each origin has to be given with its scheme and exact host - `example.com` and `www.example.com` are different origins - and without any path.
+
 ### Allowing PouchDB to function under CSP
 
 The browser-side database system PouchDB uses map-reduce functions for indexing which are defined as strings.


### PR DESCRIPTION
## Problem

Embedding an instance in an iframe on another site is currently impossible, and it broke silently rather than by decision.

Until #4094 the header was written as `add_header X-Frame-Options: SAMEORIGIN;` — with a colon, so nginx emitted a header whose *field name* was `X-Frame-Options:`. That is not a valid header token, so browsers never matched it as X-Frame-Options and framing worked by accident. #4094 (released in 3.86.0) corrected the syntax, the header became effective for the first time, and existing iframe embeds started failing with:

> Refused to display '…' in a frame because it set 'X-Frame-Options' to 'sameorigin'

`X-Frame-Options` has no way to express "allow this one other origin" — `ALLOW-FROM` never shipped in Chrome/Safari and was removed from Firefox — so this needs CSP's `frame-ancestors`.

## Change

- Replace `X-Frame-Options SAMEORIGIN` with `Content-Security-Policy: frame-ancestors 'self' ${CSP_EXTRA_FRAME_ANCESTORS}`.
- New docker env variable `CSP_EXTRA_FRAME_ANCESTORS`, **empty by default**, so every existing deployment keeps exactly today's behaviour without knowing about it.
- Document it in the security concepts doc.

### Why a separate, enforcing CSP header

`frame-ancestors` is ignored in a `Content-Security-Policy-Report-Only` policy, so it cannot simply be appended to the existing `$CSP` whitelist. Multiple CSP headers are enforced independently, and this one contains no other directive — it therefore restricts nothing except framing, and the existing whitelist stays report-only as before.

### Why `X-Frame-Options` is dropped rather than kept alongside

Where both are present, browsers must ignore XFO in favour of `frame-ancestors`, so keeping it would mean shipping two headers that deliberately contradict each other on any instance that allows embedding. Its only remaining function is for browsers predating CSP2 — which cannot run this app anyway. Happy to keep it as a one-line addition if reviewers prefer the extra header for security scanners.

## Verification

Built the image from this branch and ran it both ways:

**Default (variable unset)** — equivalent to the previous SAMEORIGIN behaviour:
```
Content-Security-Policy: frame-ancestors 'self'
Content-Security-Policy-Report-Only: default-src 'self' … (unchanged)
X-Content-Type-Options: nosniff
```

**With `CSP_EXTRA_FRAME_ANCESTORS="https://example.com https://www.example.com"`:**
```
Content-Security-Policy: frame-ancestors 'self' https://example.com https://www.example.com
```

nginx starts cleanly in both cases (no errors in the container log), and `$CSP` still substitutes correctly after adding the new name to the `envsubst` allowlist.

## Sequencing

Aam-Digital/ndb-setup#115 passes the variable through to the app container. It is inert until an image containing this change is deployed, and no instance becomes embeddable until its `.env` actually sets the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Relates to #4286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable iframe embedding support for trusted origins.
  * Same-origin framing remains enabled by default, with additional origins configurable at deployment time.

* **Documentation**
  * Documented iframe embedding controls, supported origin formats, and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->