### PR TITLE
chore(renovate): monitor GitHub Actions, the CI toolchain and the nginx base image

### DIFF
--- a/.github/workflows/_node-toolchain.yml
+++ b/.github/workflows/_node-toolchain.yml
@@ -19,5 +19,7 @@ jobs:
     steps:
       - id: versions
         run: |
+          # renovate: datasource=node-version depName=node
           echo "node-version=22.19.0" >> "$GITHUB_OUTPUT"
+          # renovate: datasource=npm depName=npm
           echo "npm-version=11.7.0" >> "$GITHUB_OUTPUT"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:alpine AS app
+FROM nginxinc/nginx-unprivileged:1.31.3-alpine AS app
 COPY ./build/default.conf /etc/nginx/templates/default.conf
 COPY ./dist/ /usr/share/nginx/html
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
-    "after 00:00 and before 09:00 on Monday"
+    "* * * * 0"
   ],
   "dependencyDashboard": false,
   "prConcurrentLimit": 5,

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,9 @@
   ],
   "enabledManagers": [
     "npm",
-    "dockerfile"
+    "dockerfile",
+    "github-actions",
+    "custom.regex"
   ],
   "timezone": "Etc/UTC",
   "schedule": [
@@ -39,6 +41,18 @@
   "constraints": {
     "npm": ">=11.0.0"
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Node.js and npm versions pinned for CI in _node-toolchain.yml, annotated with a '# renovate:' comment. No manager reads these, so without this they silently go stale.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/_node-toolchain\\.yml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*echo\\s+\"[a-z-]+=(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": [
@@ -76,6 +90,28 @@
         "patch"
       ],
       "groupName": "docker-base-image",
+      "automerge": false
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "github-actions",
+      "automerge": false
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "ci-toolchain",
       "automerge": false
     }
   ]


### PR DESCRIPTION
Part of a sweep across all six Aam Digital repos to make sure every dependency surface is actually watched by Renovate.

## What was unmonitored

`enabledManagers` is an allowlist, and it only listed `npm` and `dockerfile`. So:

- **GitHub Actions were never checked** and have drifted: `actions/checkout@v4` (v6 out), `docker/build-push-action@v6` (v7), `docker/login-action@v3` (v4), `docker/setup-buildx-action@v3`, `docker/setup-qemu-action@v3`, `actions/cache@v4`, `actions/setup-node@v4`, `github/codeql-action@v3`.
- **The Node and npm versions every CI job runs on** are pinned in a shell `echo` in `_node-toolchain.yml` (Node 22.19.0, npm 11.7.0). No manager can see a shell string, so they just go stale.
- **The nginx base image was not really monitored** either, despite `dockerfile` being enabled: the tag `alpine` carries no version, so there is nothing for Renovate to compare against.

## Changes

1. `github-actions` + `custom.regex` added to `enabledManagers`, with minor/patch grouped into one `github-actions` PR and one `ci-toolchain` PR rather than one PR per dependency.
2. `# renovate:` annotations on the two toolchain pins so the regex manager can track them. Worth knowing when reviewing the resulting PRs: the `ci-toolchain` group edits `_node-toolchain.yml`, i.e. the Node version every CI job runs on — not an app dependency.
3. **Separable — drop this commit if you'd rather not touch the image:** `build/Dockerfile` pinned to `nginxinc/nginx-unprivileged:1.31.3-alpine`. That is the exact image `alpine` resolves to today (identical digest `sha256:f972e5322b97…`), so nothing about the built image changes — it just gives Renovate a version to compare.

## Shared update window

Part of the same sweep: all six repos now use one window — **all day Sunday** (`* * * * 0`). Before this they were split across Monday 00:00–09:00 and Wednesday 00:00–04:00, so update PRs landed on a different day per repo and each window was narrow enough that a hosted-app run could miss it entirely. `vulnerabilityAlerts` still runs at any time, so security fixes are never held to the window.

## Verified

Ran `renovate --platform=local --dry-run` against this branch. Extraction: github-actions 6 files / 41 deps, regex 1 file / 2 deps, dockerfile 1 dep. Among the updates it would open: `renovate/ci-toolchain`, `renovate/node-24.x`, `renovate/npm-12.x`, and the action bumps listed above. Config passes `renovate-config-validator --strict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the production web server image to a specific version for more consistent deployments.
  * Improved automated monitoring and scheduling for toolchain, container, and workflow updates.
  * Updates to non-major components are now grouped separately and require review before adoption.
  * CI workflows now identify Node.js and npm versions more clearly for automated maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->