### PR TITLE
feat(template-export): use the current user's record as {c.user.…} placeholders

### DIFF
--- a/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
@@ -20,17 +20,21 @@ import {
   mockEntityMapperProvider,
   MockEntityMapperService,
 } from "../../../core/entity/entity-mapper/mock-entity-mapper-service";
+import { CurrentUserSubject } from "../../../core/session/current-user-subject";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
 
 describe("TemplateExportApiService", () => {
   let service: TemplateExportApiService;
 
   let entityMapper: MockEntityMapperService;
+  let currentUser: CurrentUserSubject;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         ...mockEntityMapperProvider(),
         EntityRegistry,
+        CurrentUserSubject,
         {
           provide: SyncStateSubject,
           useValue: of(SyncState.COMPLETED),
@@ -45,6 +49,7 @@ describe("TemplateExportApiService", () => {
     entityMapper = TestBed.inject(
       EntityMapperService,
     ) as MockEntityMapperService;
+    currentUser = TestBed.inject(CurrentUserSubject);
   });
 
   it("should be created", () => {
@@ -168,6 +173,52 @@ describe("TemplateExportApiService", () => {
     );
   });
 
+  it("should send the entity of the logged-in user as complement context", async () => {
+    const templateEntity = new TemplateExport("test-template-id");
+    const dataEntity = { name: "abc" };
+    const userEntity = new TestEntity("user-1");
+    userEntity.name = "Test User";
+    currentUser.next(userEntity);
+
+    const mockApiResponse = vi
+      .spyOn(TestBed.inject(HttpClient), "post")
+      .mockReturnValue(of(new HttpResponse({ body: new ArrayBuffer(10) })));
+
+    await lastValueFrom(
+      service.generatePdfFromTemplate(templateEntity, dataEntity),
+    );
+
+    expect(mockApiResponse).toHaveBeenCalledWith(
+      service.API_URL + "/render/" + templateEntity.getId(),
+      {
+        convertTo: "pdf",
+        data: dataEntity,
+        complement: { user: userEntity },
+      },
+      expect.any(Object),
+    );
+  });
+
+  it("should not send a complement if the user account has no linked entity", async () => {
+    const templateEntity = new TemplateExport("test-template-id");
+    const dataEntity = { name: "abc" };
+    currentUser.next(null);
+
+    const mockApiResponse = vi
+      .spyOn(TestBed.inject(HttpClient), "post")
+      .mockReturnValue(of(new HttpResponse({ body: new ArrayBuffer(10) })));
+
+    await lastValueFrom(
+      service.generatePdfFromTemplate(templateEntity, dataEntity),
+    );
+
+    expect(mockApiResponse).toHaveBeenCalledWith(
+      service.API_URL + "/render/" + templateEntity.getId(),
+      { convertTo: "pdf", data: dataEntity },
+      expect.any(Object),
+    );
+  });
+
   it("should call the render-batch endpoint with the array and parse Content-Disposition (zip mode)", async () => {
     const templateEntity = new TemplateExport("test-template-id");
     const dataList = [{ name: "A" }, { name: "B" }, { name: "C" }];
@@ -196,6 +247,32 @@ describe("TemplateExportApiService", () => {
       {
         convertTo: "pdf",
         data: dataList,
+      },
+      expect.any(Object),
+    );
+  });
+
+  it("should send the complement once for the whole batch", async () => {
+    const templateEntity = new TemplateExport("test-template-id");
+    const dataList = [{ name: "A" }, { name: "B" }];
+    const userEntity = new TestEntity("user-1");
+    userEntity.name = "Test User";
+    currentUser.next(userEntity);
+
+    const mockApiResponse = vi
+      .spyOn(TestBed.inject(HttpClient), "post")
+      .mockReturnValue(of(new HttpResponse({ body: new ArrayBuffer(20) })));
+
+    await lastValueFrom(
+      service.generateBatchFromTemplate(templateEntity, dataList),
+    );
+
+    expect(mockApiResponse).toHaveBeenCalledWith(
+      service.API_URL + "/render-batch/" + templateEntity.getId() + "?mode=zip",
+      {
+        convertTo: "pdf",
+        data: dataList,
+        complement: { user: userEntity },
       },
       expect.any(Object),
     );

--- a/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
@@ -20,8 +20,8 @@ import {
   mockEntityMapperProvider,
   MockEntityMapperService,
 } from "../../../core/entity/entity-mapper/mock-entity-mapper-service";
-import { CurrentUserSubject } from "../../../core/session/current-user-subject";
-import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { CurrentUserSubject } from "#src/app/core/session/current-user-subject";
+import { TestEntity } from "#src/app/utils/test-utils/TestEntity";
 
 describe("TemplateExportApiService", () => {
   let service: TemplateExportApiService;

--- a/src/app/features/template-export/template-export-api/template-export-api.service.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.ts
@@ -10,6 +10,10 @@ import { switchMap } from "rxjs/operators";
 import { TemplateExport } from "../template-export.entity";
 import { Logging } from "../../../core/logging/logging.service";
 import { environment } from "../../../../environments/environment";
+import {
+  TemplateExportComplement,
+  TemplateExportContextService,
+} from "../template-export-context/template-export-context.service";
 
 /**
  * Format of API response body upon uploading a new template file.
@@ -32,6 +36,11 @@ interface TemplateRenderRequestDto {
    * The data used to fill placeholders in the template.
    */
   data: Object;
+
+  /**
+   * Additional context data available in the template under the `{c.…}` prefix.
+   */
+  complement?: TemplateExportComplement;
 }
 
 /**
@@ -41,6 +50,12 @@ interface TemplateRenderRequestDto {
 interface TemplateRenderBatchRequestDto {
   convertTo: string;
   data: Object[];
+
+  /**
+   * Additional context data, shared by all records of the batch,
+   * available in the template under the `{c.…}` prefix.
+   */
+  complement?: TemplateExportComplement;
 }
 
 export interface TemplateExportResult {
@@ -61,6 +76,7 @@ export interface TemplateExportBatchResult {
 })
 export class TemplateExportApiService extends FileService {
   private navigator = inject<Navigator>(NAVIGATOR_TOKEN);
+  private readonly exportContext = inject(TemplateExportContextService);
 
   readonly API_URL = environment.API_PROXY_PREFIX + "/v1/export";
 
@@ -133,12 +149,15 @@ export class TemplateExportApiService extends FileService {
     template: TemplateExport,
     data: Object,
   ): Observable<TemplateExportResult> {
+    const complement = this.exportContext.getComplement();
+
     return this.httpClient
       .post(
         this.API_URL + "/render/" + template.getId(),
         {
           convertTo: "pdf",
           data: data,
+          ...(complement ? { complement } : {}),
         } as TemplateRenderRequestDto,
         { observe: "response", responseType: "arraybuffer" },
       )
@@ -181,12 +200,15 @@ export class TemplateExportApiService extends FileService {
     mode: "zip" | "combined" = "zip",
   ): Observable<TemplateExportBatchResult> {
     const fallbackExtension = mode === "combined" ? ".pdf" : ".zip";
+    const complement = this.exportContext.getComplement();
+
     return this.httpClient
       .post(
         this.API_URL + "/render-batch/" + template.getId() + "?mode=" + mode,
         {
           convertTo: "pdf",
           data: dataList,
+          ...(complement ? { complement } : {}),
         } as TemplateRenderBatchRequestDto,
         { observe: "response", responseType: "arraybuffer" },
       )

--- a/src/app/features/template-export/template-export-context/template-export-context.service.spec.ts
+++ b/src/app/features/template-export/template-export-context/template-export-context.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from "@angular/core/testing";
+
+import { TemplateExportContextService } from "./template-export-context.service";
+import { CurrentUserSubject } from "../../../core/session/current-user-subject";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
+
+describe("TemplateExportContextService", () => {
+  let service: TemplateExportContextService;
+  let currentUser: CurrentUserSubject;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CurrentUserSubject],
+    });
+    service = TestBed.inject(TemplateExportContextService);
+    currentUser = TestBed.inject(CurrentUserSubject);
+  });
+
+  it("should provide the entity of the logged-in user as context", () => {
+    const userEntity = new TestEntity("user-1");
+    userEntity.name = "Test User";
+    currentUser.next(userEntity);
+
+    expect(service.getComplement()).toEqual({ user: userEntity });
+  });
+
+  it("should not provide any context if the user account has no linked entity", () => {
+    currentUser.next(null);
+
+    expect(service.getComplement()).toBeUndefined();
+  });
+
+  it("should not provide any context if no user is logged in", () => {
+    // CurrentUserSubject holds `undefined` until a session is established
+    expect(service.getComplement()).toBeUndefined();
+  });
+});

--- a/src/app/features/template-export/template-export-context/template-export-context.service.spec.ts
+++ b/src/app/features/template-export/template-export-context/template-export-context.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from "@angular/core/testing";
 
 import { TemplateExportContextService } from "./template-export-context.service";
-import { CurrentUserSubject } from "../../../core/session/current-user-subject";
-import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { CurrentUserSubject } from "#src/app/core/session/current-user-subject";
+import { TestEntity } from "#src/app/utils/test-utils/TestEntity";
 
 describe("TemplateExportContextService", () => {
   let service: TemplateExportContextService;

--- a/src/app/features/template-export/template-export-context/template-export-context.service.ts
+++ b/src/app/features/template-export/template-export-context/template-export-context.service.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable } from "@angular/core";
+import { Entity } from "../../../core/entity/model/entity";
+import { CurrentUserSubject } from "../../../core/session/current-user-subject";
+
+/**
+ * Additional context data (beyond the record itself) available in template placeholders.
+ *
+ * This is sent to the API as carbone's `complement` and can be used in templates
+ * with the `{c.…}` prefix (e.g. `{c.user.name}`),
+ * clearly separated from the record data available under `{d.…}`.
+ */
+export interface TemplateExportComplement {
+  /**
+   * The entity linked to the currently logged-in user (if any).
+   */
+  user?: Entity;
+}
+
+/**
+ * Assemble the context data that is available in template placeholders
+ * in addition to the record(s) a file is generated for.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class TemplateExportContextService {
+  private readonly currentUser = inject(CurrentUserSubject);
+
+  /**
+   * Build the context object to be sent alongside the record data.
+   * @return the context or `undefined` if no context data is available at all
+   */
+  getComplement(): TemplateExportComplement | undefined {
+    // CurrentUserSubject is `undefined` if not logged in and `null` if no entity is linked to the account
+    const user = this.currentUser.value;
+
+    return user ? { user } : undefined;
+  }
+}

--- a/src/app/features/template-export/template-export-context/template-export-context.service.ts
+++ b/src/app/features/template-export/template-export-context/template-export-context.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from "@angular/core";
-import { Entity } from "../../../core/entity/model/entity";
-import { CurrentUserSubject } from "../../../core/session/current-user-subject";
+import { Entity } from "#src/app/core/entity/model/entity";
+import { CurrentUserSubject } from "#src/app/core/session/current-user-subject";
 
 /**
  * Additional context data (beyond the record itself) available in template placeholders.

--- a/src/app/features/template-export/template-export-file-datatype/edit-template-export-file.component.spec.ts
+++ b/src/app/features/template-export/template-export-file-datatype/edit-template-export-file.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormFieldConfig } from "#src/app/core/common-components/entity-form/FormConfig";
 import { EntityRegistry } from "#src/app/core/entity/database-entity.decorator";
 import { setupCustomFormControlEditComponent } from "#src/app/core/entity/entity-field-edit/dynamic-edit/edit-component-test-utils";
+import { CurrentUserSubject } from "#src/app/core/session/current-user-subject";
 import { SyncStateSubject } from "#src/app/core/session/session-type";
 import { FontAwesomeTestingModule } from "@fortawesome/angular-fontawesome/testing";
 import { FileService } from "app/features/file/file.service";
@@ -47,6 +48,8 @@ describe("EditTemplateExportFileComponent", () => {
         { provide: TemplateExportService, useValue: mockTemplateExportService },
         EntityRegistry,
         SyncStateSubject,
+        // the component provides the real TemplateExportApiService as FileService (see its `providers`)
+        CurrentUserSubject,
       ],
     }).compileComponents();
 

--- a/src/app/features/template-export/template-export.entity.ts
+++ b/src/app/features/template-export/template-export.entity.ts
@@ -85,7 +85,7 @@ export class TemplateExport extends Entity {
   @DatabaseField({
     label: $localize`:TemplateExport:File name pattern for generated file`,
     labelShort: $localize`:TemplateExport:File name pattern`,
-    description: $localize`:TemplateExport:The filename for the resulting file when using this template. You can use the same placeholders here as in the template file itself (e.g. "my-report_{d.name}.pdf").`,
+    description: $localize`:TemplateExport:The filename for the resulting file when using this template. You can use the same placeholders here as in the template file itself (e.g. "my-report_{d.name}_{c.user.name}.pdf").`,
     validators: { required: true },
   })
   targetFileName: string;

--- a/src/app/features/template-export/template-export.module.ts
+++ b/src/app/features/template-export/template-export.module.ts
@@ -128,7 +128,7 @@ See the documentation of the [carbone system](https://carbone.io/documentation.h
 The placeholder keys must match the field "Field ID" of the record data structure in Aam Digital.
 You can find this in the Admin UI form builder (Edit Data Structure -> Details View) and edit a specific field to view its details.
 
-In addition to the selected record, you can use fields of the currently logged-in user's own record with the "{c.user.}" prefix (e.g. {c.user.name}), both in the template file and in the file name pattern.
+In addition to the selected record, you can also use fields of the currently logged-in user's own record by prefixing them with "c.user." (e.g. {c.user.name}). This works both in the template file and in the file name pattern.
 
 Template files can be in most office document formats (odt, docx, ods, xlsx, odp, pptx) or PDF.`,
                       },

--- a/src/app/features/template-export/template-export.module.ts
+++ b/src/app/features/template-export/template-export.module.ts
@@ -128,6 +128,8 @@ See the documentation of the [carbone system](https://carbone.io/documentation.h
 The placeholder keys must match the field "Field ID" of the record data structure in Aam Digital.
 You can find this in the Admin UI form builder (Edit Data Structure -> Details View) and edit a specific field to view its details.
 
+In addition to the selected record, you can use fields of the currently logged-in user's own record with the "{c.user.}" prefix (e.g. {c.user.name}), both in the template file and in the file name pattern.
+
 Template files can be in most office document formats (odt, docx, ods, xlsx, odp, pptx) or PDF.`,
                       },
                       "templateFile",


### PR DESCRIPTION
- closes #4233

Templates for the "Generate File" feature so far could only use fields of the record the action is performed on (`{d.…}`). This makes the entity linked to the **logged-in user** available as well, so a generated document can pre-fill the name of the person generating and signing it.

Placeholder syntax: `{c.user.name}` — usable both **inside the template file** and in the **file name pattern**.

### Approach

Carbone's own `complement` option is used to pass context data alongside the record. This keeps it cleanly separated from `{d.…}` and namespaced, so further context parts (e.g. `{c.now}`) can be added later without breaking existing templates:

```json
{ "convertTo": "pdf", "data": <entity>, "complement": { "user": <user entity> } }
```

A `{d._user.…}` prefix (as sketched in the issue) is not possible with carbone, since `d` is the record itself.

- new `TemplateExportContextService` assembles the complement from `CurrentUserSubject`
- `TemplateExportApiService` sends it on both the single-render and the batch path
- if the account has **no linked entity**, the `complement` key is omitted entirely, so the request is byte-identical to before

Frontend-only — no backend change was required, as the export controller forwards the request body to carbone verbatim. That implicit contract is now documented and test-covered in Aam-Digital/aam-services#184.

### Notes for review

- In bulk mode the complement is sent **once** and shared by all records.
- A missing/empty complement renders as an empty value without error (verified against carbone 4.23.4 and 5.9.0), so no dummy object is needed.
- If the user account is not linked to an entity record, the placeholders simply stay empty — there is deliberately no fallback to the Keycloak account name/email.
- The `complement` sends the whole user entity, serialized the same way the record `data` already is. Worth a thought if user records hold sensitive fields.
- Two `$localize` source strings changed, so their existing translations will need re-translation in POEditor.

### Testing

Unit tests cover both request paths (with and without a linked user entity) and the batch case. **Not yet manually tested end-to-end against a real carbone instance** — the placeholder resolution itself was verified separately against local carbone 4.23.4 / 5.9.0.

## PR Checklist

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template-generated PDFs and batch exports can now include information from the logged-in user’s record.
  * File names and templates support user-field placeholders using the `c.user.` prefix.
  * Context data is omitted when no linked user record is available.

* **Documentation**
  * Updated template export guidance with examples of user-field placeholders.

* **Tests**
  * Added coverage for single exports, batch exports, and cases without user context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->