### PR TITLE
docs(security): high-level security concept, CSP details to the build docs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ ENV QUERY_URL="http://localhost:3000"
 ENV NOMINATIM_URL="https://nominatim.openstreetmap.org"
 
 # content security policy headers
-# (also see Developer Documentation: https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/security.html)
+# (see ./README.md in this folder for what these do and how to change them)
 ENV CSP_REPORT_URI="https://o167951.ingest.sentry.io/api/1242399/security/"
 # overwrite the Content-Security-Policy rules (report-uri is added automatically)
 # default includes all required whitelists for production server

--- a/build/README.md
+++ b/build/README.md
@@ -27,3 +27,49 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 1. Commits on the `master` branch are analyzed and a pre-release version is automatically tagged.
 2. To create a stable release, a core team member manually triggers the release GitHub Action (`create-release.yml` workflow dispatch). This creates a regular (non-prerelease) version from `master`.
+
+## Content Security Policy (CSP)
+
+The nginx server built here sets the security headers of the served app.
+Two CSP headers are set in [`default.conf`](./default.conf), with their values coming from docker environment variables defined in the [`Dockerfile`](./Dockerfile).
+
+For the wider picture of what these headers do and do not protect against, see the [Security concept](https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/security.html).
+
+### Whitelisting sources (`CSP`)
+
+Which sources the app may load code, styles and data from is whitelisted through the `CSP` environment variable.
+The default whitelist covers everything a production server needs and is defined in the [`Dockerfile`](./Dockerfile).
+
+> This policy is currently sent as `Content-Security-Policy-Report-Only` for testing.
+> Violations are reported to `CSP_REPORT_URI` but scripts and connections are not yet blocked.
+
+To disable any CSP blocking entirely, set
+`CSP="default-src *  data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval'"`.
+
+#### Allowing PouchDB to function under CSP
+
+The browser-side database system PouchDB uses map-reduce functions for indexing which are defined as strings.
+It therefore requires `'unsafe-eval'` in the CSP.
+
+#### Whitelisting the index.html
+
+To whitelist a specific script section (currently only in the index.html) a [CSP hash](https://content-security-policy.com/hash/) can be used.
+Updating the hash should be necessary only rarely, when that script section changes.
+
+The easiest and most reliable way to get the correct hash is to deploy a production build image and check the browser console.
+It states something like `"Refused to execute inline script because it violates the following Content Security Policy directive: "...". Either the 'unsafe-inline' keyword, a hash ('sha256-<RELEVANT HASH>')" or a nonce is required."` from where you can copy the given hash and include/update it in the CSP headers.
+Generating the hash by pasting the script into an online generator does not seem to work, probably because code is minified during the build process.
+
+### Embedding the app in an iframe (`CSP_EXTRA_FRAME_ANCESTORS`)
+
+Which sites are allowed to embed the app in an iframe is controlled by a second, _enforcing_ CSP header: `Content-Security-Policy: frame-ancestors 'self' ...`.
+This has to be a separate header because `frame-ancestors` is ignored in a "report-only" policy.
+As that policy contains no other directive, it does not restrict anything but framing and the whitelist above stays report-only.
+
+By default only the app's own origin can embed it.
+To let other sites embed an instance (e.g. a demo system embedded into a project website), set the docker environment variable `CSP_EXTRA_FRAME_ANCESTORS` to a space-separated list of origins, e.g. `https://example.com https://www.example.com`.
+Each origin has to be given with its scheme and exact host - `example.com` and `www.example.com` are different origins - and without any path.
+
+### Other security headers
+
+`X-Content-Type-Options: nosniff` is set unconditionally and is not configurable.

--- a/build/README.md
+++ b/build/README.md
@@ -21,6 +21,23 @@ docker run -p=80:80 --name aam-digital aam/digital:latest
 docker stop aam-digital
 ```
 
+## Configuration
+
+The image is configured through environment variables, declared with their
+defaults as `ENV` values in [`Dockerfile`](./Dockerfile) and substituted into
+the nginx config at container start (see [`default.conf`](./default.conf)).
+Override any of them (e.g. via `docker run -e`, a `docker-compose.yml`
+`environment:` block, or a Helm chart's pod spec) to change that behavior;
+anything left unset keeps the default below.
+
+| Variable                                             | Default                               | Purpose                                                                                                    |
+| ---------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `PORT`                                               | `8080`                                | Port nginx listens on inside the container.                                                                |
+| `COUCHDB_URL`                                        | `http://localhost`                    | Proxy target for the app's `/db` path.                                                                     |
+| `QUERY_URL`                                          | `http://localhost:3000`               | Proxy target for the app's `/api` path (and the deprecated `/query` alias).                                |
+| `NOMINATIM_URL`                                      | `https://nominatim.openstreetmap.org` | Proxy target for the app's `/nominatim` path, used for geocoding.                                          |
+| `CSP`, `CSP_REPORT_URI`, `CSP_EXTRA_FRAME_ANCESTORS` | see below                             | Content Security Policy headers — see [Content Security Policy (CSP)](#content-security-policy-csp) below. |
+
 ## How does the release process work?
 
 We use [semantic-release](https://github.com/semantic-release/semantic-release) to automatically create new versions.
@@ -41,7 +58,7 @@ Which sources the app may load code, styles and data from is whitelisted through
 The default whitelist covers everything a production server needs and is defined in the [`Dockerfile`](./Dockerfile).
 
 > This policy is currently sent as `Content-Security-Policy-Report-Only` for testing.
-> Violations are reported to `CSP_REPORT_URI` but scripts and connections are not yet blocked.
+> Violations are reported to `CSP_REPORT_URI` (defaulting to aam-digital's Sentry security endpoint) but scripts and connections are not yet blocked.
 
 To disable any CSP blocking entirely, set
 `CSP="default-src *  data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval'"`.

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -30,7 +30,7 @@ The directives, their defaults and how to change them are documented with the im
 Users authenticate against a **Keycloak** server (OpenID Connect). Aam Digital never sees or stores a password: the app receives a token and passes it on to the database.
 Password policy, multi-factor authentication, session lifetime, account lockout and email verification are therefore Keycloak configuration, not application code.
 
-Each system has its own Keycloak realm, and **membership of that realm is what grants access to that system's data**. Removing a person's access means disabling or removing their account in Keycloak — changing their roles inside the application is not sufficient on its own, for the reason described next.
+Each system has its own Keycloak realm, and **membership of that realm is what grants access to that system's data**. In a database-only deployment, removing a person's access means disabling or removing their account in Keycloak — changing their roles inside the application is not sufficient on its own; see "Database-only, and what it does not give you" below.
 
 Once a user has logged in online at least once, the app offers them an **offline login** on the same device. This is a profile selection, not an authentication step: no credential is checked, because none is stored and the authentication server cannot be reached. It opens the local copy of the data that is already on that device, and grants nothing beyond it — but it does mean that whoever holds the device can open that copy. See "The copy of data on each user's device" below.
 
@@ -52,24 +52,24 @@ Where those rules are actually _enforced_ depends on how the system is deployed,
 
 #### Database-only, and what it does not give you
 
-CouchDB is exposed directly and validates the user's token itself. Access is granted to a **single role that every user of the system holds**, so the boundary the server enforces is all-or-nothing: a user is either a member of this system's database, or not.
+This light-weight deployment does explicitly not support user roles and individual permissions.
+All users with a valid login have full read/write access to all data.
 
-The permission rules still run, but only in the browser. There they decide what the interface offers and block writes before they are sent — which is genuinely useful, because it keeps users out of areas that do not concern them and prevents accidental edits. It is a usability and safety layer. **It is not an access boundary**, and nothing about it survives a user who talks to the database API directly instead of using the app. Concretely, in this mode any user who can log in can:
+Access to the database without a valid user account is not possible.
+This also means _**Public Forms**_ cannot work for external data collection.
 
-- **read the entire database**, including entity types and records their role hides in the interface — and, since it is one database, that includes the configuration and the permission rules themselves;
-- **write or delete any document**, including those same permission rules, because the rule check that would have stopped it lives in the browser they are bypassing;
-- **keep reading after their roles change**, because a narrowed role restricts the interface but not what their token can fetch. Withdrawing access means disabling the account in Keycloak.
+> Adding a `Config:Permissions` doc (in preparation of introducing user roles) is technically still possible.
+> Those permissions are partly enforced by the local device's user interface
+> but this **does not** enforce actual data protection on the server.
+> DO NOT USE this as a security functionality.
 
-Two further consequences follow from the same design:
-
-- **There is no audit log.** Nothing records who changed what and when.
-- **Public forms cannot work.** They rely on the `_public` rules being applied to visitors without an account, and the database accepts only tokens carrying the role above — so an anonymous request never reaches it.
+Because CouchDB checks only realm membership and nothing about a user's role, narrowing someone's role never restricts what their existing token can fetch — withdrawing access means disabling their account in Keycloak, not just changing their role.
 
 This mode is therefore appropriate when everyone with an account in the system is trusted with all of its data — a small team working on one caseload — and not when the roles are meant to keep colleagues apart.
 
 #### With the permission backend
 
-The same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored, with CouchDB itself no longer reachable from outside. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface. It is also the only one that can record who changed what.
+The same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored, with CouchDB itself no longer reachable from outside. Unlike database-only mode, a narrowed role then restricts what the user can actually fetch, not only what the interface offers. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface. It is also the only one that can record who changed what.
 
 **So if different users of one system must not see each other's data, the permission backend is required.**
 Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#docker-compose-profiles).
@@ -79,7 +79,7 @@ Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com
 To work offline, the app stores a copy of the records a user may access in the browser's storage on that user's device. This is what makes Aam Digital usable without connectivity, and it has consequences worth stating plainly:
 
 - The copy is stored **unencrypted**. On a device without full-disk encryption, whoever holds the device can read it.
-- Its extent is whatever the user is allowed to sync — which, in database-only mode, is the whole database.
+- Its extent is whatever the user is allowed to sync.
 - Revoking permissions server-side does not reach a device that never connects again. Local data is cleared when the server reports lost permissions during a sync, and that requires the device to come online.
 - The offline login described above opens that copy without checking any credential, so the device itself is the only thing standing between a stranger and the data.
 

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -63,7 +63,7 @@ The permission rules still run, but only in the browser. There they decide what 
 Two further consequences follow from the same design:
 
 - **There is no audit log.** Nothing records who changed what and when.
-- **Rules for anonymous visitors (`_public`) have no effect**, since the database only accepts tokens carrying the role above.
+- **Public forms cannot work.** They rely on the `_public` rules being applied to visitors without an account, and the database accepts only tokens carrying the role above — so an anonymous request never reaches it.
 
 This mode is therefore appropriate when everyone with an account in the system is trusted with all of its data — a small team working on one caseload — and not when the roles are meant to keep colleagues apart.
 

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -6,7 +6,7 @@ what the application does, what it leaves to the deployment, and what it does no
 This is about **one deployed system** — the app, its database and the accounts that reach it.
 
 > **Server operation and infrastructure are out of scope here.**
-> See [what this document does not cover](#what-this-document-does-not-cover) at the end.
+> See the last section, "What this document does not cover".
 
 ## The application in the browser
 
@@ -32,7 +32,7 @@ Password policy, multi-factor authentication, session lifetime, account lockout 
 
 Each system has its own Keycloak realm, and **membership of that realm is what grants access to that system's data**. Removing a person's access means disabling or removing their account in Keycloak — changing their roles inside the application is not sufficient on its own, for the reason described next.
 
-A local login lets an already-synced user open the app without connectivity. It works against credentials cached from a previous online login and grants no access the user did not already have.
+Once a user has logged in online at least once, the app offers them an **offline login** on the same device. This is a profile selection, not an authentication step: no credential is checked, because none is stored and the authentication server cannot be reached. It opens the local copy of the data that is already on that device, and grants nothing beyond it — but it does mean that whoever holds the device can open that copy. See "The copy of data on each user's device" below.
 
 ## Roles and permissions
 
@@ -48,7 +48,7 @@ Where those rules are actually _enforced_ depends on how the system is deployed,
 | Who checks a token | CouchDB, against the realm's public key | the backend, against the realm's public key                                                               |
 | Read access        | the whole database of that system       | filtered per user, rule by rule                                                                           |
 | Write access       | any document                            | validated against the same rules                                                                          |
-| Audit log          | none                                    | records write access                                                                                      |
+| Audit log          | none                                    | optional (`AUDIT_ENABLED`): every write recorded with user and time                                       |
 
 **Database-only** is the simpler setup. CouchDB validates the user's token itself and grants access to a single role that every user of the system holds. That is an all-or-nothing boundary: a user is either a member of this database or not.
 The permission rules still run — but only in the browser, where they decide what the interface offers and block writes before they are sent. **They are not an access boundary.** Anyone who can log in can read the entire database by talking to the database API directly, whatever their role says.
@@ -56,7 +56,7 @@ The permission rules still run — but only in the browser, where they decide wh
 **With the permission backend**, the same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface.
 
 So if different users of one system must not see each other's data, the permission backend is required.
-Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#deployment-profiles).
+Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#docker-compose-profiles).
 
 ## The copy of data on each user's device
 
@@ -65,6 +65,7 @@ To work offline, the app stores a copy of the records a user may access in the b
 - The copy is stored **unencrypted**. On a device without full-disk encryption, whoever holds the device can read it.
 - Its extent is whatever the user is allowed to sync — which, in database-only mode, is the whole database.
 - Revoking permissions server-side does not reach a device that never connects again. Local data is cleared when the server reports lost permissions during a sync, and that requires the device to come online.
+- The offline login described above opens that copy without checking any credential, so the device itself is the only thing standing between a stranger and the data.
 
 Two settings bear on this:
 

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -50,12 +50,28 @@ Where those rules are actually _enforced_ depends on how the system is deployed,
 | Write access       | any document                            | validated against the same rules                                                                          |
 | Audit log          | none                                    | optional (`AUDIT_ENABLED`): every write recorded with user and time                                       |
 
-**Database-only** is the simpler setup. CouchDB validates the user's token itself and grants access to a single role that every user of the system holds. That is an all-or-nothing boundary: a user is either a member of this database or not.
-The permission rules still run — but only in the browser, where they decide what the interface offers and block writes before they are sent. **They are not an access boundary.** Anyone who can log in can read the entire database by talking to the database API directly, whatever their role says.
+#### Database-only, and what it does not give you
 
-**With the permission backend**, the same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface.
+CouchDB is exposed directly and validates the user's token itself. Access is granted to a **single role that every user of the system holds**, so the boundary the server enforces is all-or-nothing: a user is either a member of this system's database, or not.
 
-So if different users of one system must not see each other's data, the permission backend is required.
+The permission rules still run, but only in the browser. There they decide what the interface offers and block writes before they are sent — which is genuinely useful, because it keeps users out of areas that do not concern them and prevents accidental edits. It is a usability and safety layer. **It is not an access boundary**, and nothing about it survives a user who talks to the database API directly instead of using the app. Concretely, in this mode any user who can log in can:
+
+- **read the entire database**, including entity types and records their role hides in the interface — and, since it is one database, that includes the configuration and the permission rules themselves;
+- **write or delete any document**, including those same permission rules, because the rule check that would have stopped it lives in the browser they are bypassing;
+- **keep reading after their roles change**, because a narrowed role restricts the interface but not what their token can fetch. Withdrawing access means disabling the account in Keycloak.
+
+Two further consequences follow from the same design:
+
+- **There is no audit log.** Nothing records who changed what and when.
+- **Rules for anonymous visitors (`_public`) have no effect**, since the database only accepts tokens carrying the role above.
+
+This mode is therefore appropriate when everyone with an account in the system is trusted with all of its data — a small team working on one caseload — and not when the roles are meant to keep colleagues apart.
+
+#### With the permission backend
+
+The same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored, with CouchDB itself no longer reachable from outside. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface. It is also the only one that can record who changed what.
+
+**So if different users of one system must not see each other's data, the permission backend is required.**
 Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#docker-compose-profiles).
 
 ## The copy of data on each user's device

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -94,6 +94,14 @@ Because the device is beyond anything the application can enforce, client organi
 
 All traffic between browser, application server, database and Keycloak is expected to be TLS-encrypted. Certificates and TLS termination are part of the deployment, not of this code base.
 
+> **Side note — anonymization and deletion.** How long data is kept is a
+> security question as much as a policy one: records that are no longer needed
+> are still exposed by everything above. Aam Digital can archive, anonymize or
+> delete an entity, with anonymization removing the personal fields while
+> keeping the record countable for statistics. What each action does, and how a
+> field is configured to survive anonymization, is documented under
+> [Archiving, Anonymizing and Deleting Entities](https://github.com/Aam-Digital/ndb-core/blob/master/src/app/core/entity/entity-actions/README.md).
+
 ## Keeping the code base secure
 
 - Dependencies are updated continuously through automated pull requests and scanned for known vulnerabilities on every push to `master` and weekly (Snyk, reported into GitHub code scanning).

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -1,41 +1,99 @@
 # Security
 
-We have made both technical and design choices to develop a secure platform.
-The Angular framework itself has some in-built protection against common security issues like cross-site scripting attacks (see [Angular > Security](https://angular.io/guide/security)).
-Beyond this, the following measures are implemented:
+A conceptual overview of how a single Aam Digital system protects the data it holds:
+what the application does, what it leaves to the deployment, and what it does not do at all.
 
-- If deployed including our ["replication-backend"](https://github.com/Aam-Digital/replication-backend), that server-side API also ensures authenticated users can only access and sync data their account has permissions for.
-- Password policy enforces users to set a strong password including special characters (either via Keycloak or the platforms user profile form)
-- Content Security Policy (CSP) headers restrict connections to and execution of code from sources that are not whitelisted.
+This is about **one deployed system** — the app, its database and the accounts that reach it.
 
-## Content Security Policy (CSP)
+> **Server operation and infrastructure are out of scope here.**
+> See [what this document does not cover](#what-this-document-does-not-cover) at the end.
 
-CSP headers are set in the nginx server being built from the code base to serve the Angular app.
-The whitelisted CSP sources can be overwritten and adapted using a docker environment variable `CSP` (the default whitelist is defined in the [Dockerfile](https://github.com/Aam-Digital/ndb-core/blob/master/build/Dockerfile)).
+## The application in the browser
 
-> CSP is currently running in "report-only" mode for testing.
-> Scripts and connections are not yet blocked by default.
+Aam Digital is an Angular single-page application. Everything a user sees is rendered in the browser from data fetched from the database.
 
-### Embedding the app in an iframe (`frame-ancestors`)
+**Cross-site scripting.** Angular treats all values as untrusted by default and escapes or sanitizes them for the context they are rendered into, which covers the ordinary case of a record field containing markup (see [Angular > Security](https://angular.dev/best-practices/security)).
+Sanitization is only bypassed deliberately and under code review, never for values that originate from user-entered record content.
 
-Which sites are allowed to embed the app in an iframe is controlled by a second, _enforcing_ CSP header: `Content-Security-Policy: frame-ancestors 'self' ...`.
-This has to be a separate header because `frame-ancestors` is ignored in a "report-only" policy.
-As that policy contains no other directive, it does not restrict anything but framing and the whitelist above stays report-only.
+**Content Security Policy and framing.** The nginx server that serves the built app sets two policy headers: a whitelist of the sources the app may load code and data from, and an enforcing policy for which sites may embed the app in an iframe.
+Both are configurable per deployment.
 
-By default only the app's own origin can embed it.
-To let other sites embed an instance (e.g. a demo system embedded into a project website), set the docker environment variable `CSP_EXTRA_FRAME_ANCESTORS` to a space-separated list of origins, e.g. `https://example.com https://www.example.com`.
-Each origin has to be given with its scheme and exact host - `example.com` and `www.example.com` are different origins - and without any path.
+> The whitelist policy is currently served in **report-only** mode: violations are reported, not blocked.
+> Only the framing policy is enforced.
 
-### Allowing PouchDB to function under CSP
+The directives, their defaults and how to change them are documented with the image that sets them, under "Content Security Policy" in [Build and Deployment](../how-to-guides/build-and-deployment.html).
 
-The browser-side database system PouchDB uses map-reduce functions for indexing which are defined as strings.
-It is therefore requiring `'unsafe-eval'` in the CSP.
+**Offline shell.** The app is installable and keeps working offline, which means an outdated version can keep running on a device until it next connects. Fixes reach users on their next online session, not immediately.
 
-### Whitelisting the index.html
+## Authentication
 
-To whitelist a specific script section (currently only in the index.html) a [CSP hash](https://content-security-policy.com/hash/) can be used.
-Updating the hash should be necessary only rarely, when that script section changes.
+Users authenticate against a **Keycloak** server (OpenID Connect). Aam Digital never sees or stores a password: the app receives a token and passes it on to the database.
+Password policy, multi-factor authentication, session lifetime, account lockout and email verification are therefore Keycloak configuration, not application code.
 
-The easiest and most reliable way to get the correct hash is to deploy a production build image and check the browser console.
-It states something like `"Refused to execute inline script because it violates the following Content Security Policy directive: "...". Either the 'unsafe-inline' keyword, a hash ('sha256-<RELEVANT HASH>')" or a nonce is required."` from where you can copy the given hash and include/update it in the CSP headers.
-Generating the hash by pasting the script into an online generator does not seem to work, probably because code is minified during the build process.
+Each system has its own Keycloak realm, and **membership of that realm is what grants access to that system's data**. Removing a person's access means disabling or removing their account in Keycloak — changing their roles inside the application is not sufficient on its own, for the reason described next.
+
+A local login lets an already-synced user open the app without connectivity. It works against credentials cached from a previous online login and grants no access the user did not already have.
+
+## Roles and permissions
+
+Permissions are role-based rules in a single configuration document that an administrator edits. The rule format, the available conditions and how rules combine are documented under [User Roles and Permissions](./user-roles-and-permissions.html).
+
+Where those rules are actually _enforced_ depends on how the system is deployed, and that difference is a security property rather than a detail.
+
+### Two deployment modes
+
+|                    | **Database-only**                       | **With permission backend**                                                                               |
+| ------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| What is exposed    | CouchDB directly                        | [replication-backend](https://github.com/Aam-Digital/replication-backend) in front of an internal CouchDB |
+| Who checks a token | CouchDB, against the realm's public key | the backend, against the realm's public key                                                               |
+| Read access        | the whole database of that system       | filtered per user, rule by rule                                                                           |
+| Write access       | any document                            | validated against the same rules                                                                          |
+| Audit log          | none                                    | records write access                                                                                      |
+
+**Database-only** is the simpler setup. CouchDB validates the user's token itself and grants access to a single role that every user of the system holds. That is an all-or-nothing boundary: a user is either a member of this database or not.
+The permission rules still run — but only in the browser, where they decide what the interface offers and block writes before they are sent. **They are not an access boundary.** Anyone who can log in can read the entire database by talking to the database API directly, whatever their role says.
+
+**With the permission backend**, the same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface.
+
+So if different users of one system must not see each other's data, the permission backend is required.
+Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#deployment-profiles).
+
+## The copy of data on each user's device
+
+To work offline, the app stores a copy of the records a user may access in the browser's storage on that user's device. This is what makes Aam Digital usable without connectivity, and it has consequences worth stating plainly:
+
+- The copy is stored **unencrypted**. On a device without full-disk encryption, whoever holds the device can read it.
+- Its extent is whatever the user is allowed to sync — which, in database-only mode, is the whole database.
+- Revoking permissions server-side does not reach a device that never connects again. Local data is cleared when the server reports lost permissions during a sync, and that requires the device to come online.
+
+Two settings bear on this:
+
+- `session_type: online` runs without any local database at all. Data is read directly from the server and nothing persists on the device — at the cost of offline capability.
+- `session_type_choice` decides whether users may choose between the two modes on the login page, or whether the configured mode is enforced.
+
+Because the device is beyond anything the application can enforce, client organisations should be advised to keep devices locked and encrypted, to avoid sharing browser profiles between staff, and to report lost devices and staff departures promptly so that accounts can be disabled.
+
+## Data in transit
+
+All traffic between browser, application server, database and Keycloak is expected to be TLS-encrypted. Certificates and TLS termination are part of the deployment, not of this code base.
+
+## Keeping the code base secure
+
+- Dependencies are updated continuously through automated pull requests and scanned for known vulnerabilities on every push to `master` and weekly (Snyk, reported into GitHub code scanning).
+- Changes are reviewed before merging; see [Review a Pull Request](../how-to-guides/review-a-pull-request.html).
+- Aam Digital is open source, so the code implementing everything described here can be inspected rather than taken on trust.
+
+## What this document does not cover
+
+Everything below is **out of scope for the application** and belongs to whoever operates the servers:
+
+- **Server and network security** — hardening, patching, firewalls, isolation between services, intrusion detection, log retention.
+- **Encryption at rest** — disk and volume encryption for the database, uploaded files and any derived copies.
+- **Backups** — that they run, that they are encrypted, that a restore has actually been tested, and who holds the keys.
+- **Operating the Keycloak server** — its own hardening, backups and administrative access, along with the password and MFA policy configured in it.
+- **Administrative access to the servers**, and the fact that whoever holds it can read the data of every system running on them.
+
+Aam Digital is built so that these can be done well, but it cannot do them for you.
+If you host the system yourself, treat them as real work: involve your IT department, or bring in an IT service provider, and hold them to the same standard as the application itself.
+
+For most organisations the easier, more reliable and more secure option is a **hosted (SaaS) Aam Digital system**, where these responsibilities sit with a provider who maintains them as a matter of routine rather than as an occasional project.

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -3,7 +3,7 @@
 A conceptual overview of how a single Aam Digital system protects the data it holds:
 what the application does, what it leaves to the deployment, and what it does not do at all.
 
-This is about **one deployed system** — the app, its database and the accounts that reach it.
+This is about **one deployed system** (the app, its database and the accounts that reach it).
 
 > **Server operation and infrastructure are out of scope here.**
 > See the last section, "What this document does not cover".
@@ -50,7 +50,7 @@ Where those rules are actually _enforced_ depends on how the system is deployed,
 | Write access       | any document                            | validated against the same rules                                                                          |
 | Audit log          | none                                    | optional (`AUDIT_ENABLED`): every write recorded with user and time                                       |
 
-#### Database-only, and what it does not give you
+#### Database-only (no user roles)
 
 This light-weight deployment does explicitly not support user roles and individual permissions.
 All users with a valid login have full read/write access to all data.
@@ -67,9 +67,14 @@ Because CouchDB checks only realm membership and nothing about a user's role, na
 
 This mode is therefore appropriate when everyone with an account in the system is trusted with all of its data — a small team working on one caseload — and not when the roles are meant to keep colleagues apart.
 
-#### With the permission backend
+#### With permission backend
 
-The same rules are additionally applied server-side: reads are filtered as they are replicated, and writes are checked again before they are stored, with CouchDB itself no longer reachable from outside. Unlike database-only mode, a narrowed role then restricts what the user can actually fetch, not only what the interface offers. This is what turns a role restriction into a real restriction, and it is the only configuration in which "this user may only see the records of their own project" is a statement about access rather than about the user interface. It is also the only one that can record who changed what.
+Permissions of user roles are enforced server-side (in addition to local UI checks on the device):
+reads are filtered while data is synced or requested from the server,
+and writes are checked again before they are stored, with the database itself no longer reachable from outside.
+Unlike database-only mode, a narrowed role then restricts what the user can actually fetch, not only what the interface offers.
+
+The permission backend also includes functionality to record a detailed change history of who changed what.
 
 **So if different users of one system must not see each other's data, the permission backend is required.**
 Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com/Aam-Digital/ndb-setup#docker-compose-profiles).
@@ -78,10 +83,8 @@ Deploying either mode is described in [Aam-Digital/ndb-setup](https://github.com
 
 To work offline, the app stores a copy of the records a user may access in the browser's storage on that user's device. This is what makes Aam Digital usable without connectivity, and it has consequences worth stating plainly:
 
-- The copy is stored **unencrypted**. On a device without full-disk encryption, whoever holds the device can read it.
-- Its extent is whatever the user is allowed to sync.
+- The copy includes whatever that user is allowed to sync.
 - Revoking permissions server-side does not reach a device that never connects again. Local data is cleared when the server reports lost permissions during a sync, and that requires the device to come online.
-- The offline login described above opens that copy without checking any credential, so the device itself is the only thing standing between a stranger and the data.
 
 Two settings bear on this:
 

--- a/doc/compodoc_sources/concepts/security.md
+++ b/doc/compodoc_sources/concepts/security.md
@@ -21,7 +21,7 @@ Both are configurable per deployment.
 > The whitelist policy is currently served in **report-only** mode: violations are reported, not blocked.
 > Only the framing policy is enforced.
 
-The directives, their defaults and how to change them are documented with the image that sets them, under "Content Security Policy" in [Build and Deployment](../how-to-guides/build-and-deployment.html).
+The directives, their defaults and how to change them are documented with the image that sets them, under [Content Security Policy in `build/README.md`](https://github.com/Aam-Digital/ndb-core/blob/master/build/README.md#content-security-policy-csp).
 
 **Offline shell.** The app is installable and keeps working offline, which means an outdated version can keep running on a device until it next connects. Fixes reach users on their next online session, not immediately.
 

--- a/doc/compodoc_sources/summary.json
+++ b/doc/compodoc_sources/summary.json
@@ -120,6 +120,10 @@
         "file": "../../e2e/README.md"
       },
       {
+        "title": "Build and Deployment",
+        "file": "../../build/README.md"
+      },
+      {
         "title": "Display Dialogs and Notifications",
         "file": "how-to-guides/dialogs-notifications.md"
       },

--- a/doc/compodoc_sources/summary.json
+++ b/doc/compodoc_sources/summary.json
@@ -120,10 +120,6 @@
         "file": "../../e2e/README.md"
       },
       {
-        "title": "Build and Deployment",
-        "file": "../../build/README.md"
-      },
-      {
         "title": "Display Dialogs and Notifications",
         "file": "how-to-guides/dialogs-notifications.md"
       },


### PR DESCRIPTION
- closes https://github.com/Aam-Digital/internal/issues/352

Part of moving the security concept developed in https://github.com/Aam-Digital/internal/issues/352 into the repos. Companion to https://github.com/Aam-Digital/aam-cloud-infrastructure/pull/221, which covers the cluster/operational side.

This repo's page covers **a single Aam Digital system**, conceptually — not the multi-instance platform, and not our internal threat model (which stays internal; there are deliberately no links to it from here).

## `doc/compodoc_sources/concepts/security.md` — rewritten

- **Browser-side**: Angular sanitization, the two CSP headers (whitelist report-only, framing enforced), and that the offline shell means fixes arrive on the next online session.
- **Authentication**: Keycloak owns password/MFA/session policy; **realm membership is what grants access to a system's data**.
- **Roles and permissions in the two deployment modes**: a comparison table plus short prose, condensed per review feedback. `database-only` explicitly does not support user roles or individual permissions — any valid login has full read/write access to all data, and access without a valid account is not possible at all (so public forms cannot work). A `Config:Permissions` doc is technically still possible to add there, but it is only partly enforced by the local device's UI and **must not be used as a security functionality**. The permission-backend section states the converse: there, a narrowed role actually restricts what can be fetched, not only what the interface offers.
- **Offline login checks no credential.** `LocalAuthService` only lists users from a previous online login and `offlineLogin()` opens the local database directly — no secret is stored or verified. Stated in both the authentication and the device section, because it is what makes the unencrypted local copy reachable by whoever holds the device.
- **The device copy**: unencrypted, bounded by what the user may sync, cleared only when a sync reports lost permissions; plus `session_type: online` and `session_type_choice`.
- **An explicit, unhedged out-of-scope section**: server and network security, encryption at rest, backups, operating Keycloak, and administrative server access — pointing at your IT department or an IT service provider, and naming a hosted (SaaS) system as usually the more reliable option. This matters because self-hosters will read this page as their guidance whether or not it was written for them.

## The other files

- **`build/README.md`** — the CSP details move here, next to the `Dockerfile` and `default.conf` that set them: the `CSP` whitelist and its report-only status, PouchDB's `'unsafe-eval'`, the `index.html` hash procedure, `CSP_EXTRA_FRAME_ANCESTORS`, and `X-Content-Type-Options`. Nothing dropped in the move; the report-only/enforced distinction from #4284 is now stated in both places. The file stays out of the published documentation — the concept page links to it on GitHub.
  - Also gained a `## Configuration` table documenting `PORT`, `COUCHDB_URL`, `QUERY_URL` and `NOMINATIM_URL`, carried over from #4297 (now closed as superseded by this PR). The CSP-related variables that table also listed stay documented in more detail further down in the existing CSP section — the table just points there instead of duplicating it.
- **`build/Dockerfile`** — the comment above the CSP variables pointed at the concept page; it now points at `build/README.md`.

## Note

Aam-Digital/internal#353 (the client-facing data security statement) is about the **hosted SaaS offer**, not about this open source product, and will live with the client-facing material rather than in a repo — see https://github.com/Aam-Digital/internal/issues/353#issuecomment-5346711952. This page must not be read as a claim about what we operate for SaaS clients.
