### PR TITLE
docs: add a security policy with a private disclosure channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 
 Report them privately through GitHub's
 [Report a vulnerability](https://github.com/Aam-Digital/ndb-core/security/advisories/new)
-form, or by email to [support@aam-digital.com](mailto:support@aam-digital.com)
+form, or by email to [it@aam-digital.com](mailto:it@aam-digital.com)
 with "security" in the subject line.
 
 Helpful to include, as far as you have it:
@@ -28,7 +28,7 @@ suspected problem that turns out to be harmless than not hear about a real one.
 ## Supported versions
 
 Fixes are released from the `master` branch and published as a new version. Only
-the most recent release is supported — if you run an older one, updating is the
+the most recent release is supported - if you run an older one, updating is the
 first step.
 
 ## Scope
@@ -50,6 +50,6 @@ describes what the application protects and what it deliberately leaves to
 whoever operates the servers.
 
 If you have found a problem in a **hosted (SaaS) Aam Digital system** we
-operate, report it the same way — say which instance it concerns, and please do
+operate, report it the same way - say which instance it concerns, and please do
 not access, modify or download any data that is not your own while
 investigating.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately through GitHub's
+[Report a vulnerability](https://github.com/Aam-Digital/ndb-core/security/advisories/new)
+form, or by email to [support@aam-digital.com](mailto:support@aam-digital.com)
+with "security" in the subject line.
+
+Helpful to include, as far as you have it:
+
+- what the issue is and which part of the app it affects
+- steps to reproduce it, or a proof of concept
+- what an attacker could achieve with it
+- the version you tested against
+
+We will acknowledge your report within five working days and keep you updated
+while we work on it. Please give us reasonable time to release a fix before
+disclosing the issue publicly. We are happy to credit you in the advisory
+unless you would rather stay anonymous.
+
+Aam Digital is used by social-sector organisations to hold personal data about
+vulnerable people. Reports are taken seriously, and we would rather hear about a
+suspected problem that turns out to be harmless than not hear about a real one.
+
+## Supported versions
+
+Fixes are released from the `master` branch and published as a new version. Only
+the most recent release is supported — if you run an older one, updating is the
+first step.
+
+## Scope
+
+This policy covers the Aam Digital application in this repository and the nginx
+image built from it.
+
+Out of scope, because they are not this code base:
+
+- the servers and databases an instance runs on, including their operating
+  system, network configuration, encryption at rest and backups
+- the Keycloak server used for authentication, and how it is configured
+- deployments run by clients or partners, and the configuration choices made in
+  them
+
+The developer documentation's
+[Security concept](https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/security.html)
+describes what the application protects and what it deliberately leaves to
+whoever operates the servers.
+
+If you have found a problem in a **hosted (SaaS) Aam Digital system** we
+operate, report it the same way — say which instance it concerns, and please do
+not access, modify or download any data that is not your own while
+investigating.


### PR DESCRIPTION
Follow-up to Aam-Digital/ndb-core#4290, filed separately because it is not part of the security concept rewrite.

## Why

This repository is public (and DPG-verified) and has no responsible-disclosure contact anywhere in it. Someone who finds a vulnerability today has no route other than opening a public issue — which is the worst possible place for it. GitHub surfaces `SECURITY.md` in the repository's Security tab and in the "Report a vulnerability" flow, so adding the file is most of the fix.

## What it says

- **Report privately**, via GitHub's advisory form or by email; not through a public issue.
- What to include, and what a reporter can expect back.
- **Supported versions**: only the most recent release.
- **Scope**, and what is out of it — servers, Keycloak, and deployments run by clients or partners — pointing at the security concept page for the full picture.
- A note for reports against a hosted (SaaS) system we operate, asking reporters not to touch data that is not theirs.

## Draft — three things to confirm before merging

1. **The reporting address.** It currently uses `support@aam-digital.com`, the only address in the repo. A dedicated `security@aam-digital.com` would be better if you want these out of the normal support queue.
2. **The acknowledgement window.** "Within five working days" is a plausible placeholder, not a commitment anyone has agreed to. Set it to whatever you can actually hold to, or drop the promise.
3. **Private vulnerability reporting has to be enabled** in Settings → Code security, or the advisory link 404s for reporters.