### PR TITLE
docs(build): document image configuration environment variables

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -21,6 +21,29 @@ docker run -p=80:80 --name aam-digital aam/digital:latest
 docker stop aam-digital
 ```
 
+## Configuration
+
+The image is configured through environment variables, declared with their
+defaults as `ENV` values in [`Dockerfile`](./Dockerfile) and substituted into
+the nginx config at container start (see [`default.conf`](./default.conf)).
+Override any of them (e.g. via `docker run -e`, a `docker-compose.yml`
+`environment:` block, or a Helm chart's pod spec) to change that behavior;
+anything left unset keeps the default below.
+
+| Variable                    | Default                                | Purpose                                                                                                                                                                                                                                                                                                                        |
+| --------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PORT`                      | `8080`                                 | Port nginx listens on inside the container.                                                                                                                                                                                                                                                                                    |
+| `COUCHDB_URL`               | `http://localhost`                     | Proxy target for the app's `/db` path.                                                                                                                                                                                                                                                                                         |
+| `QUERY_URL`                 | `http://localhost:3000`                | Proxy target for the app's `/api` path (and the deprecated `/query` alias).                                                                                                                                                                                                                                                    |
+| `NOMINATIM_URL`             | `https://nominatim.openstreetmap.org`  | Proxy target for the app's `/nominatim` path, used for geocoding.                                                                                                                                                                                                                                                              |
+| `CSP`                       | see `Dockerfile`                       | Overwrites the report-only `Content-Security-Policy-Report-Only` directives; `report-uri ${CSP_REPORT_URI}` is appended automatically. The default already allowlists everything the app needs in production — only override it if a deployment needs additional sources.                                                      |
+| `CSP_REPORT_URI`            | aam-digital's Sentry security endpoint | Where violation reports for the report-only policy above are sent.                                                                                                                                                                                                                                                             |
+| `CSP_EXTRA_FRAME_ANCESTORS` | empty                                  | Other origins (space-separated, e.g. `"https://example.com https://www.example.com"`) allowed to embed the app in an iframe, added to the enforcing `Content-Security-Policy: frame-ancestors` header. The app's own origin is always allowed; leaving this empty is equivalent to the previous `X-Frame-Options: SAMEORIGIN`. |
+
+See also the [security
+documentation](https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/security.html)
+for more on the app's CSP approach.
+
 ## How does the release process work?
 
 We use [semantic-release](https://github.com/semantic-release/semantic-release) to automatically create new versions.


### PR DESCRIPTION
## Summary
- The deployed image's `Dockerfile` and `default.conf` define several `ENV` variables (`PORT`, `COUCHDB_URL`, `QUERY_URL`, `NOMINATIM_URL`, `CSP`, `CSP_REPORT_URI`, `CSP_EXTRA_FRAME_ANCESTORS`) that operators can override to configure a deployment, but they were only documented as inline Dockerfile comments.
- Adds a "Configuration" section to `build/README.md` listing each variable, its default, and what it does, so downstream deployments (docker-compose, Helm, etc.) have a single reference instead of reading the Dockerfile.

## Test plan
- [x] `npx prettier --write build/README.md` to match repo formatting
- [ ] Docs-only change — no functional testing needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)