### PR TITLE
fix(filter): clearing a single-select filter no longer clears other filters

### DIFF
--- a/src/app/core/filter/filter/filter.component.spec.ts
+++ b/src/app/core/filter/filter/filter.component.spec.ts
@@ -253,6 +253,34 @@ describe("FilterComponent", () => {
     expect(categoryFilter.selectedOptionValues).toEqual(["someCategory"]);
   });
 
+  it("should keep other filters' defaults when the user selects a filter option", async () => {
+    await setComponentInputs({
+      entityType: Note,
+      useUrlQueryParams: true,
+      filterConfig: [{ id: "date", default: "0" }, { id: "category" }],
+    });
+
+    const categoryFilter = component
+      .filterSelections()
+      .find((f) => f.name === "category");
+    component.filterOptionSelected(categoryFilter, ["someCategory"]);
+
+    // the router has written the selection to the URL by the time the
+    // dropdown closing triggers another change event
+    activatedRouteMock.snapshot = {
+      queryParams: { category: "someCategory" },
+    };
+    component.filterOptionSelected(categoryFilter, ["someCategory"]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const dateFilter = component
+      .filterSelections()
+      .find((f) => f.name === "date");
+    expect(dateFilter.selectedOptionValues).toEqual(["0"]);
+  });
+
   it("should compute available category options and build filterObj", async () => {
     const t1 = defaultInteractionTypes[0];
     const t2 = defaultInteractionTypes[1];

--- a/src/app/core/filter/filter/filter.component.spec.ts
+++ b/src/app/core/filter/filter/filter.component.spec.ts
@@ -263,13 +263,18 @@ describe("FilterComponent", () => {
     const categoryFilter = component
       .filterSelections()
       .find((f) => f.name === "category");
+    // In the real app, selecting an option writes it to the URL (async router
+    // navigation) and the dropdown closing then fires another change event,
+    // which used to read the URL back and clear all other filters.
+    // The mocked ActivatedRoute is static and never reflects the component's
+    // own navigation, so both steps are simulated manually here:
     component.filterOptionSelected(categoryFilter, ["someCategory"]);
 
-    // the router has written the selection to the URL by the time the
-    // dropdown closing triggers another change event
+    // 1. the router has now written the selection to the URL
     activatedRouteMock.snapshot = {
       queryParams: { category: "someCategory" },
     };
+    // 2. the follow-up change event from the closing dropdown
     component.filterOptionSelected(categoryFilter, ["someCategory"]);
     fixture.detectChanges();
     await fixture.whenStable();

--- a/src/app/core/filter/filter/filter.component.ts
+++ b/src/app/core/filter/filter/filter.component.ts
@@ -117,9 +117,15 @@ export class FilterComponent<T extends Entity = Entity> {
 
   constructor() {
     effect(() => {
-      const selectionsWithUrlParams = this.loadUrlParams(
-        this.filterSelections(),
-      );
+      const selections = this.filterSelections();
+      // Only sync state from the URL for freshly generated selections
+      // (initial load or data change). During user interaction the URL
+      // trails the state and reading it back would clear the selections
+      // of other filters (e.g. their configured defaults).
+      const selectionsWithUrlParams =
+        selections === this.generatedFilterSelections.value()
+          ? this.loadUrlParams(selections)
+          : selections;
       this.applyFilterSelections(selectionsWithUrlParams);
     });
 

--- a/src/app/core/filter/list-filter/list-filter.component.spec.ts
+++ b/src/app/core/filter/list-filter/list-filter.component.spec.ts
@@ -27,4 +27,16 @@ describe("ListFilterComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  it("should emit an empty selection when the autocomplete resets its value to undefined", () => {
+    // basic-autocomplete emits undefined when a cleared single-select dropdown is closed
+    const emittedValues: string[][] = [];
+    component
+      .filterConfig()
+      .selectedOptionChange.subscribe((values) => emittedValues.push(values));
+
+    component.autocompleteControl.setValue(undefined);
+
+    expect(emittedValues).toEqual([[]]);
+  });
 });

--- a/src/app/core/filter/list-filter/list-filter.component.ts
+++ b/src/app/core/filter/list-filter/list-filter.component.ts
@@ -47,7 +47,7 @@ export class ListFilterComponent<E extends Entity> {
     this.autocompleteControl.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((values) => {
-        const selectedValues = asArray(values);
+        const selectedValues = asArray(values ?? []);
         this.selectedValues.set(selectedValues);
         this.filterConfig().selectedOptionChange.emit(selectedValues);
       });


### PR DESCRIPTION
- closes #4273

Clearing a single-select filter (such as the prebuilt "Tasks due" filter or a configurable-enum filter with `singleSelectOnly`) and then closing its dropdown emitted `undefined` from the autocomplete, which `ListFilterComponent` converted to `[undefined]`. This was serialized into the URL as `filter=undefined`, a non-empty query param. `FilterComponent.loadUrlParams` then cleared every other filter whose selection (including defaults like "Assigned to" = current user) was not present in the URL.

The fix normalizes a nullish autocomplete value to an empty selection in `ListFilterComponent`, so no garbage URL param is written and other filters keep their state.

### Manual Testing Steps

1. Go to "Tasks". The "Assigned to" filter shows the current user and "Tasks due" shows "Currently Active".
2. Open the "Tasks due" filter and click "Clear".
3. Click outside of the filter popup to close it.
4. Only the "Tasks due" filter is cleared; "Assigned to" keeps its value and the URL contains no `todo-due-status=undefined` parameter.

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete filter behavior when its value is cleared or reset.
  * The filter now consistently treats cleared values as an empty selection.

* **Tests**
  * Added coverage to verify that resetting the autocomplete emits an empty selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->