### PR TITLE
fix: report permission-driven local data deletion accurately, and stop acting on unresolved rules

### DIFF
--- a/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.spec.ts
@@ -10,6 +10,7 @@ import { Subject } from "rxjs";
 import { SyncState } from "../../session/session-states/sync-state.enum";
 import { SyncedPouchDatabase } from "./synced-pouch-database";
 import { NotAvailableOfflineError } from "../../session/not-available-offline.error";
+import { Logging } from "../../logging/logging.service";
 
 describe("SyncedPouchDatabase", () => {
   let service: SyncedPouchDatabase;
@@ -418,8 +419,28 @@ describe("SyncedPouchDatabase", () => {
 
   describe("purgeDocsWithLostPermissions", () => {
     let purgeSpy: Mock;
+    let warnSpy: Mock;
+
+    /** the reported ids that the server sends along the `_changes` response */
+    function mockLostPermissions(ids: string[]) {
+      vi.spyOn(
+        service["remoteDatabase"],
+        "collectAndClearLostPermissions",
+      ).mockReturnValue(ids);
+    }
+
+    function warnedMessages(): string[] {
+      return warnSpy.mock.calls.map(([message]) => message);
+    }
 
     beforeEach(() => {
+      warnSpy = vi
+        .spyOn(Logging, "warn")
+        .mockImplementation(() => {}) as unknown as Mock;
+      // spying on an already-spied method returns the existing mock,
+      // which would still hold the calls recorded by the previous test
+      warnSpy.mockClear();
+
       const mockLocalDb = {
         name: "unit-test-db",
         sync: vi.fn().mockReturnValue(mockSyncHandler()),
@@ -434,10 +455,7 @@ describe("SyncedPouchDatabase", () => {
     });
 
     it("should purge local docs reported in lostPermissions after sync", async () => {
-      vi.spyOn(
-        service["remoteDatabase"],
-        "collectAndClearLostPermissions",
-      ).mockReturnValue(["Child:1", "School:2"]);
+      mockLostPermissions(["Child:1", "School:2"]);
 
       await service.sync();
 
@@ -446,10 +464,7 @@ describe("SyncedPouchDatabase", () => {
     });
 
     it("should not purge anything if no permissions were lost", async () => {
-      vi.spyOn(
-        service["remoteDatabase"],
-        "collectAndClearLostPermissions",
-      ).mockReturnValue([]);
+      mockLostPermissions([]);
 
       await service.sync();
 
@@ -458,10 +473,7 @@ describe("SyncedPouchDatabase", () => {
 
     it("should skip gracefully if purge returns false (doc not found locally)", async () => {
       purgeSpy.mockResolvedValue(false);
-      vi.spyOn(
-        service["remoteDatabase"],
-        "collectAndClearLostPermissions",
-      ).mockReturnValue(["Child:missing"]);
+      mockLostPermissions(["Child:missing"]);
 
       await expect(service.sync()).resolves.not.toThrow();
     });
@@ -472,15 +484,56 @@ describe("SyncedPouchDatabase", () => {
           ? Promise.reject(new Error("unexpected"))
           : Promise.resolve(true),
       );
-      vi.spyOn(
-        service["remoteDatabase"],
-        "collectAndClearLostPermissions",
-      ).mockReturnValue(["Child:1", "School:2"]);
+      mockLostPermissions(["Child:1", "School:2"]);
 
       await service.sync();
 
       expect(purgeSpy).toHaveBeenCalledWith("Child:1");
       expect(purgeSpy).toHaveBeenCalledWith("School:2");
+    });
+
+    it("should not warn if none of the reported docs exist locally", async () => {
+      // the server reports every doc the user may not read, not only docs this
+      // client actually holds - so this is the normal case and no data is lost
+      purgeSpy.mockResolvedValue(false);
+      mockLostPermissions(["Child:1", "School:2", "Note:3"]);
+
+      await service.sync();
+
+      expect(warnedMessages()).toEqual([]);
+    });
+
+    it("should warn with the number of docs actually purged, not the number reported", async () => {
+      purgeSpy.mockImplementation(async (id: string) => id === "Child:1");
+      mockLostPermissions(["Child:1", "School:2", "Note:3"]);
+
+      await service.sync();
+
+      expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining("purged local docs"),
+        expect.objectContaining({
+          purged: 1,
+          notPresentLocally: 2,
+          failed: 0,
+          reportedByServer: 3,
+          sampleIds: ["Child:1"],
+        }),
+      );
+    });
+
+    it("should report failed purges as a single, separate warning", async () => {
+      // e.g. the legacy "idb" adapter, which does not implement purge at all
+      const error = new Error("Purge is not implemented in the idb adapter.");
+      purgeSpy.mockRejectedValue(error);
+      mockLostPermissions(["Child:1", "School:2", "Note:3"]);
+
+      await service.sync();
+
+      expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining("failed to purge local docs"),
+        expect.objectContaining({ purged: 0, failed: 3, reportedByServer: 3 }),
+        error,
+      );
     });
 
     it("should skip purge and lost-permission tracking on first sync", async () => {

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -376,7 +376,7 @@ export class SyncedPouchDatabase extends PouchDatabase {
     const purgedIds: string[] = [];
     const failedIds: string[] = [];
     let notPresentLocally = 0;
-    let firstError: any;
+    let firstError: unknown;
 
     for (const _id of reportedIds) {
       try {

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -155,7 +155,11 @@ export class SyncedPouchDatabase extends PouchDatabase {
 
   private async logSyncContext() {
     const lastSyncTime = localStorage.getItem(this.LAST_SYNC_KEY);
-    Logging.addContext("Aam Digital sync", {
+    // the context key includes the database name: every synced database (app,
+    // notifications, ...) writes its own block. With a shared key the last
+    // writer would overwrite the others, so a reported event could show the
+    // sync state of a different database than the one it is about.
+    Logging.addContext(`Aam Digital sync: ${this.dbName}`, {
       db: this.dbName,
       "last sync completed": lastSyncTime,
       "last sync docs pushed": this.lastSyncStats?.pushed,

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -343,39 +343,86 @@ export class SyncedPouchDatabase extends PouchDatabase {
   }
 
   /**
+   * How many document ids to include as an example in the logs below, which can
+   * report on thousands of documents (the count is logged in full alongside).
+   */
+  private readonly SAMPLE_IDS_LOGGED = 5;
+
+  /**
    * Purge local documents for which the server reported lost permissions
    * during the most recent sync's `_changes` calls.
+   *
+   * The server reports every document changed since this client's checkpoint
+   * that the user may not read - it has no knowledge of which of those the
+   * client actually holds locally. Most reported ids therefore do not exist
+   * locally at all and purging them is a no-op. Only an actual local deletion
+   * is reported as a warning, so that the log stays a signal for data being
+   * removed rather than a count of what the server reported.
    */
   private async purgeDocsWithLostPermissions(): Promise<void> {
-    const lostPermissionIds = this.remoteDatabase
+    const reportedIds = this.remoteDatabase
       .collectAndClearLostPermissions()
       // design docs for indices are managed locally (and shouldn't be synced anyway)
       .filter((id) => !id.startsWith("_design/"));
 
-    if (lostPermissionIds.length > 0) {
-      // deleting local data based on server response - log for traceability of possible data loss.
+    if (reportedIds.length === 0) {
+      return;
+    }
+
+    const purgedIds: string[] = [];
+    const failedIds: string[] = [];
+    let notPresentLocally = 0;
+    let firstError: any;
+
+    for (const _id of reportedIds) {
+      try {
+        if (await this.purge(_id)) {
+          purgedIds.push(_id);
+        } else {
+          notPresentLocally++;
+        }
+      } catch (err) {
+        failedIds.push(_id);
+        firstError ??= err;
+      }
+    }
+
+    const stats = {
+      db: this.dbName,
+      purged: purgedIds.length,
+      notPresentLocally,
+      failed: failedIds.length,
+      reportedByServer: reportedIds.length,
+    };
+
+    if (purgedIds.length > 0) {
+      // local data was actually deleted - log for traceability of possible data loss
       Logging.warn(
-        "sync: purging local docs after server reported lost permissions",
+        "sync: purged local docs that the server reported as no longer permitted",
         {
-          db: this.dbName,
-          count: lostPermissionIds.length,
-          // how far behind the server this client was: local edits made since then are lost
-          lastSyncCompleted: localStorage.getItem(this.LAST_SYNC_KEY),
+          ...stats,
+          sampleIds: purgedIds.slice(0, this.SAMPLE_IDS_LOGGED),
+          // the sync triggering this purge has replicated but not yet recorded its
+          // own timestamp, so this is the previously completed sync - i.e. how long
+          // this device had been out of sync *before* the sync that just succeeded.
+          previousSyncCompleted: localStorage.getItem(this.LAST_SYNC_KEY),
         },
+      );
+    } else {
+      Logging.debug(
+        "sync: no local docs to purge for server-reported lost permissions",
+        stats,
       );
     }
 
-    for (const _id of lostPermissionIds) {
-      try {
-        const purged = await this.purge(_id);
-        if (purged) {
-          Logging.debug(`Purged doc with lost permissions: ${_id}`);
-        } else {
-          Logging.debug(`Skipped purge for ${_id} (does not exist locally)`);
-        }
-      } catch (err) {
-        Logging.warn(`Error trying to purge doc`, _id, err);
-      }
+    if (failedIds.length > 0) {
+      // the local database keeps docs the user is no longer allowed to read
+      // (the legacy "idb" adapter does not implement purge at all, see purge())
+      Logging.warn(
+        "sync: failed to purge local docs that the server reported as no longer permitted",
+        { ...stats, sampleIds: failedIds.slice(0, this.SAMPLE_IDS_LOGGED) },
+        firstError,
+      );
     }
   }
 

--- a/src/app/core/permissions/ability/ability.service.spec.ts
+++ b/src/app/core/permissions/ability/ability.service.spec.ts
@@ -477,4 +477,43 @@ describe("AbilityService", () => {
       vi.useRealTimers();
     }
   });
+
+  describe("failed rules load", () => {
+    /** run initializeRules() with a load that rejects with the given error */
+    async function initWithLoadError(err: any) {
+      entityMapper.load.mockRejectedValue(err);
+      service.initializeRules();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("should not report an expected permission denial as an error", async () => {
+      // anonymous visitors of a public form may not read the rules config
+      const errorSpy = vi.spyOn(Logging, "error");
+
+      await initWithLoadError({ status: 401, message: "unauthorized" });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not report a connectivity failure as an error", async () => {
+      const errorSpy = vi.spyOn(Logging, "error");
+
+      await initWithLoadError(new Error("Failed to fetch from DB"));
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should report an unexpected failure as PermissionRulesLoadError", async () => {
+      const errorSpy = vi.spyOn(Logging, "error");
+
+      await initWithLoadError(new Error("something unexpected"));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "PermissionRulesLoadError" }),
+      );
+    });
+  });
 });

--- a/src/app/core/permissions/ability/ability.service.spec.ts
+++ b/src/app/core/permissions/ability/ability.service.spec.ts
@@ -506,6 +506,37 @@ describe("AbilityService", () => {
       expect(errorSpy).not.toHaveBeenCalled();
     });
 
+    it("should not hand the permissive fallback to the enforcer while the rules are unknown", async () => {
+      // otherwise "allowed everything" is stored as the baseline, so the real
+      // rules arriving later look like a permission change
+      await initWithLoadError(new Error("something unexpected"));
+
+      TestBed.inject(SessionSubject).next({
+        name: "some-user",
+        id: "1",
+        roles: ["user_app"],
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(
+        TestBed.inject(PermissionEnforcerService).enforcePermissionsOnLocalData,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should enforce the real rules once they arrive after a failed load", async () => {
+      await initWithLoadError(new Error("something unexpected"));
+
+      entityUpdates.next({
+        entity: new Config(Config.PERMISSION_KEY, rules),
+        type: "update",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(
+        TestBed.inject(PermissionEnforcerService).enforcePermissionsOnLocalData,
+      ).toHaveBeenCalledWith(rules["user_app"]);
+    });
+
     it("should report an unexpected failure as PermissionRulesLoadError", async () => {
       const errorSpy = vi.spyOn(Logging, "error");
 

--- a/src/app/core/permissions/ability/ability.service.spec.ts
+++ b/src/app/core/permissions/ability/ability.service.spec.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { TestBed, waitForAsync } from "@angular/core/testing";
 
 import { AbilityService } from "./ability.service";
@@ -72,6 +73,7 @@ describe("AbilityService", () => {
           provide: PermissionEnforcerService,
           useValue: {
             enforcePermissionsOnLocalData: vi.fn(),
+            getLastEnforcedRules: vi.fn(),
           },
         },
         { provide: EntityMapperService, useValue: entityMapper },
@@ -535,6 +537,28 @@ describe("AbilityService", () => {
       expect(
         TestBed.inject(PermissionEnforcerService).enforcePermissionsOnLocalData,
       ).toHaveBeenCalledWith(rules["user_app"]);
+    });
+
+    it("should apply the rules of the previous session if they cannot be loaded", async () => {
+      // a transient failure must not escalate the user to full permissions
+      const lastKnownRules: DatabaseRule[] = [
+        { subject: TestEntity.ENTITY_TYPE, action: "read" },
+      ];
+      (
+        TestBed.inject(PermissionEnforcerService)
+          .getLastEnforcedRules as unknown as Mock
+      ).mockReturnValue(lastKnownRules);
+
+      await initWithLoadError(new Error("Failed to fetch from DB"));
+
+      expect(ability.rules).toEqual(lastKnownRules);
+    });
+
+    it("should allow everything if no rules were ever applied on this device", async () => {
+      // instances that intentionally define no permissions must keep working
+      await initWithLoadError(new Error("Failed to fetch from DB"));
+
+      expect(ability.rules).toEqual([{ action: "manage", subject: "all" }]);
     });
 
     it("should report an unexpected failure as PermissionRulesLoadError", async () => {

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -20,6 +20,8 @@ import { SessionInfo, SessionSubject } from "../../session/auth/session-info";
 import { CurrentUserSubject } from "../../session/current-user-subject";
 import { filter, firstValueFrom, merge } from "rxjs";
 import { map } from "rxjs/operators";
+import { HttpStatusCode } from "@angular/common/http";
+import { isConnectivityError } from "#src/app/utils/connectivity-error";
 
 /**
  * This service sets up the `EntityAbility` injectable with the JSON defined rules for the currently logged in user.
@@ -51,11 +53,7 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
     try {
       initialPermissions = await super.startLoading();
     } catch (err) {
-      const error = new Error("Failed to load permission rules", {
-        cause: err,
-      });
-      error.name = "PermissionRulesLoadError";
-      Logging.error(error);
+      this.logRulesLoadFailure(err);
     }
 
     if (initialPermissions) {
@@ -71,6 +69,37 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
       this.sessionInfo.pipe(map(() => this.currentRules)),
       this.currentUser.pipe(map(() => this.currentRules)),
     ).subscribe((rules) => this.updateAbilityWithUserRules(rules));
+  }
+
+  /**
+   * Report a failed load of the permission rules, unless the failure is an
+   * expected part of normal operation:
+   *
+   * - 401/403: the session may not read the rules config. Anonymous visitors of
+   *   a public form never can, and an expired session is already handled by the
+   *   database layer (which triggers re-login).
+   * - connectivity: offline, a request timeout or a 5xx from the server.
+   *
+   * Both are transient or by design and would otherwise drown out the failures
+   * that do indicate a problem.
+   */
+  private logRulesLoadFailure(err: any) {
+    const status = err?.status ?? err?.statusCode;
+    if (
+      status === HttpStatusCode.Unauthorized ||
+      status === HttpStatusCode.Forbidden
+    ) {
+      Logging.debug("Permission rules not readable for this session", err);
+      return;
+    }
+    if (isConnectivityError(err)) {
+      Logging.debug("Could not load permission rules (connectivity)", err);
+      return;
+    }
+
+    const error = new Error("Failed to load permission rules", { cause: err });
+    error.name = "PermissionRulesLoadError";
+    Logging.error(error);
   }
 
   private async updateAbilityWithUserRules(rules: DatabaseRules): Promise<any> {

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -76,24 +76,56 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
 
     if (initialPermissions) {
       await this.updateAbilityWithUserRules(initialPermissions.data);
-    } else {
-      // as default fallback if no permission object is defined: allow everything
+    } else if (this.rulesKnown) {
+      // no permission object is defined for this instance: allow everything
       this.ability.update([{ action: "manage", subject: "all" }]);
       this.ability.initialized = true;
+    } else {
+      this.applyLastKnownRules();
     }
 
     merge(
       this.entityUpdated.pipe(map((config) => config.data)),
       this.sessionInfo.pipe(map(() => this.currentRules)),
       this.currentUser.pipe(map(() => this.currentRules)),
-    )
-      // While the rules are unknown, a session or user change must not re-derive
-      // the permissive fallback and hand it to the enforcer: that would store
-      // "allowed everything" as the baseline for future comparisons, so the real
-      // rules arriving afterwards look like a permission change and trigger a
-      // full re-sync (or, on the legacy adapter, destroy the local database).
-      .pipe(filter(() => this.rulesKnown))
-      .subscribe((rules) => this.updateAbilityWithUserRules(rules));
+    ).subscribe((rules) => {
+      if (this.rulesKnown) {
+        this.updateAbilityWithUserRules(rules);
+      } else {
+        // While the rules are unknown, a session or user change must not
+        // re-derive the permissive fallback and hand it to the enforcer: that
+        // would store "allowed everything" as the baseline for future
+        // comparisons, so the real rules arriving afterwards look like a
+        // permission change and trigger a full re-sync (or, on the legacy
+        // adapter, destroy the local database).
+        this.applyLastKnownRules();
+      }
+    });
+  }
+
+  /**
+   * Apply the rules of the previous session, while the actual rules could not
+   * be loaded (e.g. the server was unreachable).
+   *
+   * Falling through to "allow everything" here would grant full client-side
+   * permissions on a transient failure - at the moment the app is least able to
+   * notice. Re-using the rules that were last successfully applied for this user
+   * keeps the app usable without escalating access.
+   * If there are none (first session on this device) the permissive fallback
+   * still applies, so that instances which intentionally define no permissions
+   * keep working.
+   */
+  private applyLastKnownRules() {
+    const lastKnownRules = this.permissionEnforcer.getLastEnforcedRules();
+    if (lastKnownRules) {
+      Logging.debug("Applying permission rules of the previous session");
+    }
+
+    // stored rules are already interpolated, so they are applied as they are
+    this.ability.update(
+      lastKnownRules ?? [{ action: "manage", subject: "all" }],
+    );
+    this.ability.initialized = true;
   }
 
   /**

--- a/src/app/core/permissions/ability/ability.service.ts
+++ b/src/app/core/permissions/ability/ability.service.ts
@@ -40,18 +40,36 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
 
   private currentRules: DatabaseRules;
 
+  /**
+   * Whether the state of the permission config is actually known, i.e. it was
+   * loaded from the database or the database confirmed it does not exist.
+   *
+   * `currentRules` alone cannot express this: it is `undefined` both for an
+   * instance that deliberately defines no permissions (-> allow everything) and
+   * for a config we simply failed to load. Only the former is a fact about the
+   * instance that may be enforced on local data.
+   */
+  private rulesKnown = false;
+
   constructor() {
     const entityMapper = inject(EntityMapperService);
 
     super(Config, Config.PERMISSION_KEY, entityMapper);
 
-    this.entityUpdated.subscribe((config) => (this.currentRules = config.data));
+    this.entityUpdated.subscribe((config) => {
+      this.currentRules = config.data;
+      // includes a deletion of the config (empty entity): that the rules are
+      // gone is a known state, unlike a failed load
+      this.rulesKnown = true;
+    });
   }
 
   async initializeRules() {
     let initialPermissions: Config<DatabaseRules> | undefined;
     try {
       initialPermissions = await super.startLoading();
+      // loaded, or confirmed to not exist (404)
+      this.rulesKnown = true;
     } catch (err) {
       this.logRulesLoadFailure(err);
     }
@@ -68,7 +86,14 @@ export class AbilityService extends LatestEntityLoader<Config<DatabaseRules>> {
       this.entityUpdated.pipe(map((config) => config.data)),
       this.sessionInfo.pipe(map(() => this.currentRules)),
       this.currentUser.pipe(map(() => this.currentRules)),
-    ).subscribe((rules) => this.updateAbilityWithUserRules(rules));
+    )
+      // While the rules are unknown, a session or user change must not re-derive
+      // the permissive fallback and hand it to the enforcer: that would store
+      // "allowed everything" as the baseline for future comparisons, so the real
+      // rules arriving afterwards look like a permission change and trigger a
+      // full re-sync (or, on the legacy adapter, destroy the local database).
+      .pipe(filter(() => this.rulesKnown))
+      .subscribe((rules) => this.updateAbilityWithUserRules(rules));
   }
 
   /**

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.spec.ts
@@ -92,6 +92,27 @@ describe("PermissionEnforcerService", () => {
     }
   });
 
+  it("should return the last enforced rules for the current user", async () => {
+    vi.useFakeTimers();
+    try {
+      service.enforcePermissionsOnLocalData(userRules);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(service.getLastEnforcedRules()).toEqual(userRules);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should not return malformed stored rules", () => {
+    window.localStorage.setItem(
+      TEST_USER + "-" + PermissionEnforcerService.LOCALSTORAGE_KEY,
+      "not json",
+    );
+
+    expect(service.getLastEnforcedRules()).toBeUndefined();
+  });
+
   it("should not reset if roles didnt change since last check", async () => {
     vi.useFakeTimers();
     try {

--- a/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
+++ b/src/app/core/permissions/permission-enforcer/permission-enforcer.service.ts
@@ -103,6 +103,30 @@ export class PermissionEnforcerService {
     this.localStorage.setItem(this.getUserStorageKey(), userRulesString);
   }
 
+  /**
+   * The rules that were last successfully applied and enforced for the current
+   * user on this device (see {@link enforcePermissionsOnLocalData}).
+   *
+   * `undefined` if there is no session or no rules have been enforced yet.
+   */
+  getLastEnforcedRules(): DatabaseRule[] | undefined {
+    if (!this.sessionInfo.value) {
+      return undefined;
+    }
+
+    const storedRules = this.localStorage.getItem(this.getUserStorageKey());
+    if (!storedRules) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(storedRules);
+    } catch (err) {
+      Logging.debug("Could not parse stored permission rules", err);
+      return undefined;
+    }
+  }
+
   private userRulesChanged(newRules: string): boolean {
     const storedRules = this.localStorage.getItem(this.getUserStorageKey());
     return storedRules !== newRules;


### PR DESCRIPTION
Addresses the parts of #4198 that turned out to be actual defects, and closes #4268. Five commits, reviewable in order.

### 1. `fix(sync)`: report docs actually purged, not ids reported by the server

`purgeDocsWithLostPermissions()` warned on `lostPermissionIds.length > 0`, before attempting any purge — so the `count` in Sentry was the number of ids the **server reported**, not documents deleted. The server reports every doc changed since the client's checkpoint that the user may not read; it cannot know which of those the client holds, so most reported ids don't exist locally and purging them is a no-op.

Now warns only once a document was actually deleted, with `purged` / `notPresentLocally` / `failed` / `reportedByServer`. Per-doc failures are aggregated into one warning per sync instead of one per document — the legacy `idb` adapter has no `purge()` at all, so every locally present doc failed individually (`AAM-DIGITAL-6NZ`, 778 events).

`lastSyncCompleted` → `previousSyncCompleted`: the purge runs after a *successful* sync that has already pushed local changes, so the value is the timestamp of the sync before it, not a measure of unsynced data at risk.

> **Expect `AAM-DIGITAL-74M` / `77B` / `6NZ` / `77C` to collapse to near zero.** That is the metric being corrected, not the bug being fixed — on the `idb` adapter this path was never able to delete anything.

### 2. `fix(logging)`: give each synced database its own sync context

`Logging.addContext("Aam Digital sync", …)` was written by every `SyncedPouchDatabase` under one key, so an event could show the sync state of a different database than the one it is about (`db: "notifications"` next to a warning about `app`).

### 3. `fix(logging)`: don't report expected permission-rules load failures as errors

`PermissionRulesLoadError` (~1,500 events/90d across `6XT`, `75B`, `72F`, `75D`) is dominated by two non-defects: 401/403 (an anonymous public-form visitor may not read the rules config; an expired session is already handled by the database layer) and connectivity failures. Both now log at debug.

### 4. `fix(permissions)`: only enforce permission rules that could be resolved

`currentRules` is `undefined` both for an instance that deliberately defines no permissions and for a config that failed to load. Since `SessionSubject` and `CurrentUserSubject` are `BehaviorSubject`s, they replay on subscribe, so after a failed load the merged stream immediately re-derived `manage all` and handed it to the enforcer — storing "allowed everything" as the baseline, so the real rules arriving afterwards looked like a permission change and triggered a full `resetSync()` (`checkpoint: false`, making the server rescan the entire changes feed) or, on `idb`, a destroy of the local database.

Now gated on whether the state of the rules is actually *known* — loaded, confirmed missing (404), or deleted, all known states, unlike a failed load.

### 5. `fix(permissions)`: keep the previous session's rules when they cannot be loaded — closes #4268

A failed load fell through to `manage all`, the same branch as an instance that deliberately defines no permissions — granting full client-side permissions on a transient infrastructure fault. Commit 4 makes the two cases distinguishable, so this one acts on it: a 404 keeps the permissive fallback, while a failed load re-applies the rules last successfully enforced for this user (which `PermissionEnforcerService` already persists in `<userId>-RULES`). With none stored — first session on this device — the permissive fallback still applies, so instances without a permission config keep working.

This is option 3 from #4268. Trade-off noted there: stale rules can outlive a revocation until the config loads, bounded by the server enforcing independently.

Also corrects a claim in #4268 — it recorded that the fail-open path could not trigger a purge because the `else` branch bypasses `updateAbilityWithUserRules()`. It does, but the `merge(...)` subscription set up immediately after replays both BehaviorSubjects and calls it anyway; see [the analysis comment](https://github.com/Aam-Digital/ndb-core/issues/4268#issuecomment-5409098091).

### Not included

- The empty-rule-set → destroy behaviour: intentional, per discussion on #4198.
- A fail-closed fallback for anonymous sessions: the server denies anonymous regardless, so it bought nothing and would have broken working public forms.
- Skipping the destroy path when no baseline is stored: unsound — `dbHasEntitiesWithoutPermissions()` evaluates against the *current* rules, so the decision is a statement of present fact, not a comparison with history.
- Narrowing what the backend reports as `lostPermissions`: split out to Aam-Digital/replication-backend#329, since it may not be feasible as stated.

Companion backend change: Aam-Digital/replication-backend#328 (independent, no deploy-order dependency either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permission handling when rules cannot be loaded, preserving the last known permissions instead of temporarily allowing unrestricted access.
  - Reduced misleading error logging for expected authorization and connectivity failures.
  - Improved synchronization warnings by reporting accurate purge results and failed operations.
  - Prevented logging context collisions between databases.

- **Tests**
  - Added coverage for permission-load failures, rule recovery, and purge warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->