### PR TITLE
fix(anonymize): never anonymize a record that is only linked from another

### DIFF
--- a/e2e/tests/anonymize.spec.ts
+++ b/e2e/tests/anonymize.spec.ts
@@ -1,0 +1,172 @@
+import { E2E_REF_DATE, expect, loadApp, Page, test } from "#e2e/fixtures.js";
+import { generateChild } from "#src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.js";
+import { generateNote } from "#src/app/child-dev-project/notes/demo-data/demo-note-generator.service.js";
+import { generateUsers } from "#src/app/core/user/demo-user-generator.service.js";
+import { createEntityOfType } from "#src/app/core/demo-data/create-entity-of-type.js";
+
+const CHILD_NAME = "<ANONYMIZE TEST CHILD>";
+const OTHER_CHILD_NAME = "<ANONYMIZE TEST OTHER CHILD>";
+const SUBJECT_SOLE_LINK = "<ANONYMIZE TEST RECORD>";
+const SUBJECT_SHARED_LINK = "<ANONYMIZE TEST SHARED RECORD>";
+const LINKED_USER_NAME = "<ANONYMIZE TEST USER>";
+const LINKED_USER_PHONE = "555-0100";
+
+/**
+ * Set the anonymize mode of the note's user reference ("Team involved")
+ * through the Admin UI.
+ */
+async function setNoteAuthorsAnonymizeMode(page: Page, mode: string) {
+  await page.getByRole("navigation").getByText("Notes").click();
+  await page
+    .locator("button[mat-icon-button][color='primary']")
+    .first()
+    .click();
+  await page.getByText("Configure Data Structure").click();
+  await page.getByText("Details View & Fields").click();
+
+  const authorsField = page
+    .locator(".admin-form-field")
+    .filter({ hasText: "Team involved" })
+    .first();
+  await authorsField.scrollIntoViewIfNeeded();
+  await authorsField.hover();
+  await authorsField.getByRole("button", { name: "Edit Field" }).click();
+
+  const fieldDialog = page.locator("mat-dialog-container");
+  await fieldDialog.getByRole("tab", { name: "Advanced Options" }).click();
+  await fieldDialog
+    .locator("app-anonymize-options")
+    .getByRole("combobox")
+    .click();
+  await page.getByRole("option", { name: mode, exact: true }).click();
+  // move the pointer away so the option's tooltip does not cover the button
+  await page.mouse.move(0, 0);
+  await fieldDialog.getByRole("button", { name: "Apply", exact: true }).click();
+  await expect(fieldDialog).not.toBeVisible();
+
+  await page.getByRole("button", { name: "Save" }).first().click();
+  await expect(page.getByText("Configuration updated")).toBeVisible();
+}
+
+/**
+ * Anonymization must never spread to a record that is only linked *from* an
+ * anonymized record. It cascades to records linking *to* it through a
+ * "composite" relation, and clears the record's own references according to
+ * their configured anonymize mode.
+ *
+ * This flow covers all of that in one pass:
+ * - the note belonging to the anonymized child only is cascaded into,
+ * - the note shared with another child is kept and reported for manual review,
+ * - both anonymize modes a user reference is realistically configured with
+ *   clear the reference and leave the referenced record alone,
+ * - and the linked user profile keeps all of its data throughout.
+ */
+test("Anonymize cascades to a record's own notes but never to a linked user profile", async ({
+  page,
+}) => {
+  const users = generateUsers();
+  const linkedUser = createEntityOfType("User", "anonymize-e2e-user");
+  linkedUser.name = LINKED_USER_NAME;
+  linkedUser.phone = LINKED_USER_PHONE;
+
+  const child = generateChild({ name: CHILD_NAME });
+  const otherChild = generateChild({ name: OTHER_CHILD_NAME });
+
+  const note = generateNote({
+    child,
+    author: linkedUser,
+    date: new Date(E2E_REF_DATE),
+  });
+  note.subject = SUBJECT_SOLE_LINK;
+
+  // a note linked to another child as well is kept, so the assertions below
+  // distinguish "the cascade anonymized this note" from "no note is listed"
+  const sharedNote = generateNote({
+    child,
+    author: linkedUser,
+    date: new Date(E2E_REF_DATE),
+  });
+  sharedNote.subject = SUBJECT_SHARED_LINK;
+  // qlty-ignore: radarlint-js:typescript:S1874 - the demo config still links notes to children through this deprecated field
+  sharedNote.children.push(otherChild.getId());
+
+  await loadApp(page, [
+    ...users,
+    linkedUser,
+    child,
+    otherChild,
+    note,
+    sharedNote,
+  ]);
+
+  // "Remove" is what a link to a user profile is usually configured with,
+  // and is stored as `anonymize: ""`
+  await setNoteAuthorsAnonymizeMode(page, "Remove");
+
+  // both notes are listed while the child they belong to is still active
+  await page.getByRole("navigation").getByText("Notes").click();
+  await expect(
+    page.getByRole("cell", { name: SUBJECT_SOLE_LINK }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("cell", { name: SUBJECT_SHARED_LINK }),
+  ).toBeVisible();
+
+  // anonymize the child
+  await page.getByRole("navigation").getByText("Children").click();
+  await page.getByRole("cell", { name: CHILD_NAME }).click();
+  await page.locator("app-entity-actions-menu").getByRole("button").click();
+  await page.getByRole("menuitem", { name: "Anonymize" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "Yes" }).click();
+
+  // the shared note is linked to another child as well, so it is left
+  // unchanged and reported for manual review
+  await page.getByRole("dialog").getByRole("button", { name: "OK" }).click();
+
+  await expect(page.getByText("Anonymized & Archived")).toBeVisible();
+
+  // the cascade reached the note that is linked to this child only: it is
+  // archived along with being anonymized and drops out of the list, while
+  // the note shared with another child stays
+  await page.getByRole("navigation").getByText("Notes").click();
+  await expect(
+    page.getByRole("cell", { name: SUBJECT_SHARED_LINK }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("cell", { name: SUBJECT_SOLE_LINK }),
+  ).toBeHidden();
+
+  // "Partially Anonymize" does not mark the referenced record as a part of the
+  // note, so it must not reach into the user profile either - the reference is
+  // removed instead
+  await setNoteAuthorsAnonymizeMode(page, "Partially Anonymize");
+
+  await page.getByRole("navigation").getByText("Notes").click();
+  await page.getByRole("cell", { name: SUBJECT_SHARED_LINK }).click();
+  const noteDialog = page.getByRole("dialog");
+  await expect(noteDialog.getByText(LINKED_USER_NAME)).toBeVisible();
+
+  await noteDialog
+    .locator("app-entity-actions-menu")
+    .getByRole("button")
+    .click();
+  await page.getByRole("menuitem", { name: "Anonymize" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "Yes" }).click();
+
+  await expect(noteDialog.getByText(LINKED_USER_NAME)).toBeHidden();
+  await noteDialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(noteDialog).toBeHidden();
+
+  // ... while the user profile itself kept all its data
+  await page.getByRole("navigation").getByText("Admin").click();
+  await page.getByRole("navigation").getByText("Users").click();
+  await page.getByRole("cell", { name: LINKED_USER_NAME }).click();
+
+  await expect(
+    page.getByRole("heading", { name: LINKED_USER_NAME }),
+  ).toBeVisible();
+  await expect(
+    page.locator("#entity-field__phone").getByRole("textbox"),
+  ).toHaveValue(LINKED_USER_PHONE);
+  await expect(page.getByText("Anonymized & Archived")).toBeHidden();
+});

--- a/e2e/tests/anonymize.spec.ts
+++ b/e2e/tests/anonymize.spec.ts
@@ -1,4 +1,11 @@
-import { E2E_REF_DATE, expect, loadApp, Page, test } from "#e2e/fixtures.js";
+import {
+  argosScreenshot,
+  E2E_REF_DATE,
+  expect,
+  loadApp,
+  Page,
+  test,
+} from "#e2e/fixtures.js";
 import { generateChild } from "#src/app/child-dev-project/children/demo-data-generators/demo-child-generator.service.js";
 import { generateNote } from "#src/app/child-dev-project/notes/demo-data/demo-note-generator.service.js";
 import { generateUsers } from "#src/app/core/user/demo-user-generator.service.js";
@@ -10,6 +17,12 @@ const SUBJECT_SOLE_LINK = "<ANONYMIZE TEST RECORD>";
 const SUBJECT_SHARED_LINK = "<ANONYMIZE TEST SHARED RECORD>";
 const LINKED_USER_NAME = "<ANONYMIZE TEST USER>";
 const LINKED_USER_PHONE = "555-0100";
+
+// The confirmation snackbars of the preceding save and anonymize actions are
+// still on screen at the points captured below and auto-dismiss after 8s, so
+// whether they show up depends on how fast the run got there.
+const HIDE_SNACKBAR_CSS =
+  ".mat-mdc-snack-bar-container { display: none !important; }";
 
 /**
  * Set the anonymize mode of the note's user reference ("Team involved")
@@ -121,7 +134,15 @@ test("Anonymize cascades to a record's own notes but never to a linked user prof
 
   // the shared note is linked to another child as well, so it is left
   // unchanged and reported for manual review
-  await page.getByRole("dialog").getByRole("button", { name: "OK" }).click();
+  const reviewDialog = page.getByRole("dialog");
+  await expect(
+    reviewDialog.getByText("Related records may still contain personal data"),
+  ).toBeVisible();
+  await argosScreenshot(page, "anonymize-related-records-review", {
+    fullPage: false,
+    argosCSS: HIDE_SNACKBAR_CSS,
+  });
+  await reviewDialog.getByRole("button", { name: "OK" }).click();
 
   await expect(page.getByText("Anonymized & Archived")).toBeVisible();
 
@@ -154,6 +175,9 @@ test("Anonymize cascades to a record's own notes but never to a linked user prof
   await page.getByRole("dialog").getByRole("button", { name: "Yes" }).click();
 
   await expect(noteDialog.getByText(LINKED_USER_NAME)).toBeHidden();
+  await argosScreenshot(page, "note-anonymized-reference-cleared", {
+    argosCSS: HIDE_SNACKBAR_CSS,
+  });
   await noteDialog.getByRole("button", { name: "Cancel" }).click();
   await expect(noteDialog).toBeHidden();
 

--- a/src/app/core/basic-datatypes/entity/entity-reference-role.ts
+++ b/src/app/core/basic-datatypes/entity/entity-reference-role.ts
@@ -1,7 +1,9 @@
 /**
- * Specifies the role of an entity reference where
+ * Specifies the role of an entity reference, seen from the entity containing the field, where
  *    "aggregate" = "has a" relationship where both entities have meaning independent of each other;
- *    "composite" = "part of" relationship where the referenced entity should not exist without the referenced entity.
+ *    "composite" = "part of" relationship where the entity containing this field should not exist
+ *                  without the referenced entity, so that deleting or anonymizing the referenced
+ *                  entity cascades to the entity containing this field.
  *
  * Default is treated as "aggregate".
  *

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -19,7 +19,6 @@ import { inject, Injectable } from "@angular/core";
 import { StringDatatype } from "../string/string.datatype";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
 import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.service";
-import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { Logging } from "app/core/logging/logging.service";
 import { ImportProcessingContext } from "../../import/import-processing-context";
 import { splitArrayValue } from "../../import/split-array-value";
@@ -43,7 +42,6 @@ import { EntityRegistry } from "../../entity/database-entity.decorator";
 @Injectable()
 export class EntityDatatype extends StringDatatype {
   private entityMapper = inject(EntityMapperService);
-  private removeService = inject(EntityActionsService);
   private schemaService = inject(EntitySchemaService);
   private readonly entityRegistry = inject(EntityRegistry);
 
@@ -331,7 +329,12 @@ export class EntityDatatype extends StringDatatype {
   }
 
   /**
-   * Recursively calls anonymize on the referenced entity and saves it.
+   * An entity reference points to an independent record, which must not be affected
+   * by anonymizing the record that holds the reference. The reference is removed instead,
+   * as for any other datatype that does not support partial anonymization.
+   *
+   * (this overrides StringDatatype, which would otherwise retain the first character of the id)
+   *
    * @param value
    * @param schemaField
    * @param parent
@@ -340,19 +343,8 @@ export class EntityDatatype extends StringDatatype {
     value,
     schemaField: EntitySchemaField,
     parent,
-  ): Promise<string> {
-    const referencedEntity = await this.entityMapper.load(
-      schemaField.additional,
-      value,
-    );
-
-    if (!referencedEntity) {
-      // TODO: remove broken references?
-      return value;
-    }
-
-    await this.removeService.anonymize(referencedEntity);
-    return value;
+  ): Promise<string | undefined> {
+    return undefined;
   }
 
   private async loadRelatedEntitiesToString(

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -3,7 +3,6 @@ import {
   mockEntityMapperProvider,
   MockEntityMapperService,
 } from "../../entity/entity-mapper/mock-entity-mapper-service";
-import { EntityActionsService } from "../../entity/entity-actions/entity-actions.service";
 import { EntitySchemaField } from "../../entity/schema/entity-schema-field";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
 import { ImportProcessingContext } from "../../import/import-processing-context";
@@ -27,16 +26,7 @@ describe("Schema data type: entity (advanced functionality)", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [CoreTestingModule],
-      providers: [
-        EntityDatatype,
-        ...mockEntityMapperProvider([]),
-        {
-          provide: EntityActionsService,
-          useValue: {
-            anonymize: vi.fn(),
-          },
-        },
-      ],
+      providers: [EntityDatatype, ...mockEntityMapperProvider([])],
     });
     dataType = TestBed.inject(EntityDatatype);
 
@@ -92,6 +82,7 @@ describe("Schema data type: entity (advanced functionality)", () => {
     const referencedEntity = new TestEntity("ref-1");
     referencedEntity.name = "test";
     await entityMapper.saveAll([referencedEntity]);
+    vi.spyOn(entityMapper, "save");
 
     const anonymizedValue = await dataType.anonymize(
       referencedEntity.getId(),
@@ -100,9 +91,15 @@ describe("Schema data type: entity (advanced functionality)", () => {
     );
 
     expect(anonymizedValue).toBeUndefined();
-    expect(
-      entityMapper.get(TestEntity.ENTITY_TYPE, referencedEntity.getId()),
-    ).toEqual(referencedEntity);
+    // the mock entity mapper hands back the same instance it was given,
+    // so assert on the actual field values rather than object identity
+    const storedEntity = entityMapper.get(
+      TestEntity.ENTITY_TYPE,
+      referencedEntity.getId(),
+    ) as TestEntity;
+    expect(storedEntity.name).toBe("test");
+    expect(storedEntity.anonymized).toBeUndefined();
+    expect(entityMapper.save).not.toHaveBeenCalled();
   });
 
   // Orthogonal: the `additional` config accepts both the legacy plain-string form

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -88,28 +88,21 @@ describe("Schema data type: entity (advanced functionality)", () => {
     ).resolves.toBe(undefined);
   });
 
-  it("should anonymize entity recursively", async () => {
+  it("should remove the reference without anonymizing the referenced entity", async () => {
     const referencedEntity = new TestEntity("ref-1");
     referencedEntity.name = "test";
-
     await entityMapper.saveAll([referencedEntity]);
-    vi.spyOn(entityMapper, "save");
-    const removeService = TestBed.inject(EntityActionsService);
-
-    const testValue = referencedEntity.getId();
-    const testSchemaField: EntitySchemaField = {
-      additional: TestEntity.ENTITY_TYPE,
-      dataType: "entity",
-    };
 
     const anonymizedValue = await dataType.anonymize(
-      testValue,
-      testSchemaField,
+      referencedEntity.getId(),
+      { additional: TestEntity.ENTITY_TYPE, dataType: "entity" },
       null,
     );
 
-    expect(anonymizedValue).toEqual(testValue);
-    expect(removeService.anonymize).toHaveBeenCalledWith(referencedEntity);
+    expect(anonymizedValue).toBeUndefined();
+    expect(
+      entityMapper.get(TestEntity.ENTITY_TYPE, referencedEntity.getId()),
+    ).toEqual(referencedEntity);
   });
 
   // Orthogonal: the `additional` config accepts both the legacy plain-string form

--- a/src/app/core/entity/entity-actions/README.md
+++ b/src/app/core/entity/entity-actions/README.md
@@ -21,6 +21,16 @@ and - depending on their configured role - may be updated or anonymized as well.
 The logic follows the scenarios shown below:
 ![Cascading delete/anonymize scenarios](https://raw.githubusercontent.com/Aam-Digital/ndb-core/master/doc/images/cascading-delete.png)
 
+The cascade only follows records that reference the anonymized/deleted entity
+through a field with `entityReferenceRole: "composite"`,
+i.e. records that are "part of" it.
+
+It never goes the other way:
+the records that the anonymized entity references itself are always independent
+records and are left untouched (a linked user profile, for example).
+For such a field, `anonymize: "retain-anonymized"` behaves like any other
+datatype without partial anonymization and simply removes the reference.
+
 ## Data Protection & GDPR regarding anonymization / pseudonomyzation
 
 The "anonymize" function is implemented specifically for data protection rules requiring to delete personal data.

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
@@ -201,6 +201,21 @@ describe("EntityAnonymizeService", () => {
     );
   });
 
+  it("should remove entity references in an array field, as the datatype has no partial anonymization", async () => {
+    const entity = new AnonymizableEntity();
+    entity.referencesToRetainAnonymized = [
+      "AnonymizableEntity:ref-1",
+      "AnonymizableEntity:ref-2",
+    ];
+
+    await service.anonymizeEntity(entity);
+
+    AnonymizableEntity.expectAnonymized(
+      entity.getId(),
+      AnonymizableEntity.create({ referencesToRetainAnonymized: [] }),
+    );
+  });
+
   it("should partially anonymize string fields by keeping only the first character", async () => {
     const entity = new AnonymizableEntity();
     entity.retainAnonymizedText = "John";

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.spec.ts
@@ -284,6 +284,35 @@ describe("EntityAnonymizeService", () => {
     expectAllUnchangedExcept(expectedToGetAnonymized, entityMapper);
   }
 
+  it("should terminate the cascade on records referencing each other as 'composite'", async () => {
+    const a = EntityWithAnonRelations.create("A");
+    const b = EntityWithAnonRelations.create("B", {
+      refComposite: [a.getId()],
+    });
+    a.refComposite = [b.getId()];
+    await entityMapper.saveAll([a, b]);
+
+    await service.anonymizeEntity(a);
+
+    for (const id of [a.getId(), b.getId()]) {
+      expect(
+        entityMapper.get(EntityWithAnonRelations.ENTITY_TYPE, id).anonymized,
+      ).toBe(true);
+    }
+  });
+
+  it("should not anonymize an already anonymized entity again", async () => {
+    const entity = EntityWithAnonRelations.create("already anonymized");
+    entity.anonymized = true;
+    await entityMapper.saveAll([entity]);
+    vi.spyOn(entityMapper, "save");
+
+    const result = await service.anonymizeEntity(entity);
+
+    expect(entityMapper.save).not.toHaveBeenCalled();
+    expect(result.originalEntitiesBeforeChange).toEqual([]);
+  });
+
   it("should not cascade anonymize the related entity if the entity holding the reference is anonymized", async () => {
     // for direct references (e.g. x.referencesToRetainAnonymized --> recursively calls anonymize on referenced entities)
     //    see EntityDatatype & EntityArrayDatatype for unit tests

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.ts
@@ -84,11 +84,15 @@ export class EntityAnonymizeService extends CascadingEntityAction {
 
     let anonymizedValue;
     if (entity.getSchema().get(key).isArray) {
-      anonymizedValue = await Promise.all(
+      const anonymizedValues = await Promise.all(
         asArray(entity[key]).map((v) =>
           dataType.anonymize(v, entity.getSchema().get(key), entity),
         ),
       );
+      // a datatype without partial anonymization returns nothing for a value.
+      // drop those entries instead of leaving empty slots in the array,
+      // which would be stored as `null` values in the database.
+      anonymizedValue = anonymizedValues.filter((v) => v !== undefined);
     } else {
       anonymizedValue = await dataType.anonymize(
         entity[key],

--- a/src/app/core/entity/entity-actions/entity-anonymize.service.ts
+++ b/src/app/core/entity/entity-actions/entity-anonymize.service.ts
@@ -26,6 +26,16 @@ export class EntityAnonymizeService extends CascadingEntityAction {
    * @private
    */
   async anonymizeEntity(entity: Entity): Promise<CascadingActionResult> {
+    if (entity.anonymized) {
+      // nothing left to remove; this also terminates the cascade if a cycle of
+      // related records leads back to an entity that has already been processed
+      // (deletion terminates naturally, because the record is gone by then)
+      Logging.debug("Anonymize for already anonymized entity skipped", {
+        entityId: entity.getId(),
+      });
+      return new CascadingActionResult();
+    }
+
     if (!entity.getConstructor().hasPII) {
       // entity types that are generally without PII by default retain all fields
       // this should only be called through a cascade action anyway


### PR DESCRIPTION
Fixes #4320 — anonymizing a record could also anonymize a completely separate record that was only linked from it, e.g. a case record's "responsible staff member" link wiping that user's profile.

## The problem

For `dataType: "entity"`, `anonymize: "retain-anonymized"` ("Partially Anonymize") did not anonymize the *value*: `EntityDatatype.anonymize()` loaded the referenced record and ran the full anonymize action on it. So whether anonymization reached into another record was decided by a per-field **data retention** setting, while the question it answers is one about the **relationship**. An admin picking that option from the dropdown had no way to know it touched other records — and it applied to every record the cascade reached, not just the one the action was triggered on.

## The fix

A referenced record is now always treated as an independent record: the reference is removed, as for any other datatype that does not support partial anonymization — which is what the option's own description in the Admin UI promises. `EntityDatatype` no longer depends on `EntityActionsService` at all.

There is a legitimate case for the opposite behaviour (a survey response that is genuinely only a part of the record linking to it), but expressing it belongs on the relationship, not on the anonymize mode — most likely as an explicit counterpart to the existing `entityReferenceRole: "composite"`. That is deliberately left out until someone actually asks for it.

No shipped base config sets `retain-anonymized` on an entity field, so the only configurations affected are those where an admin picked "Partially Anonymize" expecting value masking — which is the bug.

## Also: a recursion guard for the cascade

`anonymizeEntity()` now returns early for a record that is already anonymized. Without it the cascade could revisit a record it had already processed, and a cycle of records referencing each other as `"composite"` recursed until the heap was exhausted (verified: removing the guard makes the new unit test run for ~140s and die with an out-of-memory error). Deletion terminates naturally in that situation because the record is gone by the time the cascade comes back around; an anonymized record stays in place with its retained references intact.

## Tests

- **Unit** (`entity.datatype_advanced.spec.ts`): anonymizing an entity reference removes the value and leaves the referenced record untouched.
- **Unit** (`entity-anonymize.service.spec.ts`): two records referencing each other as `"composite"` are both anonymized and the cascade terminates; an already anonymized record is not saved again. Note that the cycle test fails by hanging if the guard is removed, as termination tests do.
- **E2E** (`anonymize.spec.ts`): one scenario walking the whole flow through the UI — configure the note's user reference via the Admin UI, anonymize a child with two notes, assert the note belonging to that child only is cascaded into while the note shared with a second child is kept and reported for manual review, then anonymize the remaining note and assert its user reference is cleared and the linked user profile still has all its data. Both modes such a link is realistically configured with are exercised: "Remove" (`anonymize: ""`) and "Partially Anonymize".

Verified by mutation, so the assertions do not pass vacuously: restoring the old recursion makes the e2e fail (the reference survives and the user profile is anonymized).

## Notes for review

- Delete is not touched: it has no outgoing propagation at all, so nothing changes there.
- One gap from #4320 is not addressed here: `EntityAnonymizeService` still ignores `enableUserAccounts`, so anonymizing a staff profile leaves a working login attached to the emptied record, and there is no guard against doing it to your own account. `EntityDeleteService` has both.
- No Argos screenshot is added — the flow shows no UI that existing baselines do not already cover.

Related: #4316 (this cascade cannot be undone, and the "Partially Anonymize" description is wrong for entity references — the latter becomes accurate with this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymization of linked records: composite-linked records are anonymized and archived, while shared records remain unchanged for manual review.
  * References to anonymized entities are removed without altering the referenced profile’s data.
  * Prevented empty entries from appearing in anonymized list fields.
  * Repeated anonymization now safely skips records already anonymized, including cyclic relationships.
* **Documentation**
  * Clarified cascading deletion and anonymization behavior for composite and referenced relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->