### PR TITLE
fix(logging): report the HTTP status of unexpected 4XX DB responses

### DIFF
--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -2,7 +2,8 @@ import type { Mock } from "vitest";
 import { DatabaseException, PouchDatabase } from "./pouch-database";
 import PouchDB from "pouchdb-browser";
 import { HttpStatusCode } from "@angular/common/http";
-import { RemotePouchDatabase } from "./remote-pouch-database";
+import { describeResponse, RemotePouchDatabase } from "./remote-pouch-database";
+import { Logging } from "../../logging/logging.service";
 import { SyncStateSubject } from "app/core/session/session-type";
 import { environment } from "environments/environment";
 
@@ -483,6 +484,82 @@ describe("RemotePouchDatabase tests", () => {
       );
 
       expect((database as any).extractLostPermissions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("4XX logging", () => {
+    const MESSAGE = "Failed to fetch from DB with 40X error";
+    let warn: Mock;
+
+    beforeEach(() => {
+      // spy set up after the outer beforeEach, and cleared per test:
+      // vi.spyOn returns the existing spy when one is already installed
+      warn = vi.spyOn(Logging, "warn") as unknown as Mock;
+      warn.mockClear();
+    });
+
+    afterEach(() => {
+      // the shared teardown destroys the database, which fetches - leave the
+      // mock succeeding again so it does not fail on this test's 4XX response
+      (PouchDB.fetch as Mock).mockReturnValue(
+        Promise.resolve(new Response("{}", { status: HttpStatusCode.Ok })),
+      );
+    });
+
+    /** The 40X warnings logged, ignoring anything else the app logs. */
+    const warningsLogged = () =>
+      warn.mock.calls.filter(([message]) => message === MESSAGE);
+
+    const fetch4xx = async (status: number) => {
+      database.init("");
+      (PouchDB.fetch as Mock).mockReturnValue(
+        Promise.resolve(new Response("{}", { status })),
+      );
+      await (database as any).defaultFetch(
+        `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
+        { headers: {} },
+      );
+    };
+
+    it("should report the status of an unexpected 4XX, not an unserializable Response", async () => {
+      // Reproduces AAM-DIGITAL-77H: passing the Response itself logged `context: [{}]`,
+      // because a Response has no own enumerable properties - so the status,
+      // the only thing distinguishing these failures, never reached monitoring.
+      await fetch4xx(HttpStatusCode.Conflict);
+
+      const [, context] = warningsLogged()[0];
+      expect(context).toEqual(
+        expect.objectContaining({ status: HttpStatusCode.Conflict }),
+      );
+      expect(JSON.stringify(context)).toContain("409");
+    });
+
+    it("should not report expected 4XX statuses as warnings", async () => {
+      await fetch4xx(HttpStatusCode.Forbidden);
+
+      expect(warningsLogged()).toEqual([]);
+    });
+  });
+
+  describe("describeResponse", () => {
+    it("should extract fields that JSON.stringify(response) drops", () => {
+      const response = new Response("{}", {
+        status: HttpStatusCode.TooManyRequests,
+        statusText: "Too Many Requests",
+      });
+
+      // the behaviour this helper exists to work around
+      expect(JSON.stringify(response)).toBe("{}");
+
+      expect(describeResponse(response)).toEqual({
+        status: HttpStatusCode.TooManyRequests,
+        statusText: "Too Many Requests",
+        responseUrl: "",
+      });
+    });
+
+    it("should handle a missing response", () => {
+      expect(describeResponse(undefined)).toEqual({});
     });
   });
 

--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -25,6 +25,30 @@ const EXPECTED_4XX_STATUSES: number[] = [
 ];
 
 /**
+ * Extract the diagnostic fields of a fetch `Response` into a plain object.
+ *
+ * `Response` keeps its state in internal slots rather than own enumerable
+ * properties, so passing one to the logger (or to `JSON.stringify`) yields an
+ * empty object - the reported event then carries no status at all, which is the
+ * one thing needed to tell e.g. a conflict from a rate limit
+ * (see AAM-DIGITAL-77H, whose `context` reads `[{}]` for every event).
+ */
+export function describeResponse(response: Response | undefined): {
+  status?: number;
+  statusText?: string;
+  responseUrl?: string;
+} {
+  if (!response) {
+    return {};
+  }
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    responseUrl: response.url,
+  };
+}
+
+/**
  * An alternative implementation of PouchDatabase that directly makes HTTP requests to a remote CouchDB.
  */
 export class RemotePouchDatabase extends PouchDatabase {
@@ -170,7 +194,7 @@ export class RemotePouchDatabase extends PouchDatabase {
       throw new DatabaseException({
         message: "Failed to fetch from DB",
         requestedUrl: remoteUrl,
-        actualResponse: JSON.stringify(result),
+        actualResponse: JSON.stringify(describeResponse(result)),
         actualResponseBody: await result?.text(),
       });
     }
@@ -184,9 +208,15 @@ export class RemotePouchDatabase extends PouchDatabase {
       } else if (EXPECTED_4XX_STATUSES.includes(result.status)) {
         // expired session (401), permission-filtered doc (403) and missing doc (404)
         // are part of normal operation and handled by callers
-        Logging.debug("Failed to fetch from DB with 40X error", result);
+        Logging.debug(
+          "Failed to fetch from DB with 40X error",
+          describeResponse(result),
+        );
       } else {
-        Logging.warn("Failed to fetch from DB with 40X error", result);
+        Logging.warn("Failed to fetch from DB with 40X error", {
+          ...describeResponse(result),
+          requestedUrl: remoteUrl,
+        });
       }
     }
 


### PR DESCRIPTION
Filed by the automated monitoring routine (window 25 Aug 23:30Z → 26 Aug 17:40Z). Tenant identifiers are anonymised per the standing rule; the mapping is in the [`#tech-monitoring-alerts` post for this run](https://aam-digital.slack.com/archives/CKJFEJ0CD/p1787786636068299).

- closes # _(no tracking issue — filed directly as a PR per the routine's "clear, low-risk, verifiable in source" rule)_

## The problem

[AAM-DIGITAL-77H](https://aam-digital.sentry.io/issues/AAM-DIGITAL-77H) `Failed to fetch from DB with 40X error` is currently the **highest-volume frontend issue in the org** — 23 events in this window alone (37 lifetime, `escalating`, first seen 25 Aug 06:24Z), across three production tenants, all on `ndb-core@3.90.0`.

It cannot be triaged past "some 4XX", because every single event carries this:

```
### Extra Data
**context**: [
  {}
]
```

`defaultFetch` logged the fetch `Response` itself as context:

```ts
Logging.warn("Failed to fetch from DB with 40X error", result);
```

`LoggingService.logToRemoteMonitoring` puts that straight into `extra.context`, and a `Response` keeps its state in internal slots rather than own enumerable properties — so it serializes to `{}`. The status never leaves the browser.

## Why the status is the whole point here

`EXPECTED_4XX_STATUSES` already routes **401, 403 and 404** to `Logging.debug`, which is not sent to remote monitoring. So everything that reaches this `warn` is by construction a 4XX that is *not* one of those — a `409 Conflict`, a `412 Precondition Failed`, a `429`, a `400`. Those are genuinely different faults with genuinely different fixes, and the status is the only thing that separates them.

Some corroboration that this is worth distinguishing rather than a uniform background: on one tenant all 10 of its 77H events pair to the same second with [AAM-DIGITAL-6Y8](https://aam-digital.sentry.io/issues/AAM-DIGITAL-6Y8) `sync failed` (07:21:39, 07:22:09, 07:22:39, 07:23:09, 07:23:39, 09:44:17, 09:44:44, 09:45:14, 09:45:44, 09:46:18) — so at least some of this volume is a sync-path failure, and a conflict would read very differently from a rate limit. With the current logging there is no way to tell which.

## The change

- Add `describeResponse()`, which lifts `status` / `statusText` / `url` off a `Response` into a plain object, and use it for the 4XX log. The warning also gets `requestedUrl`, matching what the 5XX branch already records.
- The 5XX branch one block up had the same defect — `actualResponse: JSON.stringify(result)` on a `Response` is likewise `"{}"` — so it goes through the same helper. (It does also capture `actualResponseBody`, so it was less blind, but the field was still dead weight.)
- No control flow changes: which statuses warn, which debug, and what is thrown are all untouched. This only changes what the log carries.

`describeResponse` deliberately does not read the body — this path is on every request, and the body is already captured on the 5XX branch where it is worth the `await`.

## Testing

`npx ng test --configuration=ci --include='src/app/core/database/pouchdb/remote-pouch-database.spec.ts'` → **29/29 pass**
`--include='src/app/core/database/**/*.spec.ts'` → **119/119 pass**
`npx eslint` and `npx prettier --check` on both changed files → clean

Three tests added:
- an unexpected 4XX (409) warns with the status present, and the serialized context actually contains `409` — this fails on `master`, where it is `{}`
- an expected 4XX (403) still produces no warning
- `describeResponse` extracts what `JSON.stringify(response)` drops, asserting `JSON.stringify(response) === "{}"` alongside it so the reason the helper exists is pinned rather than just described

## PR Checklist

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — _covered by unit tests above; the change is log content only, with no reachable UI behaviour to exercise manually_
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review) — _no UI surface touched; leaving for the reviewer to decide_
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

---
_Generated by [Claude Code](https://claude.ai/code/session_019QfGs1fAPeA4Qt5XUn4m6n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for remote database errors by including response status, status text, and URL.
  - Unexpected client-side errors now generate warning logs with their status codes.
  - Expected client-side responses are no longer reported as warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->