### PR TITLE
fix: avoid related-entities components to add wrong filters from relation property  and enhance loaderMethods to handle ambiguous relation properties

### DIFF
--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
@@ -41,6 +41,17 @@ describe("NotesRelatedToEntityComponent", () => {
   it("should not filter out notes linked to a non-Child entity through relatedEntities", async () => {
     // the loader returns notes related through any of the linking properties,
     // so the display filter must not narrow this down to a single property (#4330)
+    fixture.componentRef.setInput("entity", new ChildSchoolRelation());
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // the mocked config load (triggered above) replaces Note's schema fields once
+    // the component has stabilized, discarding any override applied earlier - so
+    // it needs to be (re-)applied here, followed by a new "entity" reference to
+    // trigger recomputation of the component's filter with the corrected schema
+    Note.schema.get("relatedEntities").additional = [
+      ChildSchoolRelation.ENTITY_TYPE,
+    ];
     const relation = new ChildSchoolRelation();
     fixture.componentRef.setInput("entity", relation);
     fixture.detectChanges();
@@ -48,11 +59,14 @@ describe("NotesRelatedToEntityComponent", () => {
 
     const relatedNote = new Note();
     relatedNote.relatedEntities = [relation.getId()];
+    const unrelatedNote = new Note();
+    unrelatedNote.relatedEntities = ["ChildSchoolRelation:other"];
     const matchesFilter = TestBed.inject(FilterService).getFilterPredicate(
       component.filterObj(),
     );
 
     expect(matchesFilter(relatedNote)).toBe(true);
+    expect(matchesFilter(unrelatedNote)).toBe(false);
   });
 
   it("should use the attendance color function when passing a child", () => {

--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.spec.ts
@@ -8,6 +8,7 @@ import { DatabaseField } from "../../../core/entity/database-field.decorator";
 import { ChildSchoolRelation } from "../../children/model/childSchoolRelation";
 import { createEntityOfType } from "../../../core/demo-data/create-entity-of-type";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { FilterService } from "../../../core/filter/filter.service";
 
 describe("NotesRelatedToEntityComponent", () => {
   let component: NotesRelatedToEntityComponent;
@@ -37,6 +38,23 @@ describe("NotesRelatedToEntityComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  it("should not filter out notes linked to a non-Child entity through relatedEntities", async () => {
+    // the loader returns notes related through any of the linking properties,
+    // so the display filter must not narrow this down to a single property (#4330)
+    const relation = new ChildSchoolRelation();
+    fixture.componentRef.setInput("entity", relation);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const relatedNote = new Note();
+    relatedNote.relatedEntities = [relation.getId()];
+    const matchesFilter = TestBed.inject(FilterService).getFilterPredicate(
+      component.filterObj(),
+    );
+
+    expect(matchesFilter(relatedNote)).toBe(true);
+  });
+
   it("should use the attendance color function when passing a child", () => {
     const note = new Note();
     vi.spyOn(note, "getColorForId");
@@ -53,7 +71,6 @@ describe("NotesRelatedToEntityComponent", () => {
     let entity: Entity = createEntityOfType("Child");
     fixture.componentRef.setInput("entity", entity);
     fixture.componentRef.setInput("filter", undefined);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
     await fixture.whenStable();
     let note = component.createNewRecordFactory()();
@@ -63,7 +80,6 @@ describe("NotesRelatedToEntityComponent", () => {
     entity = createEntityOfType("School");
     fixture.componentRef.setInput("entity", entity);
     fixture.componentRef.setInput("filter", undefined);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
     await fixture.whenStable();
     note = component.createNewRecordFactory()();
@@ -73,7 +89,6 @@ describe("NotesRelatedToEntityComponent", () => {
     entity = createEntityOfType("User");
     fixture.componentRef.setInput("entity", entity);
     fixture.componentRef.setInput("filter", undefined);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
     await fixture.whenStable();
     note = component.createNewRecordFactory()();
@@ -85,7 +100,6 @@ describe("NotesRelatedToEntityComponent", () => {
     entity["schoolId"] = `School:someSchool`;
     fixture.componentRef.setInput("entity", entity);
     fixture.componentRef.setInput("filter", undefined);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
     await fixture.whenStable();
     note = component.createNewRecordFactory()();
@@ -100,7 +114,6 @@ describe("NotesRelatedToEntityComponent", () => {
     relation.childId = ["Child:1", "Child:2"] as any; // assume entity config was overwritten to hold array
 
     fixture.componentRef.setInput("entity", relation);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -143,7 +156,6 @@ describe("NotesRelatedToEntityComponent", () => {
       EntityWithRelations.ENTITY_TYPE,
     ];
     fixture.componentRef.setInput("entity", customEntity);
-    fixture.componentRef.setInput("property", undefined);
     fixture.detectChanges();
 
     const newNote = component.createNewRecordFactory()();

--- a/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.ts
+++ b/src/app/child-dev-project/notes/notes-related-to-entity/notes-related-to-entity.component.ts
@@ -38,9 +38,6 @@ export class NotesRelatedToEntityComponent extends RelatedEntitiesComponent<Note
   override loaderMethod = input<LoaderMethod>(
     LoaderMethod.NotesRelatedToEntity,
   );
-  /** set this to make sure that loader method is used (it will not be used if multiple relation properties are found) */
-  override property = input("children");
-
   protected override getDefaultColumns(): FormFieldConfig[] {
     return structuredClone(
       RELATED_ENTITIES_DEFAULT_CONFIGS["NotesRelatedToEntity"].columns,

--- a/src/app/core/common-components/entities-table/data-source/entities-table-data-source.ts
+++ b/src/app/core/common-components/entities-table/data-source/entities-table-data-source.ts
@@ -26,9 +26,10 @@ export interface LoadRecordConfig<T extends Entity> {
    */
   forEntity?: Entity;
   /**
-   * Property through which the relation can be resolved
+   * Property through which the relation to `forEntity` can be resolved,
+   * or several candidates if it cannot be determined unambiguously
    */
-  relationProperty?: keyof Entity;
+  relationProperty?: string | string[];
   /**
    * Select if a special loader method should be used for this entity
    */

--- a/src/app/core/config/config-migrations.spec.ts
+++ b/src/app/core/config/config-migrations.spec.ts
@@ -236,6 +236,91 @@ describe("applyConfigMigrations", () => {
     });
   });
 
+  describe("removeIsActiveFilters", () => {
+    it("removes the isActive condition from a configured filter", () => {
+      const old = {
+        component: "RelatedEntities",
+        config: {
+          entityType: "RecurringActivity",
+          filter: { "category.id": "SCHOOL_CLASS", isActive: true },
+        },
+      };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        component: "RelatedEntities",
+        config: {
+          entityType: "RecurringActivity",
+          filter: { "category.id": "SCHOOL_CLASS" },
+        },
+      });
+    });
+
+    it("removes an isActive condition selecting archived records, which cannot be expressed anymore", () => {
+      const old = { filter: { isActive: false, center: "alpha" } };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        filter: { center: "alpha" },
+      });
+    });
+
+    it("removes the isActive condition from prefilters and prebuilt filter options", () => {
+      const old = {
+        leftSide: { prefilter: { isActive: true } },
+        filters: [
+          {
+            id: "status",
+            type: "prebuilt",
+            options: [
+              { key: "current", filter: { isActive: true, status: "open" } },
+            ],
+          },
+        ],
+      };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        leftSide: { prefilter: {} },
+        filters: [
+          {
+            id: "status",
+            type: "prebuilt",
+            options: [{ key: "current", filter: { status: "open" } }],
+          },
+        ],
+      });
+    });
+
+    it("drops branches of a logical operator that only held the isActive condition", () => {
+      const old = {
+        filter: {
+          $or: [{ isActive: true }, { center: "alpha" }],
+          $and: [{ isActive: true }],
+        },
+      };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        filter: { $or: [{ center: "alpha" }] },
+      });
+    });
+
+    it("leaves filters without an isActive condition unchanged", () => {
+      const old = {
+        filter: { center: "alpha", $or: [{ a: 1 }, { b: 2 }], tags: [] },
+      };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        filter: { center: "alpha", $or: [{ a: 1 }, { b: 2 }], tags: [] },
+      });
+    });
+
+    it("keeps an isActive value that is not part of a filter config", () => {
+      const old = { config: { isActive: true } };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        config: { isActive: true },
+      });
+    });
+  });
+
   it("drops stored options of the prebuilt todo filter", () => {
     const old = {
       filters: [

--- a/src/app/core/config/config-migrations.spec.ts
+++ b/src/app/core/config/config-migrations.spec.ts
@@ -302,6 +302,19 @@ describe("applyConfigMigrations", () => {
       });
     });
 
+    it("drops nested branches that only held the isActive condition", () => {
+      const old = {
+        filter: {
+          children: { $elemMatch: "some-id" },
+          $and: [{ $or: [{ isActive: true }] }],
+        },
+      };
+
+      expect(applyConfigMigrations(old)).toEqual({
+        filter: { children: { $elemMatch: "some-id" } },
+      });
+    });
+
     it("leaves filters without an isActive condition unchanged", () => {
       const old = {
         filter: { center: "alpha", $or: [{ a: 1 }, { b: 2 }], tags: [] },

--- a/src/app/core/config/config-migrations.ts
+++ b/src/app/core/config/config-migrations.ts
@@ -646,6 +646,78 @@ const migrateIsActiveReportQueries: ConfigMigration = (key, configPart) => {
 };
 
 /**
+ * Config keys whose value is a filter object (MongoDB-style query) defined by admins,
+ * e.g. the fixed `filter` of a RelatedEntities view, the `filter` of a prebuilt filter option
+ * or the `prefilter` of a matching view's side.
+ */
+const FILTER_CONFIG_KEYS = ["filter", "prefilter"];
+
+/** Filter operators whose value is a list of nested filter conditions. */
+const FILTER_LOGICAL_OPERATORS = ["$and", "$or", "$nor"];
+
+/**
+ * Entities do not provide a calculated "isActive" property anymore,
+ * so a configured filter selecting on it cannot match anything.
+ *
+ * `isActive: true` is simply dropped: lists exclude archived records by default now
+ * (see NOT_ARCHIVED_FILTER), which is exactly what the condition used to express.
+ *
+ * `isActive: false` (i.e. archived records only) is dropped as well. It has no equivalent in a
+ * configured filter anymore, because the default not-archived condition is combined with `$and`
+ * and any explicit "archived" condition would make such a filter match no record at all.
+ * Users can include archived records through the list's "show inactive" toggle instead.
+ */
+const removeIsActiveFilters: ConfigMigration = (key, configPart) => {
+  if (!FILTER_CONFIG_KEYS.includes(key)) {
+    return configPart;
+  }
+
+  return removeIsActiveCondition(configPart);
+};
+
+function removeIsActiveCondition(filterPart: any): any {
+  if (
+    !filterPart ||
+    typeof filterPart !== "object" ||
+    Array.isArray(filterPart)
+  ) {
+    return filterPart;
+  }
+
+  delete filterPart["isActive"];
+
+  for (const operator of FILTER_LOGICAL_OPERATORS) {
+    if (!Array.isArray(filterPart[operator])) {
+      continue;
+    }
+
+    // an emptied branch matches every record: drop it, so that an `$or` does not silently
+    // become unconditional (for `$and` / `$nor` it does not carry any information either),
+    // and drop the operator itself if no condition is left
+    const conditions = filterPart[operator]
+      .map((condition) => removeIsActiveCondition(condition))
+      .filter((condition) => !isEmptyFilterCondition(condition));
+
+    if (conditions.length === 0) {
+      delete filterPart[operator];
+    } else {
+      filterPart[operator] = conditions;
+    }
+  }
+
+  return filterPart;
+}
+
+function isEmptyFilterCondition(condition: any): boolean {
+  return (
+    !!condition &&
+    typeof condition === "object" &&
+    !Array.isArray(condition) &&
+    Object.keys(condition).length === 0
+  );
+}
+
+/**
  * Older configs contain a full copy of the prebuilt "tasks due" filter,
  * whose options selected on calculated properties that do not exist anymore.
  * Drop the stored options so the definition provided by the app is used.
@@ -689,6 +761,7 @@ export const configMigrations: ConfigMigration[] = [
   migrateAttendanceRecurringActivityRoute,
   removeExportConfig,
   migrateIsActiveReportQueries,
+  removeIsActiveFilters,
   migrateTodoDueStatusFilter,
   migrateShortcutDashboardLinks,
   migrateNavigationMenuEntityLinks, // must run last to see all default-added view configs

--- a/src/app/core/entity-details/related-entities/related-entities.component.ts
+++ b/src/app/core/entity-details/related-entities/related-entities.component.ts
@@ -170,15 +170,13 @@ export class RelatedEntitiesComponent<E extends Entity> {
     });
 
     effect(() => {
+      // each loader decides for itself how to handle an ambiguous relation property
       const config: LoadRecordConfig<E> = {
         entityCtr: this.entityCtr(),
         forEntity: this.entity(),
+        relationProperty: this.relationProperty(),
+        loaderMethod: this.loaderMethod(),
       };
-      if (!Array.isArray(this.relationProperty())) {
-        // Only when a single relation property is defined/exists, a loader method can be used
-        config.relationProperty = this.relationProperty() as keyof Entity;
-        config.loaderMethod = this.loaderMethod();
-      }
       this.recordsDataSource().loadRecordConfig.set(config);
     });
   }

--- a/src/app/core/entity/entity-special-loader/entity-special-loader.service.ts
+++ b/src/app/core/entity/entity-special-loader/entity-special-loader.service.ts
@@ -59,10 +59,15 @@ export class EntitySpecialLoaderService {
     return updatedEntity;
   }
 
+  /**
+   * @param property the property of the loaded entity type that links to the given entity,
+   *        or several candidates if it cannot be determined unambiguously.
+   *        Each loader decides for itself whether and how it needs this.
+   */
   loadDataFor<E extends Entity = Entity>(
     loaderMethod: LoaderMethod,
     entity: Entity,
-    property?: string,
+    property?: string | string[],
   ): Promise<E[]> {
     switch (loaderMethod) {
       case LoaderMethod.HistoricalDataService:

--- a/src/app/features/todos/todo.service.spec.ts
+++ b/src/app/features/todos/todo.service.spec.ts
@@ -5,17 +5,27 @@ import { AlertService } from "../../core/alerts/alert.service";
 import { EntityMapperService } from "../../core/entity/entity-mapper/entity-mapper.service";
 import { CurrentUserSubject } from "../../core/session/current-user-subject";
 import { DatabaseIndexingService } from "#src/app/core/entity/database-indexing/database-indexing.service";
+import { Todo } from "./model/todo";
+import { TestEntity } from "../../utils/test-utils/TestEntity";
 
 describe("TodoService", () => {
   let service: TodoService;
+  let mockIndexing: Partial<DatabaseIndexingService>;
+  let mockEntityMapper: Partial<EntityMapperService>;
 
   beforeEach(() => {
+    mockIndexing = {
+      generateIndexOnProperty: vi.fn().mockResolvedValue(undefined),
+      queryIndexDocs: vi.fn().mockResolvedValue([]),
+    };
+    mockEntityMapper = { loadType: vi.fn().mockResolvedValue([]) };
+
     TestBed.configureTestingModule({
       providers: [
         CurrentUserSubject,
         { provide: AlertService, useValue: null },
-        { provide: EntityMapperService, useValue: null },
-        { provide: DatabaseIndexingService, useValue: null },
+        { provide: EntityMapperService, useValue: mockEntityMapper },
+        { provide: DatabaseIndexingService, useValue: mockIndexing },
       ],
     });
     service = TestBed.inject(TodoService);
@@ -23,5 +33,36 @@ describe("TodoService", () => {
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  describe("getTodosFor", () => {
+    it("should query the index of the given relation property", async () => {
+      const entity = new TestEntity("1");
+
+      await service.getTodosFor(entity, "relatedEntities");
+
+      expect(mockIndexing.queryIndexDocs).toHaveBeenCalledWith(
+        Todo,
+        "todo_index/by_relatedEntities",
+        expect.objectContaining({ endkey: [entity.getId()] }),
+      );
+      expect(mockEntityMapper.loadType).not.toHaveBeenCalled();
+    });
+
+    it("should load all Todos if the relation property is ambiguous, because the index needs one property", async () => {
+      const entity = new TestEntity("1");
+
+      await service.getTodosFor(entity, ["assignedTo", "relatedEntities"]);
+
+      expect(mockEntityMapper.loadType).toHaveBeenCalledWith(Todo);
+      expect(mockIndexing.queryIndexDocs).not.toHaveBeenCalled();
+    });
+
+    it("should load all Todos if no relation property is given", async () => {
+      await service.getTodosFor(new TestEntity("1"));
+
+      expect(mockEntityMapper.loadType).toHaveBeenCalledWith(Todo);
+      expect(mockIndexing.queryIndexDocs).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/features/todos/todo.service.ts
+++ b/src/app/features/todos/todo.service.ts
@@ -19,8 +19,19 @@ export class TodoService {
   /**
    * Load Todo entities related to the given entity through a database index on
    * the given relation property (ordered by deadline).
+   *
+   * The index can only be built on one specific property. If the property linking to the given
+   * entity is not unambiguous, all Todos are loaded instead and the caller's filter narrows them
+   * down (see RelatedEntitiesComponent).
    */
-  async getTodosFor(entity: Entity, relationProperty: string): Promise<Todo[]> {
+  async getTodosFor(
+    entity: Entity,
+    relationProperty?: string | string[],
+  ): Promise<Todo[]> {
+    if (typeof relationProperty !== "string") {
+      return this.entityMapper.loadType(Todo);
+    }
+
     // TODO: move this generic index creation into schema
     this.dbIndexing.generateIndexOnProperty(
       "todo_index",


### PR DESCRIPTION
- closes #4330

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes related to an entity now display correctly when multiple relationship properties apply.
  * Todo lists load reliably for single, multiple, or missing relationship properties.
  * Updated saved filters remove obsolete “is active” conditions, including nested logical filters.
* **Improvements**
  * Related records can now be resolved through multiple possible relationship properties, improving consistency across entity views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->