### PR TITLE
fix(logging): keep the dynamic component load failure as one Sentry issue

### DIFF
--- a/src/app/core/config/dynamic-components/dynamic-component.directive.spec.ts
+++ b/src/app/core/config/dynamic-components/dynamic-component.directive.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "@angular/core";
 import { DynamicComponentDirective } from "./dynamic-component.directive";
 import { ComponentRegistry } from "../../../dynamic-components";
+import { Logging } from "../../logging/logging.service";
 
 @Component({
   selector: "app-test-signal-input",
@@ -117,6 +118,27 @@ describe("DynamicComponentDirective", () => {
     expect(setInputSpy).toHaveBeenCalledWith("signalInput", 42);
     expect(typeof componentRef.instance.signalInput).toBe("function");
     expect(componentRef.instance.signalInput).not.toBe(42);
+  });
+
+  it("should log a failed component load with a static message and the error as cause", async () => {
+    const errorSpy = vi.spyOn(Logging, "error").mockImplementation(() => {});
+    const loadError = new Error("Importing a module script failed.");
+    directive.appDynamicComponent = {
+      component: "EditAge",
+      config: { id: "some-entity-id" },
+    };
+    mockRegistry.get.mockReturnValue(() => Promise.reject(loadError));
+
+    await directive.ngOnChanges();
+
+    // the message must not interpolate the component or id, otherwise every
+    // component name opens its own issue in remote monitoring
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to load dynamic component",
+      loadError,
+      { component: "EditAge", id: "some-entity-id" },
+    );
+    expect(mockContainer.createComponent).not.toHaveBeenCalled();
   });
 
   it("should skip component creation if destroyed before async load resolves", async () => {

--- a/src/app/core/config/dynamic-components/dynamic-component.directive.ts
+++ b/src/app/core/config/dynamic-components/dynamic-component.directive.ts
@@ -65,9 +65,16 @@ export class DynamicComponentDirective implements OnChanges, OnDestroy {
     try {
       component = await this.components.get(dynamicComponentConfig.component)();
     } catch (e) {
-      Logging.error({
-        message: `Failed to load dynamic component ${dynamicComponentConfig.component} for ${dynamicComponentConfig?.config?.id}`,
-        error: e,
+      // the message stays static and the varying details go into the context,
+      // so that one problem is one issue in remote monitoring: interpolating
+      // the component name here split a single failed page load across one
+      // issue per field component. Passing the caught error as context (rather
+      // than as a property of the logged object) keeps it linked as the
+      // reported error's `cause`, which is what distinguishes a chunk that
+      // could not be fetched from a component missing in the registry.
+      Logging.error("Failed to load dynamic component", e, {
+        component: dynamicComponentConfig.component,
+        id: dynamicComponentConfig?.config?.id,
       });
       // abort if component failed to load
       return;


### PR DESCRIPTION
Filed by the automated monitoring routine, window 26 Aug 23:23Z → 27 Aug 23:24Z. Tenant identifiers are anonymised per the standing rule; the mapping is in the corresponding `#tech-monitoring-alerts` post.

## What happened

At **17:51:34Z** today a single visitor loading a public intake form on Tenant B4 (iPhone / Mobile Safari 27.0 / iOS 18.7, `ndb-core@3.90.1`) produced **six error events that opened five separate Sentry issues** in the same second:

| Issue | Message |
|---|---|
| [AAM-DIGITAL-78B](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78B) | `Failed to load dynamic component DisplayDescriptionOnly for <uuid>` (×2) |
| [AAM-DIGITAL-78C](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78C) | `Failed to load dynamic component EditConfigurableEnum for undefined` |
| [AAM-DIGITAL-78D](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78D) | `Failed to load dynamic component EditPhoto for undefined` |
| [AAM-DIGITAL-78E](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78E) | `Failed to load dynamic component EditDate for undefined` |
| [AAM-DIGITAL-78F](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78F) | `Failed to load dynamic component EditAge for undefined` |

It is one fault — every field component's lazy chunk failed to load, so the form rendered without its fields — and it also generated five separate Slack alerts.

## Why it split, confirmed against `logging.service.ts`

The event carries a stack and `hint.originalException instanceof LoggedError`, so `groupSentryEvent()` routes it to `groupByErrorChain()`, which groups on the reported error's message. `normalizeErrorValue()` masks only the volatile values it recognises — urls, uuids, revs, numbers. That is why the two different entity ids in 78B *did* collapse into one issue: they matched the `<uuid>` pattern. A **component name matches none of the patterns**, so each one opened its own issue.

Second, smaller defect in the same call: the caught error was passed as a *property of the logged object* rather than as context, so `toReportedError()`'s `context.find((c) => c instanceof Error)` never found it and the `LoggedError` was built without a cause. The real root cause — `TypeError: Importing a module script failed.` — stayed in extra data instead of entering the exception chain. That matters beyond tidiness: `groupByErrorChain()` deliberately includes the root cause in the grouping key precisely so that *"a config load failing because the device is offline is a different problem from the same load failing because the user is unauthorized"*. Here it is the difference between a chunk that could not be fetched and a component genuinely missing from the registry — currently indistinguishable without opening an event.

## The change

```diff
-      Logging.error({
-        message: `Failed to load dynamic component ${dynamicComponentConfig.component} for ${dynamicComponentConfig?.config?.id}`,
-        error: e,
-      });
+      Logging.error("Failed to load dynamic component", e, {
+        component: dynamicComponentConfig.component,
+        id: dynamicComponentConfig?.config?.id,
+      });
```

This is the shape `LoggedError`'s own doc comment prescribes (`Logging.error("msg", err)`), and it matches the convention already applied in #4173, #4174, #4210 and #4308. The component name and id are not lost — they move to structured context, where they are filterable instead of being baked into the grouping key. Behaviour is otherwise unchanged: the load is still aborted and nothing is rendered.

Added a regression test asserting the message stays static and the caught error is passed as the cause.

## Verification

- `npx ng test --configuration=ci` — **2746 passed, 21 skipped, 0 failed**.
  For transparency: one earlier run of the full suite showed `keycloak-auth.service.spec.ts > should throw RemoteLoginNotAvailableError on any error when offline` failing. It passes on a clean `master` and passes on this branch on re-run, and that test manipulates `Navigator.prototype.onLine` globally — it looks like a pre-existing order-sensitive test rather than anything to do with this change, but flagging it since I saw it.
- `npx eslint` and `npx prettier --check` clean on both changed files.

## PR Checklist

- [x] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — covered by the added unit test; the production failure is reproduced by making `ComponentRegistry.get()`'s loader reject, which is what the test does
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review) — no UI change
- [ ] triggered CodeRabbit AI review
- [ ] marked each code review comment as resolved

## Related

- The underlying chunk-load failure itself is not addressed here — this PR only makes it one issue instead of five. Worth watching whether it recurs now that it groups; `3.90.1` had been deployed ~2h17m before the event, so a stale cached `index.html` referencing replaced chunk hashes is the leading hypothesis.
- #4210, #4308 — the grouping machinery this relies on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lci1NmwFmYA4wXW8sN6tQL)_