### PR TITLE
fix(logging): report DB responses by root cause, count conflicts instead of alerting

### DIFF
--- a/src/app/core/database/database-factory.service.spec.ts
+++ b/src/app/core/database/database-factory.service.spec.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { environment } from "../../../environments/environment";
 import {
@@ -58,5 +59,82 @@ describe("DatabaseFactoryService", () => {
     environment.session_type = SessionType.synced;
     const db = service.createDatabase("test-db") as SyncedPouchDatabase;
     expect(db.adapter).toBe("indexeddb");
+  });
+
+  describe("conflict tracking", () => {
+    let eventTrack: Mock;
+
+    beforeEach(() => {
+      eventTrack = vi.fn();
+      // stubbed rather than provided: AnalyticsService is resolved lazily to
+      // break a DI cycle, and importing it here would defeat that
+      vi.spyOn<any, any>(service, "getAnalyticsService").mockResolvedValue({
+        eventTrack,
+      });
+    });
+
+    it("should count a conflict as a usage event, by entity type and outcome", async () => {
+      environment.session_type = SessionType.mock;
+      const db = service.createDatabase("test-db") as PouchDatabase;
+
+      db.conflictReporter("unresolved", "Child");
+
+      await vi.waitFor(() =>
+        expect(eventTrack).toHaveBeenCalledWith("unresolved", {
+          category: "document_update_conflict",
+          label: "Child",
+        }),
+      );
+    });
+
+    it("should also track conflicts on a remote database", async () => {
+      const db = service.createRemoteDatabase(
+        "test-remote-db",
+      ) as PouchDatabase;
+
+      expect(db.conflictReporter).toBeDefined();
+      db.conflictReporter("overwritten", "Note");
+
+      await vi.waitFor(() =>
+        expect(eventTrack).toHaveBeenCalledWith("overwritten", {
+          category: "document_update_conflict",
+          label: "Note",
+        }),
+      );
+    });
+
+    it("should not fail a save when analytics is unavailable", async () => {
+      vi.spyOn<any, any>(service, "getAnalyticsService").mockResolvedValue(
+        null,
+      );
+      environment.session_type = SessionType.mock;
+      const db = service.createDatabase("test-db") as PouchDatabase;
+
+      expect(() => db.conflictReporter("unresolved", "Child")).not.toThrow();
+      await expect(
+        (service as any).trackConflict("unresolved", "Child"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should swallow an analytics failure, so counting never breaks the save", async () => {
+      eventTrack.mockImplementation(() => {
+        throw new Error("matomo unreachable");
+      });
+
+      await expect(
+        (service as any).trackConflict("unresolved", "Child"),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("should resolve analytics lazily to null when it is not available, and only once", async () => {
+    // the lazy resolution is what keeps the AnalyticsService -> ConfigService ->
+    // EntityMapperService -> DatabaseResolver -> DatabaseFactoryService cycle
+    // from being closed during bootstrap
+    const first = (service as any).getAnalyticsService();
+    const second = (service as any).getAnalyticsService();
+
+    expect(second).toBe(first);
+    await expect(first).resolves.toBeNull();
   });
 });

--- a/src/app/core/database/database-factory.service.spec.ts
+++ b/src/app/core/database/database-factory.service.spec.ts
@@ -61,69 +61,25 @@ describe("DatabaseFactoryService", () => {
     expect(db.adapter).toBe("indexeddb");
   });
 
-  describe("conflict tracking", () => {
-    let eventTrack: Mock;
-
-    beforeEach(() => {
-      eventTrack = vi.fn();
+  describe("analytics access", () => {
+    // what a database reports through it is covered by the pouch-database spec;
+    // here only the wiring matters, as a database cannot inject the service
+    it("should give a database from either entry point an analytics accessor", async () => {
+      const analytics = { eventTrack: vi.fn() };
       // stubbed rather than provided: AnalyticsService is resolved lazily to
       // break a DI cycle, and importing it here would defeat that
-      vi.spyOn<any, any>(service, "getAnalyticsService").mockResolvedValue({
-        eventTrack,
-      });
-    });
-
-    it("should count a conflict as a usage event, by entity type and outcome", async () => {
-      environment.session_type = SessionType.mock;
-      const db = service.createDatabase("test-db") as PouchDatabase;
-
-      db.conflictReporter("unresolved", "Child");
-
-      await vi.waitFor(() =>
-        expect(eventTrack).toHaveBeenCalledWith("unresolved", {
-          category: "document_update_conflict",
-          label: "Child",
-        }),
-      );
-    });
-
-    it("should also track conflicts on a remote database", async () => {
-      const db = service.createRemoteDatabase(
-        "test-remote-db",
-      ) as PouchDatabase;
-
-      expect(db.conflictReporter).toBeDefined();
-      db.conflictReporter("overwritten", "Note");
-
-      await vi.waitFor(() =>
-        expect(eventTrack).toHaveBeenCalledWith("overwritten", {
-          category: "document_update_conflict",
-          label: "Note",
-        }),
-      );
-    });
-
-    it("should not fail a save when analytics is unavailable", async () => {
       vi.spyOn<any, any>(service, "getAnalyticsService").mockResolvedValue(
-        null,
+        analytics,
       );
       environment.session_type = SessionType.mock;
-      const db = service.createDatabase("test-db") as PouchDatabase;
 
-      expect(() => db.conflictReporter("unresolved", "Child")).not.toThrow();
-      await expect(
-        (service as any).trackConflict("unresolved", "Child"),
-      ).resolves.toBeUndefined();
-    });
-
-    it("should swallow an analytics failure, so counting never breaks the save", async () => {
-      eventTrack.mockImplementation(() => {
-        throw new Error("matomo unreachable");
-      });
-
-      await expect(
-        (service as any).trackConflict("unresolved", "Child"),
-      ).resolves.toBeUndefined();
+      // easy to wire on one entry point and forget on the other
+      for (const db of [
+        service.createDatabase("test-db") as PouchDatabase,
+        service.createRemoteDatabase("test-remote-db") as PouchDatabase,
+      ]) {
+        await expect(db.analytics()).resolves.toBe(analytics);
+      }
     });
   });
 

--- a/src/app/core/database/database-factory.service.spec.ts
+++ b/src/app/core/database/database-factory.service.spec.ts
@@ -1,4 +1,3 @@
-import type { Mock } from "vitest";
 import { TestBed } from "@angular/core/testing";
 import { environment } from "../../../environments/environment";
 import {

--- a/src/app/core/database/database-factory.service.ts
+++ b/src/app/core/database/database-factory.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable, Injector, NgZone } from "@angular/core";
 import { Database } from "./database";
-import { PouchDatabase } from "./pouchdb/pouch-database";
+import { ConflictOutcome, PouchDatabase } from "./pouchdb/pouch-database";
+import type { AnalyticsService } from "../analytics/analytics.service";
 import { KeycloakAuthService } from "../session/auth/keycloak/keycloak-auth.service";
 import { environment } from "../../../environments/environment";
 import {
@@ -15,6 +16,7 @@ import { NAVIGATOR_TOKEN } from "../../utils/di-tokens";
 import { Entity } from "../entity/model/entity";
 import { AlertService } from "../alerts/alert.service";
 import { PouchdbCorruptionRecoveryService } from "./pouchdb/pouchdb-corruption-recovery.service";
+import { Logging } from "../logging/logging.service";
 
 /**
  * Provides a method to generate Database instances
@@ -32,11 +34,22 @@ export class DatabaseFactoryService {
   private readonly alertService = inject(AlertService);
   private readonly injector = inject(Injector);
 
+  private analyticsServicePromise?: Promise<AnalyticsService | null>;
+
   createDatabase(dbName: string): Database {
     // only the "primary" (app) database should manage the global login state
     const syncState =
       dbName === Entity.DATABASE ? this.syncState : new SyncStateSubject();
 
+    return this.withConflictTracking(
+      this.instantiateDatabase(dbName, syncState),
+    );
+  }
+
+  private instantiateDatabase(
+    dbName: string,
+    syncState: SyncStateSubject,
+  ): PouchDatabase {
     if (environment.session_type === SessionType.synced) {
       return new SyncedPouchDatabase(
         dbName,
@@ -78,6 +91,51 @@ export class DatabaseFactoryService {
       this.alertService,
     );
     db.init(dbName);
+    return this.withConflictTracking(db);
+  }
+
+  /**
+   * Let a database count the document update conflicts it resolves
+   * (see {@link PouchDatabase.reportConflict}).
+   */
+  private withConflictTracking(db: PouchDatabase): PouchDatabase {
+    db.conflictReporter = (outcome, entityType) => {
+      // deliberately not awaited: counting a conflict must neither delay nor
+      // fail the save that hit it, so the promise is settled inside
+      // trackConflict rather than handed back to the database layer
+      void this.trackConflict(outcome, entityType);
+    };
     return db;
+  }
+
+  private async trackConflict(outcome: ConflictOutcome, entityType: string) {
+    try {
+      const analytics = await this.getAnalyticsService();
+      analytics?.eventTrack(outcome, {
+        category: "document_update_conflict",
+        label: entityType,
+      });
+    } catch (err) {
+      Logging.debug("could not report document update conflict", err);
+    }
+  }
+
+  /**
+   * Lazily resolves AnalyticsService, so that it is only reached once a conflict
+   * actually occurs. Injecting it here would close a circular dependency at
+   * bootstrap: AnalyticsService -> ConfigService -> EntityMapperService ->
+   * DatabaseResolver -> DatabaseFactoryService.
+   * (IndexeddbMigrationService uses the same pattern for the same reason.)
+   */
+  private getAnalyticsService(): Promise<AnalyticsService | null> {
+    if (this.analyticsServicePromise === undefined) {
+      this.analyticsServicePromise = import("../analytics/analytics.service")
+        .then(({ AnalyticsService }) =>
+          this.injector.get<AnalyticsService | null>(AnalyticsService, null),
+        )
+        .catch(() => null);
+    }
+
+    return this.analyticsServicePromise;
   }
 }

--- a/src/app/core/database/database-factory.service.ts
+++ b/src/app/core/database/database-factory.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, Injector, NgZone } from "@angular/core";
 import { Database } from "./database";
-import { ConflictOutcome, PouchDatabase } from "./pouchdb/pouch-database";
+import { PouchDatabase } from "./pouchdb/pouch-database";
 import type { AnalyticsService } from "../analytics/analytics.service";
 import { KeycloakAuthService } from "../session/auth/keycloak/keycloak-auth.service";
 import { environment } from "../../../environments/environment";
@@ -16,7 +16,6 @@ import { NAVIGATOR_TOKEN } from "../../utils/di-tokens";
 import { Entity } from "../entity/model/entity";
 import { AlertService } from "../alerts/alert.service";
 import { PouchdbCorruptionRecoveryService } from "./pouchdb/pouchdb-corruption-recovery.service";
-import { Logging } from "../logging/logging.service";
 
 /**
  * Provides a method to generate Database instances
@@ -41,9 +40,7 @@ export class DatabaseFactoryService {
     const syncState =
       dbName === Entity.DATABASE ? this.syncState : new SyncStateSubject();
 
-    return this.withConflictTracking(
-      this.instantiateDatabase(dbName, syncState),
-    );
+    return this.withAnalytics(this.instantiateDatabase(dbName, syncState));
   }
 
   private instantiateDatabase(
@@ -91,38 +88,21 @@ export class DatabaseFactoryService {
       this.alertService,
     );
     db.init(dbName);
-    return this.withConflictTracking(db);
+    return this.withAnalytics(db);
   }
 
   /**
-   * Let a database count the document update conflicts it resolves
-   * (see {@link PouchDatabase.reportConflict}).
+   * Give a database access to usage analytics, which it cannot inject itself
+   * (see {@link PouchDatabase.analytics}).
    */
-  private withConflictTracking(db: PouchDatabase): PouchDatabase {
-    db.conflictReporter = (outcome, entityType) => {
-      // deliberately not awaited: counting a conflict must neither delay nor
-      // fail the save that hit it, so the promise is settled inside
-      // trackConflict rather than handed back to the database layer
-      void this.trackConflict(outcome, entityType);
-    };
+  private withAnalytics(db: PouchDatabase): PouchDatabase {
+    db.analytics = () => this.getAnalyticsService();
     return db;
   }
 
-  private async trackConflict(outcome: ConflictOutcome, entityType: string) {
-    try {
-      const analytics = await this.getAnalyticsService();
-      analytics?.eventTrack(outcome, {
-        category: "document_update_conflict",
-        label: entityType,
-      });
-    } catch (err) {
-      Logging.debug("could not report document update conflict", err);
-    }
-  }
-
   /**
-   * Lazily resolves AnalyticsService, so that it is only reached once a conflict
-   * actually occurs. Injecting it here would close a circular dependency at
+   * Lazily resolves AnalyticsService, so that it is only reached once something
+   * is actually tracked. Injecting it here would close a circular dependency at
    * bootstrap: AnalyticsService -> ConfigService -> EntityMapperService ->
    * DatabaseResolver -> DatabaseFactoryService.
    * (IndexeddbMigrationService uses the same pattern for the same reason.)

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -15,6 +15,7 @@
  *     along with ndb-core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import type { Mock } from "vitest";
 import { DatabaseException, PouchDatabase } from "./pouch-database";
 import { MemoryPouchDatabase } from "./memory-pouch-database";
 import { SyncStateSubject } from "app/core/session/session-type";
@@ -292,6 +293,42 @@ describe("PouchDatabase tests", () => {
         expect.objectContaining({ status: 409 }),
       ],
     ]);
+  });
+
+  describe("counting document update conflicts", () => {
+    const STALE = { _id: "Child:1", name: "Rudolph", _rev: "1-invalid_rev" };
+    let conflictReporter: Mock;
+
+    beforeEach(async () => {
+      conflictReporter = vi.fn();
+      database.conflictReporter = conflictReporter;
+      await database.put({ _id: "Child:1", name: "Rudolph" });
+    });
+
+    it("counts a conflict that could not be resolved, by entity type only", async () => {
+      // the document ID must not be passed on - see #4174
+      await expect(database.put({ ...STALE })).rejects.toBeInstanceOf(
+        DatabaseException,
+      );
+
+      expect(conflictReporter).toHaveBeenCalledWith("unresolved", "Child");
+    });
+
+    it("counts a conflict that was overwritten on the caller's request", async () => {
+      await database.put({ ...STALE }, true);
+
+      expect(conflictReporter).toHaveBeenCalledWith("overwritten", "Child");
+    });
+
+    it("still saves when counting the conflict fails", async () => {
+      conflictReporter.mockImplementation(() => {
+        throw new Error("analytics unavailable");
+      });
+
+      await expect(database.put({ ...STALE }, true)).resolves.toEqual(
+        expect.objectContaining({ ok: true }),
+      );
+    });
   });
 
   it("should correctly determine if database is empty", async () => {

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -298,33 +298,51 @@ describe("PouchDatabase tests", () => {
 
   describe("counting document update conflicts", () => {
     const STALE = { _id: "Child:1", name: "Rudolph", _rev: "1-invalid_rev" };
-    let conflictReporter: Mock;
+    let eventTrack: Mock;
+
+    /** The tracked events, once analytics has resolved asynchronously. */
+    const tracked = () =>
+      vi.waitFor(() => {
+        expect(eventTrack).toHaveBeenCalled();
+        return eventTrack.mock.calls;
+      });
 
     beforeEach(async () => {
-      conflictReporter = vi.fn();
-      database.conflictReporter = conflictReporter;
+      eventTrack = vi.fn();
+      database.analytics = () => Promise.resolve({ eventTrack } as any);
       await database.put({ _id: "Child:1", name: "Rudolph" });
     });
 
     it("counts a conflict that could not be resolved, by entity type only", async () => {
-      // the document ID must not be passed on - see #4174
       await expect(database.put({ ...STALE })).rejects.toBeInstanceOf(
         DatabaseException,
       );
 
-      expect(conflictReporter).toHaveBeenCalledWith("unresolved", "Child");
+      // the document ID must never be reported - see #4174
+      expect(await tracked()).toEqual([
+        [
+          "unresolved",
+          { category: "document_update_conflict", label: "Child" },
+        ],
+      ]);
     });
 
     it("counts a conflict that was overwritten on the caller's request", async () => {
       await database.put({ ...STALE }, true);
 
-      expect(conflictReporter).toHaveBeenCalledWith("overwritten", "Child");
+      expect((await tracked())[0][0]).toBe("overwritten");
+    });
+
+    it("still saves when analytics is unavailable", async () => {
+      database.analytics = () => Promise.resolve(null);
+
+      await expect(database.put({ ...STALE }, true)).resolves.toEqual(
+        expect.objectContaining({ ok: true }),
+      );
     });
 
     it("still saves when counting the conflict fails", async () => {
-      conflictReporter.mockImplementation(() => {
-        throw new Error("analytics unavailable");
-      });
+      database.analytics = () => Promise.reject(new Error("analytics is down"));
 
       await expect(database.put({ ...STALE }, true)).resolves.toEqual(
         expect.objectContaining({ ok: true }),
@@ -338,7 +356,7 @@ describe("PouchDatabase tests", () => {
       // the batch still rejects, so the caller is not left thinking it saved
       await expect(database.putAll([{ ...STALE }])).rejects.toBeTruthy();
 
-      expect(conflictReporter).toHaveBeenCalledWith("unresolved", "Child");
+      expect((await tracked())[0][0]).toBe("unresolved");
       expect(
         warn.mock.calls.filter(
           ([message]) => message === "error during putAll",

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -19,6 +19,7 @@ import type { Mock } from "vitest";
 import { DatabaseException, PouchDatabase } from "./pouch-database";
 import { MemoryPouchDatabase } from "./memory-pouch-database";
 import { SyncStateSubject } from "app/core/session/session-type";
+import { Logging } from "../../logging/logging.service";
 
 describe("PouchDatabase tests", () => {
   let database: PouchDatabase;
@@ -328,6 +329,21 @@ describe("PouchDatabase tests", () => {
       await expect(database.put({ ...STALE }, true)).resolves.toEqual(
         expect.objectContaining({ ok: true }),
       );
+    });
+
+    it("counts a conflict during putAll without alerting on it", async () => {
+      const warn = vi.spyOn(Logging, "warn") as unknown as Mock;
+      warn.mockClear();
+
+      // the batch still rejects, so the caller is not left thinking it saved
+      await expect(database.putAll([{ ...STALE }])).rejects.toBeTruthy();
+
+      expect(conflictReporter).toHaveBeenCalledWith("unresolved", "Child");
+      expect(
+        warn.mock.calls.filter(
+          ([message]) => message === "error during putAll",
+        ),
+      ).toEqual([]);
     });
   });
 

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -333,6 +333,32 @@ describe("PouchDatabase tests", () => {
       expect((await tracked())[0][0]).toBe("overwritten");
     });
 
+    it("does not count a conflict when the write that would resolve it fails", async () => {
+      // the overwrite can conflict again (another writer got in between), and
+      // then the retry reports its own outcome - counting up front would count
+      // a save that never happened, and count one conflict twice
+      const pouchDB = (database as any).pouchDB;
+      const realPut = pouchDB.put.bind(pouchDB);
+      let puts = 0;
+      vi.spyOn(pouchDB, "put").mockImplementation(
+        (doc: any, ...rest: any[]) => {
+          puts++;
+          // 1st is the caller's forced put (conflicts), 2nd the overwrite attempt
+          return puts === 2
+            ? Promise.reject(Object.assign(new Error("nope"), { status: 500 }))
+            : realPut(doc, ...rest);
+        },
+      );
+
+      await expect(database.put({ ...STALE }, true)).rejects.toBeInstanceOf(
+        DatabaseException,
+      );
+
+      // analytics resolves asynchronously, so give it the chance to be called
+      await new Promise((resolve) => setTimeout(resolve));
+      expect(eventTrack).not.toHaveBeenCalled();
+    });
+
     it("still saves when analytics is unavailable", async () => {
       database.analytics = () => Promise.resolve(null);
 

--- a/src/app/core/database/pouchdb/pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/pouch-database.spec.ts
@@ -359,6 +359,37 @@ describe("PouchDatabase tests", () => {
       expect(eventTrack).not.toHaveBeenCalled();
     });
 
+    it("counts a conflict once, not twice, when the overwrite conflicts again", async () => {
+      // the retry reports "unresolved" itself, so reporting "overwritten" up
+      // front would count the same conflict under two outcomes
+      const pouchDB = (database as any).pouchDB;
+      const realPut = pouchDB.put.bind(pouchDB);
+      let puts = 0;
+      vi.spyOn(pouchDB, "put").mockImplementation(
+        (doc: any, ...rest: any[]) => {
+          puts++;
+          // another writer wins the race on the overwrite attempt too
+          return puts === 2
+            ? Promise.reject(
+                Object.assign(new Error("conflict"), { status: 409 }),
+              )
+            : realPut(doc, ...rest);
+        },
+      );
+
+      await expect(database.put({ ...STALE }, true)).rejects.toBeInstanceOf(
+        DatabaseException,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve));
+      expect(eventTrack.mock.calls).toEqual([
+        [
+          "unresolved",
+          { category: "document_update_conflict", label: "Child" },
+        ],
+      ]);
+    });
+
     it("still saves when analytics is unavailable", async () => {
       database.analytics = () => Promise.resolve(null);
 

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -12,6 +12,8 @@ import { environment } from "environments/environment";
 import { SyncState } from "app/core/session/session-states/sync-state.enum";
 import { SyncStateSubject } from "app/core/session/session-type";
 import { NotificationEvent } from "#src/app/features/notification/model/notification-event";
+// type-only, so the database layer gains no runtime dependency on analytics
+import type { AnalyticsService } from "../../analytics/analytics.service";
 
 // Register the newer "indexeddb" adapter alongside the default "idb" adapter
 PouchDB.plugin(indexeddbAdapter);
@@ -63,13 +65,15 @@ export class PouchDatabase extends Database {
   adapter: string = "indexeddb";
 
   /**
-   * Optional hook to count document update conflicts in usage statistics
-   * (see {@link reportConflict}).
+   * Optional accessor for usage analytics (see {@link reportConflict}).
    *
    * Assigned by `DatabaseFactoryService` rather than injected: the database
-   * classes are constructed manually and have no access to Angular DI.
+   * classes are constructed manually and have no access to Angular DI. It
+   * resolves lazily, and only once something is actually tracked, so that
+   * bootstrap never closes the cycle AnalyticsService -> ConfigService ->
+   * EntityMapperService -> DatabaseResolver -> DatabaseFactoryService.
    */
-  conflictReporter?: (outcome: ConflictOutcome, entityType: string) => void;
+  analytics?: () => Promise<AnalyticsService | null>;
 
   constructor(
     dbName: string,
@@ -569,17 +573,24 @@ export class PouchDatabase extends Database {
    * rejected is told so by the form that attempted it, so nothing is silently
    * swallowed here.
    *
-   * Only the entity type is passed on, never the document ID: the point is to
+   * Only the entity type is reported, never the document ID: the point is to
    * see which record types collide, and record identifiers have no place in
    * monitoring (see #4174).
+   *
+   * Deliberately not awaited by its callers, and total: counting a conflict must
+   * neither delay a save nor be the reason one fails.
    */
   private reportConflict(outcome: ConflictOutcome, docId: string) {
-    try {
-      this.conflictReporter?.(outcome, docId?.split(":")[0]);
-    } catch (err) {
-      // counting a conflict must never be the reason a save fails
-      Logging.debug("could not report document update conflict", err);
-    }
+    this.analytics?.()
+      .then((analytics) =>
+        analytics?.eventTrack(outcome, {
+          category: "document_update_conflict",
+          label: docId?.split(":")[0],
+        }),
+      )
+      .catch((err) =>
+        Logging.debug("could not report document update conflict", err),
+      );
   }
 
   private mergeObjects(_existingObject: any, _newObject: any) {

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -233,11 +233,20 @@ export class PouchDatabase extends Database {
           forceOverwrite,
           result,
         ).catch((e) => {
-          Logging.warn(
-            "error during putAll",
-            e,
-            objects.map((x) => x._id),
-          );
+          if (e?.status === HttpStatusCode.Conflict) {
+            // counted by reportConflict and still returned to the caller below,
+            // so alerting on it here would only repeat what the single-document
+            // path deliberately stopped reporting
+            Logging.debug("could not resolve conflict during putAll", e);
+          } else {
+            Logging.warn("error during putAll", e, {
+              // entity types only - a list of document IDs has no place in
+              // remote monitoring (see #4174)
+              entityTypes: [
+                ...new Set(objects.map((x) => x._id?.split(":")[0])),
+              ],
+            });
+          }
           return new DatabaseException(e);
         });
       }

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -18,6 +18,12 @@ PouchDB.plugin(indexeddbAdapter);
 PouchDB.plugin(pouchdbFind);
 
 /**
+ * What happened to a document whose update was rejected as a conflict
+ * (see {@link PouchDatabase.resolveConflict}).
+ */
+export type ConflictOutcome = "merged" | "overwritten" | "unresolved";
+
+/**
  * Wrapper for a PouchDB instance to decouple the code from
  * that external library.
  *
@@ -55,6 +61,15 @@ export class PouchDatabase extends Database {
    * Default: "indexeddb" (the newer adapter). Use "idb" for the legacy adapter.
    */
   adapter: string = "indexeddb";
+
+  /**
+   * Optional hook to count document update conflicts in usage statistics
+   * (see {@link reportConflict}).
+   *
+   * Assigned by `DatabaseFactoryService` rather than injected: the database
+   * classes are constructed manually and have no access to Angular DI.
+   */
+  conflictReporter?: (outcome: ConflictOutcome, entityType: string) => void;
 
   constructor(
     dbName: string,
@@ -515,19 +530,46 @@ export class PouchDatabase extends Database {
       Logging.debug(
         "resolved document conflict automatically (" + resolvedObject._id + ")",
       );
+      this.reportConflict("merged", newObject._id);
       return this.put(resolvedObject);
     } else if (overwriteChanges) {
       Logging.debug(
         "overwriting conflicting document version (" + newObject._id + ")",
       );
+      this.reportConflict("overwritten", newObject._id);
       newObject._rev = existingObject._rev;
       return this.put(newObject);
     } else {
+      this.reportConflict("unresolved", newObject._id);
       // the document's ID is passed as entityId rather than appended to the
       // message: remote monitoring groups by message, so an ID in there would
       // fragment one recurring problem into a separate issue per document
       existingError.message = `${existingError.message} (unable to resolve)`;
       throw new DatabaseException(existingError, newObject._id);
+    }
+  }
+
+  /**
+   * Count a document update conflict in usage statistics.
+   *
+   * Two users editing the same record is normal operation for an offline-first
+   * app, not a fault, so conflicts are counted rather than reported as errors:
+   * how often they happen (and for which record types) is the signal worth
+   * having, while an alert per occurrence only buries the failures that do need
+   * attention - which is what happened in AAM-DIGITAL-77H. A user whose save was
+   * rejected is told so by the form that attempted it, so nothing is silently
+   * swallowed here.
+   *
+   * Only the entity type is passed on, never the document ID: the point is to
+   * see which record types collide, and record identifiers have no place in
+   * monitoring (see #4174).
+   */
+  private reportConflict(outcome: ConflictOutcome, docId: string) {
+    try {
+      this.conflictReporter?.(outcome, docId?.split(":")[0]);
+    } catch (err) {
+      // counting a conflict must never be the reason a save fails
+      Logging.debug("could not report document update conflict", err);
     }
   }
 

--- a/src/app/core/database/pouchdb/pouch-database.ts
+++ b/src/app/core/database/pouchdb/pouch-database.ts
@@ -543,15 +543,18 @@ export class PouchDatabase extends Database {
       Logging.debug(
         "resolved document conflict automatically (" + resolvedObject._id + ")",
       );
+      // counted only once the write actually went through - see reportConflict
+      const result = await this.put(resolvedObject);
       this.reportConflict("merged", newObject._id);
-      return this.put(resolvedObject);
+      return result;
     } else if (overwriteChanges) {
       Logging.debug(
         "overwriting conflicting document version (" + newObject._id + ")",
       );
-      this.reportConflict("overwritten", newObject._id);
       newObject._rev = existingObject._rev;
-      return this.put(newObject);
+      const result = await this.put(newObject);
+      this.reportConflict("overwritten", newObject._id);
+      return result;
     } else {
       this.reportConflict("unresolved", newObject._id);
       // the document's ID is passed as entityId rather than appended to the
@@ -579,6 +582,11 @@ export class PouchDatabase extends Database {
    *
    * Deliberately not awaited by its callers, and total: counting a conflict must
    * neither delay a save nor be the reason one fails.
+   *
+   * `merged` and `overwritten` are reported only after the write that resolved
+   * the conflict succeeded. That write can conflict again (another writer got in
+   * between), in which case the retry reports its own outcome - so reporting up
+   * front would count a save that never happened, and count one conflict twice.
    */
   private reportConflict(outcome: ConflictOutcome, docId: string) {
     this.analytics?.()

--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -2,7 +2,7 @@ import type { Mock } from "vitest";
 import { DatabaseException, PouchDatabase } from "./pouch-database";
 import PouchDB from "pouchdb-browser";
 import { HttpStatusCode } from "@angular/common/http";
-import { describeResponse, RemotePouchDatabase } from "./remote-pouch-database";
+import { RemotePouchDatabase } from "./remote-pouch-database";
 import { Logging } from "../../logging/logging.service";
 import { SyncStateSubject } from "app/core/session/session-type";
 import { environment } from "environments/environment";
@@ -538,24 +538,22 @@ describe("RemotePouchDatabase tests", () => {
       expect(JSON.stringify(context)).toContain("400");
     });
 
-    it("should name the status in the message, so that monitoring reports one issue per root cause", async () => {
-      // a number would be masked away by the monitoring service's grouping,
-      // merging unrelated failures back into a single issue
+    it("should report each status under its own message, so monitoring separates the root causes", async () => {
+      // the wording itself is covered by the http-response-logging spec; what
+      // matters here is that two statuses do not end up in one bucket
       await fetch4xx(HttpStatusCode.BadRequest);
       await fetch4xx(HttpStatusCode.TooManyRequests);
 
-      expect(warningsLogged().map(([message]) => message)).toEqual([
-        "Unexpected DB response: bad request",
-        "Unexpected DB response: too many requests",
-      ]);
+      const [first, second] = warningsLogged().map(([message]) => message);
+      expect(first).not.toEqual(second);
     });
 
-    it("should collect statuses without a name into one bucket, keeping the number in the context", async () => {
+    it("should keep the numeric status in the context of an unnamed 4XX", async () => {
       await fetch4xx(423); // Locked - not one we expect from CouchDB
 
-      const [message, context] = warningsLogged()[0];
-      expect(message).toBe("Unexpected DB response: unnamed client error");
-      expect(context).toEqual(expect.objectContaining({ status: 423 }));
+      expect(warningsLogged()[0][1]).toEqual(
+        expect.objectContaining({ status: 423 }),
+      );
     });
 
     it("should not report expected 4XX statuses as warnings", async () => {
@@ -571,41 +569,6 @@ describe("RemotePouchDatabase tests", () => {
       await fetch4xx(HttpStatusCode.Conflict, "PUT");
 
       expect(warningsLogged()).toEqual([]);
-    });
-  });
-
-  describe("describeResponse", () => {
-    it("should extract fields that JSON.stringify(response) drops", () => {
-      const response = new Response("{}", {
-        status: HttpStatusCode.TooManyRequests,
-        statusText: "Too Many Requests",
-      });
-
-      // the behaviour this helper exists to work around
-      expect(JSON.stringify(response)).toBe("{}");
-
-      expect(describeResponse(response)).toEqual({
-        status: HttpStatusCode.TooManyRequests,
-        statusText: "Too Many Requests",
-        responseUrl: "",
-      });
-    });
-
-    it("should include the request method, which the Response does not carry", () => {
-      // without it a status cannot be classified: a 409 on a PUT is a rejected
-      // save, on a replication checkpoint it is internal housekeeping
-      expect(
-        describeResponse(
-          new Response("{}", { status: HttpStatusCode.Conflict }),
-          "PUT",
-        ),
-      ).toEqual(expect.objectContaining({ method: "PUT" }));
-    });
-
-    it("should handle a missing response", () => {
-      expect(describeResponse(undefined)).toEqual({});
-      // a write that never got a response is the case most in need of the method
-      expect(describeResponse(undefined, "PUT")).toEqual({ method: "PUT" });
     });
   });
 

--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -488,7 +488,6 @@ describe("RemotePouchDatabase tests", () => {
   });
 
   describe("4XX logging", () => {
-    const MESSAGE = "Failed to fetch from DB with 40X error";
     let warn: Mock;
 
     beforeEach(() => {
@@ -506,36 +505,62 @@ describe("RemotePouchDatabase tests", () => {
       );
     });
 
-    /** The 40X warnings logged, ignoring anything else the app logs. */
+    /** The DB response warnings logged, ignoring anything else the app logs. */
     const warningsLogged = () =>
-      warn.mock.calls.filter(([message]) => message === MESSAGE);
+      warn.mock.calls.filter(([message]) =>
+        String(message).startsWith("Unexpected DB response"),
+      );
 
-    const fetch4xx = async (status: number) => {
+    const fetch4xx = async (status: number, method?: string) => {
       database.init("");
       (PouchDB.fetch as Mock).mockReturnValue(
         Promise.resolve(new Response("{}", { status })),
       );
       await (database as any).defaultFetch(
         `${environment.DB_PROXY_PREFIX}/unit-test-db/Entity:ABC`,
-        { headers: {} },
+        { headers: {}, method },
       );
     };
 
-    it("should report the status of an unexpected 4XX, not an unserializable Response", async () => {
+    it("should report the status and method of an unexpected 4XX, not an unserializable Response", async () => {
       // Reproduces AAM-DIGITAL-77H: passing the Response itself logged `context: [{}]`,
       // because a Response has no own enumerable properties - so the status,
       // the only thing distinguishing these failures, never reached monitoring.
-      await fetch4xx(HttpStatusCode.Conflict);
+      await fetch4xx(HttpStatusCode.BadRequest);
 
       const [, context] = warningsLogged()[0];
       expect(context).toEqual(
-        expect.objectContaining({ status: HttpStatusCode.Conflict }),
+        expect.objectContaining({
+          status: HttpStatusCode.BadRequest,
+          method: "GET",
+        }),
       );
-      expect(JSON.stringify(context)).toContain("409");
+      expect(JSON.stringify(context)).toContain("400");
+    });
+
+    it("should name the status in the message, so that monitoring reports one issue per root cause", async () => {
+      // a number would be masked away by the monitoring service's grouping,
+      // merging unrelated failures back into a single issue
+      await fetch4xx(HttpStatusCode.BadRequest);
+      await fetch4xx(HttpStatusCode.TooManyRequests);
+
+      expect(warningsLogged().map(([message]) => message)).toEqual([
+        "Unexpected DB response: bad request",
+        "Unexpected DB response: too many requests",
+      ]);
     });
 
     it("should not report expected 4XX statuses as warnings", async () => {
       await fetch4xx(HttpStatusCode.Forbidden);
+
+      expect(warningsLogged()).toEqual([]);
+    });
+
+    it("should not report a conflict as a warning, as only the caller knows its outcome", async () => {
+      // a 409 is always surfaced to whoever made the write - either
+      // PouchDatabase.resolveConflict or PouchDB's own replication - so warning
+      // here alerts on something nobody can act on
+      await fetch4xx(HttpStatusCode.Conflict, "PUT");
 
       expect(warningsLogged()).toEqual([]);
     });
@@ -558,8 +583,21 @@ describe("RemotePouchDatabase tests", () => {
       });
     });
 
+    it("should include the request method, which the Response does not carry", () => {
+      // without it a status cannot be classified: a 409 on a PUT is a rejected
+      // save, on a replication checkpoint it is internal housekeeping
+      expect(
+        describeResponse(
+          new Response("{}", { status: HttpStatusCode.Conflict }),
+          "PUT",
+        ),
+      ).toEqual(expect.objectContaining({ method: "PUT" }));
+    });
+
     it("should handle a missing response", () => {
       expect(describeResponse(undefined)).toEqual({});
+      // a write that never got a response is the case most in need of the method
+      expect(describeResponse(undefined, "PUT")).toEqual({ method: "PUT" });
     });
   });
 

--- a/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.spec.ts
@@ -550,6 +550,14 @@ describe("RemotePouchDatabase tests", () => {
       ]);
     });
 
+    it("should collect statuses without a name into one bucket, keeping the number in the context", async () => {
+      await fetch4xx(423); // Locked - not one we expect from CouchDB
+
+      const [message, context] = warningsLogged()[0];
+      expect(message).toBe("Unexpected DB response: unnamed client error");
+      expect(context).toEqual(expect.objectContaining({ status: 423 }));
+    });
+
     it("should not report expected 4XX statuses as warnings", async () => {
       await fetch4xx(HttpStatusCode.Forbidden);
 

--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -12,6 +12,10 @@ import { exhaustMap, takeUntil } from "rxjs/operators";
 import { AlertService } from "../../alerts/alert.service";
 import { isVersionNewer } from "./version-comparison.utils";
 import { isConnectivityError } from "#src/app/utils/connectivity-error";
+import {
+  describeResponse,
+  unexpectedResponseMessage,
+} from "../../logging/http-response-logging";
 
 /**
  * 4XX statuses that occur during normal operation
@@ -24,83 +28,9 @@ const EXPECTED_4XX_STATUSES: number[] = [
   HttpStatusCode.NotFound,
 ];
 
-/**
- * Names for the 4XX statuses that are reported to remote monitoring.
- *
- * Remote monitoring groups a reported message by its normalized text, and that
- * normalization masks numbers (see `fingerprintKey` in the logging service). A
- * status interpolated as a number would therefore collapse every unexpected
- * response into one issue - which is exactly the mixed bucket this replaces: in
- * AAM-DIGITAL-77H a rejected write, a malformed query and a replication
- * checkpoint read were all reported under one title, so none of them could be
- * told apart or triaged. Naming the status keeps the message text static (as the
- * logging conventions require) while giving each root cause its own issue and a
- * title that says what actually happened.
- */
-const UNEXPECTED_STATUS_NAMES: Record<number, string> = {
-  [HttpStatusCode.BadRequest]: "bad request",
-  [HttpStatusCode.MethodNotAllowed]: "method not allowed",
-  [HttpStatusCode.NotAcceptable]: "not acceptable",
-  [HttpStatusCode.PreconditionFailed]: "precondition failed",
-  [HttpStatusCode.PayloadTooLarge]: "payload too large",
-  [HttpStatusCode.UnsupportedMediaType]: "unsupported media type",
-  [HttpStatusCode.TooManyRequests]: "too many requests",
-};
-
-/**
- * The message reported for an unexpected 4XX response from the database.
- *
- * Deliberately does not mention "fetch": the same code path carries reads and
- * writes, and calling a rejected write a failed fetch is what sent the first
- * analysis of AAM-DIGITAL-77H down the wrong path.
- *
- * A status without a name falls into one shared bucket - digit-free so that it
- * is not mangled by the number masking described on {@link UNEXPECTED_STATUS_NAMES} -
- * and still carries the numeric status in the logged context.
- */
-function unexpectedResponseMessage(status: number): string {
-  return `Unexpected DB response: ${UNEXPECTED_STATUS_NAMES[status] ?? "unnamed client error"}`;
-}
-
 /** The HTTP method of a fetch request, defaulting the way `fetch` itself does. */
 function requestMethod(opts: RequestInit | undefined): string {
   return (opts?.method ?? "GET").toUpperCase();
-}
-
-/**
- * Extract the diagnostic fields of a fetch `Response` into a plain object.
- *
- * `Response` keeps its state in internal slots rather than own enumerable
- * properties, so passing one to the logger (or to `JSON.stringify`) yields an
- * empty object - the reported event then carries no status at all, which is the
- * one thing needed to tell e.g. a conflict from a rate limit
- * (see AAM-DIGITAL-77H, whose `context` reads `[{}]` for every event).
- *
- * The `method` is not part of the `Response` and has to be passed in, but it
- * decides how a report should be read: the same status means different things
- * for a read and for a write (a 409 on a `PUT` is a rejected save, on a
- * `_local` checkpoint it is replication housekeeping), so without it an event
- * cannot be classified at all - which is why the AAM-DIGITAL-77H events from
- * before this was recorded remain unclassifiable.
- */
-export function describeResponse(
-  response: Response | undefined,
-  method?: string,
-): {
-  method?: string;
-  status?: number;
-  statusText?: string;
-  responseUrl?: string;
-} {
-  if (!response) {
-    return { method };
-  }
-  return {
-    method,
-    status: response.status,
-    statusText: response.statusText,
-    responseUrl: response.url,
-  };
 }
 
 /**

--- a/src/app/core/database/pouchdb/remote-pouch-database.ts
+++ b/src/app/core/database/pouchdb/remote-pouch-database.ts
@@ -25,6 +25,49 @@ const EXPECTED_4XX_STATUSES: number[] = [
 ];
 
 /**
+ * Names for the 4XX statuses that are reported to remote monitoring.
+ *
+ * Remote monitoring groups a reported message by its normalized text, and that
+ * normalization masks numbers (see `fingerprintKey` in the logging service). A
+ * status interpolated as a number would therefore collapse every unexpected
+ * response into one issue - which is exactly the mixed bucket this replaces: in
+ * AAM-DIGITAL-77H a rejected write, a malformed query and a replication
+ * checkpoint read were all reported under one title, so none of them could be
+ * told apart or triaged. Naming the status keeps the message text static (as the
+ * logging conventions require) while giving each root cause its own issue and a
+ * title that says what actually happened.
+ */
+const UNEXPECTED_STATUS_NAMES: Record<number, string> = {
+  [HttpStatusCode.BadRequest]: "bad request",
+  [HttpStatusCode.MethodNotAllowed]: "method not allowed",
+  [HttpStatusCode.NotAcceptable]: "not acceptable",
+  [HttpStatusCode.PreconditionFailed]: "precondition failed",
+  [HttpStatusCode.PayloadTooLarge]: "payload too large",
+  [HttpStatusCode.UnsupportedMediaType]: "unsupported media type",
+  [HttpStatusCode.TooManyRequests]: "too many requests",
+};
+
+/**
+ * The message reported for an unexpected 4XX response from the database.
+ *
+ * Deliberately does not mention "fetch": the same code path carries reads and
+ * writes, and calling a rejected write a failed fetch is what sent the first
+ * analysis of AAM-DIGITAL-77H down the wrong path.
+ *
+ * A status without a name falls into one shared bucket - digit-free so that it
+ * is not mangled by the number masking described on {@link UNEXPECTED_STATUS_NAMES} -
+ * and still carries the numeric status in the logged context.
+ */
+function unexpectedResponseMessage(status: number): string {
+  return `Unexpected DB response: ${UNEXPECTED_STATUS_NAMES[status] ?? "unnamed client error"}`;
+}
+
+/** The HTTP method of a fetch request, defaulting the way `fetch` itself does. */
+function requestMethod(opts: RequestInit | undefined): string {
+  return (opts?.method ?? "GET").toUpperCase();
+}
+
+/**
  * Extract the diagnostic fields of a fetch `Response` into a plain object.
  *
  * `Response` keeps its state in internal slots rather than own enumerable
@@ -32,16 +75,28 @@ const EXPECTED_4XX_STATUSES: number[] = [
  * empty object - the reported event then carries no status at all, which is the
  * one thing needed to tell e.g. a conflict from a rate limit
  * (see AAM-DIGITAL-77H, whose `context` reads `[{}]` for every event).
+ *
+ * The `method` is not part of the `Response` and has to be passed in, but it
+ * decides how a report should be read: the same status means different things
+ * for a read and for a write (a 409 on a `PUT` is a rejected save, on a
+ * `_local` checkpoint it is replication housekeeping), so without it an event
+ * cannot be classified at all - which is why the AAM-DIGITAL-77H events from
+ * before this was recorded remain unclassifiable.
  */
-export function describeResponse(response: Response | undefined): {
+export function describeResponse(
+  response: Response | undefined,
+  method?: string,
+): {
+  method?: string;
   status?: number;
   statusText?: string;
   responseUrl?: string;
 } {
   if (!response) {
-    return {};
+    return { method };
   }
   return {
+    method,
     status: response.status,
     statusText: response.statusText,
     responseUrl: response.url,
@@ -188,19 +243,22 @@ export class RemotePouchDatabase extends PouchDatabase {
       }
     }
 
+    const method = requestMethod(opts);
+
     if (!result || result.status >= 500) {
       Logging.debug("Actual DB Fetch response", result);
       Logging.debug("navigator.onLine", navigator.onLine);
       throw new DatabaseException({
         message: "Failed to fetch from DB",
         requestedUrl: remoteUrl,
-        actualResponse: JSON.stringify(describeResponse(result)),
+        actualResponse: JSON.stringify(describeResponse(result, method)),
         actualResponseBody: await result?.text(),
       });
     }
 
     // additional output for debugging
     if (result?.status >= 400) {
+      const response = describeResponse(result, method);
       if (this.isNotificationsDatabase() && result.status === 404) {
         Logging.debug(
           "Notifications database not found (404) - may be expected",
@@ -208,13 +266,23 @@ export class RemotePouchDatabase extends PouchDatabase {
       } else if (EXPECTED_4XX_STATUSES.includes(result.status)) {
         // expired session (401), permission-filtered doc (403) and missing doc (404)
         // are part of normal operation and handled by callers
-        Logging.debug(
-          "Failed to fetch from DB with 40X error",
-          describeResponse(result),
-        );
+        Logging.debug("Expected 4XX response from DB", response);
+      } else if (result.status === HttpStatusCode.Conflict) {
+        // A 409 is CouchDB rejecting a write whose revision is out of date. This
+        // layer cannot tell whether that cost anyone anything, but whoever made
+        // the request always can:
+        //  - remote-only session: the write came from PouchDatabase.put(), and
+        //    PouchDatabase.resolveConflict() decides between merging,
+        //    overwriting and failing - and counts the outcome it chose.
+        //  - synced session: writes go to the local database, so the only 409s
+        //    reaching here are replication's own `PUT /_local/<checkpoint>`
+        //    races between concurrent tabs, which PouchDB retries internally.
+        // Reporting it here would therefore be an alert nobody can act on, and
+        // it is what buried the genuinely unexpected statuses in the same issue.
+        Logging.debug("Document update conflict from DB", response);
       } else {
-        Logging.warn("Failed to fetch from DB with 40X error", {
-          ...describeResponse(result),
+        Logging.warn(unexpectedResponseMessage(result.status), {
+          ...response,
           requestedUrl: remoteUrl,
         });
       }
@@ -286,7 +354,7 @@ export class RemotePouchDatabase extends PouchDatabase {
     url: string,
     opts: RequestInit,
   ): Promise<Response> {
-    const method = (opts.method ?? "GET").toUpperCase();
+    const method = requestMethod(opts);
     const isSafeMethod = method === "GET" || method === "HEAD";
 
     if (!isSafeMethod) {

--- a/src/app/core/logging/http-response-logging.spec.ts
+++ b/src/app/core/logging/http-response-logging.spec.ts
@@ -1,0 +1,65 @@
+import { HttpStatusCode } from "@angular/common/http";
+import {
+  describeResponse,
+  unexpectedResponseMessage,
+} from "./http-response-logging";
+
+describe("describeResponse", () => {
+  it("should extract fields that JSON.stringify(response) drops", () => {
+    const response = new Response("{}", {
+      status: HttpStatusCode.TooManyRequests,
+      statusText: "Too Many Requests",
+    });
+
+    // the behaviour this helper exists to work around
+    expect(JSON.stringify(response)).toBe("{}");
+
+    expect(describeResponse(response)).toEqual({
+      status: HttpStatusCode.TooManyRequests,
+      statusText: "Too Many Requests",
+      responseUrl: "",
+    });
+  });
+
+  it("should include the request method, which the Response does not carry", () => {
+    // without it a status cannot be classified: a 409 on a PUT is a rejected
+    // save, on a replication checkpoint it is internal housekeeping
+    expect(
+      describeResponse(
+        new Response("{}", { status: HttpStatusCode.Conflict }),
+        "PUT",
+      ),
+    ).toEqual(expect.objectContaining({ method: "PUT" }));
+  });
+
+  it("should handle a missing response", () => {
+    expect(describeResponse(undefined)).toEqual({});
+    // a write that never got a response is the case most in need of the method
+    expect(describeResponse(undefined, "PUT")).toEqual({ method: "PUT" });
+  });
+});
+
+describe("unexpectedResponseMessage", () => {
+  it("should name the status, so that monitoring reports one issue per root cause", () => {
+    // a number would be masked away by the grouping normalization, merging
+    // unrelated failures back into a single issue
+    expect(unexpectedResponseMessage(HttpStatusCode.BadRequest)).toBe(
+      "Unexpected DB response: bad request",
+    );
+    expect(unexpectedResponseMessage(HttpStatusCode.PayloadTooLarge)).toBe(
+      "Unexpected DB response: payload too large",
+    );
+  });
+
+  it("should collect statuses without a name into one bucket", () => {
+    expect(unexpectedResponseMessage(423)).toBe(
+      "Unexpected DB response: unnamed client error",
+    );
+  });
+
+  it("should not put a digit in the message, which the grouping would mask", () => {
+    for (const status of [HttpStatusCode.BadRequest, 423]) {
+      expect(unexpectedResponseMessage(status)).not.toMatch(/\d/);
+    }
+  });
+});

--- a/src/app/core/logging/http-response-logging.ts
+++ b/src/app/core/logging/http-response-logging.ts
@@ -1,0 +1,85 @@
+import { HttpStatusCode } from "@angular/common/http";
+
+/**
+ * Helpers to turn an HTTP response into something worth reporting.
+ *
+ * These live with the logging module rather than with the code that makes the
+ * requests: what they encode is how remote monitoring groups and titles an
+ * issue, not how the database talks to CouchDB.
+ */
+
+/**
+ * Names for the response statuses that are reported to remote monitoring.
+ *
+ * Monitoring groups a reported message by its normalized text, and that
+ * normalization masks numbers (see `fingerprintKey`), so a status interpolated
+ * as a number would collapse every unexpected response into one issue - the
+ * mixed bucket this exists to prevent. In AAM-DIGITAL-77H a rejected write, a
+ * malformed query and a replication checkpoint read all shared one title, and
+ * none of them could be told apart or triaged. Naming the status keeps the
+ * message text static (as the logging conventions require) while giving each
+ * root cause its own issue and a title that says what happened.
+ *
+ * Only statuses that plausibly occur are listed, because each one here should
+ * mean a different response:
+ *  - 400 a malformed request (a bad query, or a proxy mangling the url)
+ *  - 413 a payload over the reverse proxy's limit, e.g. a large attachment
+ *  - 429 throttling
+ * Anything else shares one bucket via {@link unexpectedResponseMessage} and is
+ * still reported with its numeric status in the logged context.
+ */
+const UNEXPECTED_STATUS_NAMES: Record<number, string> = {
+  [HttpStatusCode.BadRequest]: "bad request",
+  [HttpStatusCode.PayloadTooLarge]: "payload too large",
+  [HttpStatusCode.TooManyRequests]: "too many requests",
+};
+
+/**
+ * The message to report for an unexpected response from a database request.
+ *
+ * Deliberately says "response" rather than "fetch": one code path carries both
+ * reads and writes, and calling a rejected write a failed fetch is what sent
+ * the first analysis of AAM-DIGITAL-77H down the wrong path.
+ *
+ * The fallback is digit-free so that it is not mangled by the number masking
+ * described on {@link UNEXPECTED_STATUS_NAMES}.
+ */
+export function unexpectedResponseMessage(status: number): string {
+  return `Unexpected DB response: ${UNEXPECTED_STATUS_NAMES[status] ?? "unnamed client error"}`;
+}
+
+/**
+ * Extract the diagnostic fields of a fetch `Response` into a plain object.
+ *
+ * `Response` keeps its state in internal slots rather than own enumerable
+ * properties, so passing one to the logger (or to `JSON.stringify`) yields an
+ * empty object - the reported event then carries no status at all, which is the
+ * one thing needed to tell e.g. a conflict from a rate limit
+ * (see AAM-DIGITAL-77H, whose `context` reads `[{}]` for every event).
+ *
+ * The `method` is not part of the `Response` and has to be passed in, but it
+ * decides how a report should be read: the same status means different things
+ * for a read and for a write (a 409 on a `PUT` is a rejected save, on a
+ * `_local` checkpoint it is replication housekeeping), so without it an event
+ * cannot be classified at all - which is why the AAM-DIGITAL-77H events from
+ * before this was recorded remain unclassifiable.
+ */
+export function describeResponse(
+  response: Response | undefined,
+  method?: string,
+): {
+  method?: string;
+  status?: number;
+  statusText?: string;
+  responseUrl?: string;
+} {
+  if (!response) {
+    return { method };
+  }
+  return {
+    method,
+    status: response.status,
+    statusText: response.statusText,
+    responseUrl: response.url,
+  };
+}

--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -136,6 +136,42 @@ describe("LoggingService", () => {
       expect(processSentryEvent(other, {})).not.toBeNull();
     });
 
+    describe("document update conflicts", () => {
+      // normal operation for an offline-first app: the user is told the save was
+      // rejected, and the occurrence is counted in usage analytics instead
+      const dbFailure = (value: string, hint: Sentry.EventHint = {}) =>
+        processSentryEvent(
+          {
+            exception: { values: [{ type: "DatabaseException", value }] },
+          } as any,
+          hint,
+        );
+
+      it("should drop a conflict identified by its status", () => {
+        expect(
+          dbFailure("whatever PouchDB said", {
+            originalException: { status: 409 },
+          }),
+        ).toBeNull();
+      });
+
+      it("should drop a conflict identified by its message, however PouchDB worded it", () => {
+        expect(
+          dbFailure("Document update conflict. (unable to resolve)"),
+        ).toBeNull();
+        expect(
+          dbFailure("Document update conflict (unable to resolve)"),
+        ).toBeNull();
+        expect(dbFailure("document update conflict")).toBeNull();
+      });
+
+      it("should still report other database failures", () => {
+        expect(
+          dbFailure("not_found", { originalException: { status: 404 } }),
+        ).not.toBeNull();
+      });
+    });
+
     it("should count message-only events (captureMessage) separately by message", () => {
       const messageEvent = () => ({ message: "repeated warning C" }) as any;
 
@@ -176,6 +212,11 @@ describe("LoggingService", () => {
         ({
           // Sentry orders the chain innermost-first: the thrown error is last
           exception: { values: [rootCause, thrown] },
+        }) as any;
+
+      const deniedEvent = (value: string) =>
+        ({
+          exception: { values: [{ type: "DatabaseException", value }] },
         }) as any;
 
       it("should group our wrapper errors by thrown error and root cause", () => {
@@ -316,7 +357,7 @@ describe("LoggingService", () => {
                 {
                   type: "DatabaseException",
                   value:
-                    'Document update conflict. ID: "8f2b1c7e-1234-4a5b-9c8d-0e1f2a3b4c5d"',
+                    'missing: no document found. ID: "8f2b1c7e-1234-4a5b-9c8d-0e1f2a3b4c5d"',
                 },
               ],
             },
@@ -330,7 +371,7 @@ describe("LoggingService", () => {
                 {
                   type: "DatabaseException",
                   value:
-                    'Document update conflict. ID: "1a2b3c4d-9999-4eee-8fff-abcdef012345"',
+                    'missing: no document found. ID: "1a2b3c4d-9999-4eee-8fff-abcdef012345"',
                 },
               ],
             },
@@ -342,21 +383,18 @@ describe("LoggingService", () => {
       });
 
       it("should ignore punctuation and casing, which third-party errors are inconsistent about", () => {
-        const conflictEvent = (value: string) =>
-          ({
-            exception: { values: [{ type: "DatabaseException", value }] },
-          }) as any;
-
+        // PouchDB reports the same failure as both "Unauthorized" and
+        // "unauthorized", with and without a trailing period
         const withPeriod = processSentryEvent(
-          conflictEvent("Document update conflict. (unable to resolve)"),
+          deniedEvent("Unauthorized. (name or password is incorrect)"),
           {},
         );
         const withoutPeriod = processSentryEvent(
-          conflictEvent("Document update conflict (unable to resolve)"),
+          deniedEvent("Unauthorized (name or password is incorrect)"),
           {},
         );
         const lowercased = processSentryEvent(
-          conflictEvent("document update conflict (unable to resolve)"),
+          deniedEvent("unauthorized (name or password is incorrect)"),
           {},
         );
 

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -8,6 +8,7 @@ import {
   provideAppInitializer,
   EnvironmentProviders,
 } from "@angular/core";
+import { HttpStatusCode } from "@angular/common/http";
 import { Router } from "@angular/router";
 import { LoginState } from "../session/session-states/login-state.enum";
 import { LoginStateSubject } from "../session/session-type";
@@ -346,13 +347,51 @@ export function processSentryEvent(
   event: Sentry.ErrorEvent,
   hint: Sentry.EventHint,
 ): Sentry.ErrorEvent | null {
-  if (isOfflineNetworkError(event)) {
+  if (isOfflineNetworkError(event) || isDocumentUpdateConflict(event, hint)) {
     return null;
   }
 
   const grouped = groupSentryEvent(enrichSentryEvent(event, hint), hint);
   return isExcessiveRepeat(grouped) ? null : grouped;
 }
+
+/**
+ * Whether the reported error is a rejected write whose revision was out of date.
+ *
+ * Two users editing one record is normal operation for an offline-first app, not
+ * a fault: the save is rejected, the user is told so by the form that attempted
+ * it, and the occurrence is counted in usage analytics instead (see
+ * `PouchDatabase.reportConflict`). Reporting it here on top of that produced a
+ * steady stream of issues nobody could act on - at *error* level, so louder than
+ * the failures that do need attention.
+ *
+ * The trade-off is deliberate: how often conflicts happen is now only visible in
+ * usage analytics, not in error monitoring.
+ */
+function isDocumentUpdateConflict(
+  event: Sentry.ErrorEvent,
+  hint: Sentry.EventHint,
+): boolean {
+  const thrown = hint?.originalException as { status?: unknown } | undefined;
+  if (
+    thrown &&
+    typeof thrown === "object" &&
+    thrown.status === HttpStatusCode.Conflict
+  ) {
+    return true;
+  }
+
+  // the status is not always preserved (e.g. an error rebuilt from a
+  // `_bulk_docs` result), so fall back to the message - normalized, because
+  // PouchDB words it both with and without a trailing period
+  return [
+    event.message,
+    ...(event.exception?.values?.map((v) => v.value) ?? []),
+  ].some((msg) => msg && fingerprintKey(msg).includes(CONFLICT_MESSAGE));
+}
+
+/** How PouchDB words a rejected write, after {@link fingerprintKey} normalization. */
+const CONFLICT_MESSAGE = "document update conflict";
 
 /**
  * Whether the event is a network-layer fetch failure that occurred while the


### PR DESCRIPTION
Fixes #4332

## The issue's diagnosis was right about the mechanism, wrong about the population

#4332 read AAM-DIGITAL-77H as CouchDB 409 conflicts. Sampling the events across **every** transaction cluster before changing anything showed 409 is the *minority*. Of the events that can be classified at all (release ≥ 3.90.1, the first to record the status):

| Status | Count | Requests |
|---|---|---|
| 409 | 3 | all `PUT` on single-document URLs — conflicts, as the issue said |
| **400** | 4 | all `GET`: `_all_docs?startkey=…`, a plain `<Type>:<uuid>`, a `User:` id **containing a space**, and a `_local/<base64>` replication checkpoint read |

So one issue was holding at least two unrelated root causes, and the larger one had never been noticed. Everything on 3.90.0 and earlier carries `context: [{}]` and is permanently unclassifiable — which is the concrete argument for proposal 1 below, not a hypothetical one.

The space-in-id 400 turned out to be a proxy bug that drops URL encoding, unrelated to this repo — tracked and fixed in Aam-Digital/ndb-setup#116 / Aam-Digital/ndb-setup#117. **This PR does not diagnose the remaining 400s**; it makes them separable so they can be.

## Changes

**Report by root cause** (`remote-pouch-database.ts`)

- Record the **request method** alongside the response. The same status means different things for a read and a write, so without it an event cannot be classified — proposal 1.
- **Name the status in the message** (`Unexpected DB response: bad request`), so each root cause becomes its own issue with a title that says what happened. A numeric status could not be used: the grouping normalization masks digits, which is precisely what merged these in the first place.
- Drop "fetch" from the wording — calling a rejected write a failed fetch is what sent the first analysis down the wrong path — proposal 3.

**Route 409 to debug** — proposal 2. The fetch layer cannot know whether a conflict cost anyone anything; whoever issued the write always can:
- remote-only session: the write came from `PouchDatabase.put()`, and `resolveConflict()` decides between merging, overwriting and failing;
- synced session: writes go to the local database, so the only 409s crossing this layer are replication's own `PUT /_local/<checkpoint>` races between concurrent tabs, which PouchDB retries internally.

**Count conflicts instead of alerting on them.** Two users editing one record is normal operation for an offline-first app, and the user whose save was rejected is already told so by the form. So conflicts now go to usage analytics (entity type and outcome only — never the document id, cf. #4174) via a `conflictReporter` hook, wired in `DatabaseFactoryService` with the lazy-`Injector` pattern `IndexeddbMigrationService` already uses to avoid the `AnalyticsService → ConfigService → EntityMapperService → DatabaseResolver → DatabaseFactoryService` cycle.

**Stop the error-level conflict noise, which the issue didn't mention.** Demoting the fetch-layer warning alone would not have met the goal: `resolveConflict` throws a `DatabaseException`, and any `entityMapper.save()` whose rejection isn't caught by a form reaches Sentry's `ErrorHandler` as an **error** — louder than the warning. That is four separate issues for one problem (one with 27 events, one still active). So conflicts are now dropped in the `beforeSend` hook, alongside the existing precedent for offline network failures. `putAll` also stopped warning on unresolvable conflicts, and stopped attaching the whole batch's document ids to the report — a repeat of the #4174 leak.

## Trade-offs and follow-ups

- **Conflict frequency is now visible only in usage analytics, not in error monitoring.** Deliberate, and stated in the code.
- Matomo is gated on `environment.production` **and** a `usage_analytics` config doc, so the count is blind on instances without analytics configured. If the number is needed for every instance, this does not deliver it.
- `remove()` sends a 409 delete straight to `DatabaseException` without going through `resolveConflict`. A behaviour change, so per AGENTS.md it belongs in its own PR.
- The renamed messages open new monitoring issues by design; AAM-DIGITAL-77H should be archived once this ships.

## Testing

Full unit suite: 2782 passed, 0 failed. `tsc`, ESLint, Prettier and `qlty check --upstream origin/master` clean.

New behaviour tests (not wording tests): 409 → debug, status named per root cause, method recorded, conflicts dropped from remote monitoring by status *and* by message, other database failures still reported, conflicts counted by entity type and outcome, and a save that still succeeds when counting the conflict throws.

Two existing tests used a conflict message as a generic example for punctuation/id normalization; they are retargeted to non-conflict messages, since conflict events no longer reach the grouping code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage analytics for database document-update conflicts, including merged, overwritten, and unresolved outcomes.
  * Improved HTTP error reporting with clearer status descriptions and request-method context.

* **Bug Fixes**
  * Reduced noisy warnings for expected database conflicts and handled them at debug level.
  * Prevented document identifiers from appearing in conflict and error logs.
  * Excluded expected document-update conflicts from error monitoring while continuing to report other database failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->