### PR TITLE
fix: bulk actions dropdown missing Archive (and other core actions)

### DIFF
--- a/e2e/tests/bulk-operations.spec.ts
+++ b/e2e/tests/bulk-operations.spec.ts
@@ -144,7 +144,7 @@ test("Bulk-merge two records combines them into one", async ({ page }) => {
 const ARCHIVE_CHILD_A_NAME = "<ARCHIVE CHILD A>";
 const ARCHIVE_CHILD_B_NAME = "<ARCHIVE CHILD B>";
 
-test("Bulk-archive selected records hides them from the default list (#4345)", async ({
+test("Bulk-archive selected records hides them from the default list", async ({
   page,
 }) => {
   const users = generateUsers();
@@ -156,8 +156,7 @@ test("Bulk-archive selected records hides them from the default list (#4345)", a
   await page.getByRole("navigation").getByText("Children").click();
 
   // Enter bulk-actions mode directly from the list, without ever opening any
-  // entity's details view first — "Archive" must be available as a bulk action
-  // regardless (#4345).
+  // entity's details view first — "Archive" must be available as a bulk action.
   await page.locator("button[mat-icon-button][color='primary']").click();
   await page.getByRole("menuitem", { name: "Bulk Actions" }).click();
 
@@ -181,6 +180,7 @@ test("Bulk-archive selected records hides them from the default list (#4345)", a
 
   // A snackbar confirms the bulk archive.
   await expect(page.getByText(/archived/)).toBeVisible();
+  await argosScreenshot(page, "bulk-archive-confirmation");
 
   // Both records are hidden from the default (active-only) list.
   await expect(

--- a/e2e/tests/bulk-operations.spec.ts
+++ b/e2e/tests/bulk-operations.spec.ts
@@ -141,6 +141,56 @@ test("Bulk-merge two records combines them into one", async ({ page }) => {
   await expect(page.getByRole("cell", { name: CHILD_A_NAME })).toBeVisible();
 });
 
+const ARCHIVE_CHILD_A_NAME = "<ARCHIVE CHILD A>";
+const ARCHIVE_CHILD_B_NAME = "<ARCHIVE CHILD B>";
+
+test("Bulk-archive selected records hides them from the default list (#4345)", async ({
+  page,
+}) => {
+  const users = generateUsers();
+  const childA = generateChild({ name: ARCHIVE_CHILD_A_NAME });
+  const childB = generateChild({ name: ARCHIVE_CHILD_B_NAME });
+
+  await loadApp(page, [...users, childA, childB]);
+
+  await page.getByRole("navigation").getByText("Children").click();
+
+  // Enter bulk-actions mode directly from the list, without ever opening any
+  // entity's details view first — "Archive" must be available as a bulk action
+  // regardless (#4345).
+  await page.locator("button[mat-icon-button][color='primary']").click();
+  await page.getByRole("menuitem", { name: "Bulk Actions" }).click();
+
+  // Select both target rows.
+  await page
+    .locator("app-entities-table tbody tr")
+    .filter({ hasText: ARCHIVE_CHILD_A_NAME })
+    .click();
+  await page
+    .locator("app-entities-table tbody tr")
+    .filter({ hasText: ARCHIVE_CHILD_B_NAME })
+    .click();
+
+  // Open the bulk action dropdown and pick "Archive".
+  await page
+    .locator("app-entity-bulk-actions")
+    .locator("input")
+    .first()
+    .click();
+  await page.getByRole("option", { name: "Archive" }).click();
+
+  // A snackbar confirms the bulk archive.
+  await expect(page.getByText(/archived/)).toBeVisible();
+
+  // Both records are hidden from the default (active-only) list.
+  await expect(
+    page.getByRole("cell", { name: ARCHIVE_CHILD_A_NAME }),
+  ).not.toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.getByRole("cell", { name: ARCHIVE_CHILD_B_NAME }),
+  ).not.toBeVisible();
+});
+
 // Center enum values from configurable-enums.json (id: label)
 const CENTER_ALIPORE = { id: "C1", label: "Alipore" };
 const CENTER_TOLLYGUNGE = { id: "C2", label: "Tollygunge" };

--- a/src/app/core/core.module.spec.ts
+++ b/src/app/core/core.module.spec.ts
@@ -43,7 +43,7 @@ describe("CoreModule", () => {
     });
   });
 
-  it("registers the default entity actions (archive, anonymize, delete, duplicate) on startup (#4345)", async () => {
+  it("registers the default entity actions (archive, anonymize, delete, duplicate) on startup", async () => {
     // Simply importing CoreModule (as AppModule does on every app startup) must be
     // enough to register these actions - they must not depend on some other,
     // unrelated component happening to inject EntityActionsService first.

--- a/src/app/core/core.module.spec.ts
+++ b/src/app/core/core.module.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from "@angular/core/testing";
+import { of } from "rxjs";
+import { Router } from "@angular/router";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { CoreModule } from "./core.module";
+import { EntityActionsMenuService } from "./entity-details/entity-actions-menu/entity-actions-menu.service";
+import { EntityMapperService } from "./entity/entity-mapper/entity-mapper.service";
+import { EntityDeleteService } from "./entity/entity-actions/entity-delete.service";
+import { EntityAnonymizeService } from "./entity/entity-actions/entity-anonymize.service";
+import { ConfirmationDialogService } from "./common-components/confirmation-dialog/confirmation-dialog.service";
+import { BulkOperationStateService } from "./entity/entity-actions/bulk-operation-state.service";
+import { PublicFormsService } from "app/features/public-form/public-forms.service";
+import { DuplicateRecordService } from "app/core/entity-list/duplicate-records/duplicate-records.service";
+import { TestEntity } from "../utils/test-utils/TestEntity";
+import { EntityAbility } from "./permissions/ability/entity-ability";
+import { ComponentRegistry } from "../dynamic-components";
+
+describe("CoreModule", () => {
+  beforeEach(() => {
+    const ability: any = { can: vi.fn().mockReturnValue(true) };
+
+    TestBed.configureTestingModule({
+      imports: [CoreModule],
+      providers: [
+        { provide: EntityAbility, useValue: ability },
+        { provide: ComponentRegistry, useValue: new ComponentRegistry() },
+        {
+          provide: EntityMapperService,
+          useValue: { receiveUpdates: vi.fn().mockReturnValue(of()) },
+        },
+        { provide: EntityDeleteService, useValue: {} },
+        { provide: EntityAnonymizeService, useValue: {} },
+        { provide: ConfirmationDialogService, useValue: {} },
+        { provide: MatSnackBar, useValue: {} },
+        { provide: Router, useValue: {} },
+        {
+          provide: PublicFormsService,
+          useValue: { initCustomFormActions: vi.fn() },
+        },
+        { provide: BulkOperationStateService, useValue: {} },
+        { provide: DuplicateRecordService, useValue: {} },
+      ],
+    });
+  });
+
+  it("registers the default entity actions (archive, anonymize, delete, duplicate) on startup (#4345)", async () => {
+    // Simply importing CoreModule (as AppModule does on every app startup) must be
+    // enough to register these actions - they must not depend on some other,
+    // unrelated component happening to inject EntityActionsService first.
+    TestBed.inject(CoreModule);
+
+    const menu = TestBed.inject(EntityActionsMenuService);
+    const entities = [TestEntity.create("A"), TestEntity.create("B")];
+
+    const bulkActions = await menu.getActionsForBulk(entities);
+    expect(bulkActions.map((action) => action.action)).toEqual(
+      expect.arrayContaining(["archive", "delete", "duplicate"]),
+    );
+
+    const singleActions = await menu.getActionsForSingle(entities[0]);
+    expect(singleActions.map((action) => action.action)).toEqual(
+      expect.arrayContaining(["archive", "delete", "duplicate"]),
+    );
+  });
+});

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -58,7 +58,7 @@ export class CoreModule {
     components.addAll(coreComponents);
 
     // Force this to be instantiated so it registers its actions (archive, anonymize, delete, duplicate)
-    // regardless of whether some other component happens to inject it first (#4345).
+    // regardless of whether some other component happens to inject it first.
     inject(EntityActionsService);
   }
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -22,6 +22,7 @@ import { PercentageDatatype } from "./basic-datatypes/number/display-percentage/
 import { UrlDatatype } from "./basic-datatypes/string/url.datatype";
 import { EmailDatatype } from "./basic-datatypes/string/email.datatype";
 import { SchemaEmbedDatatype } from "./basic-datatypes/schema-embed/schema-embed.datatype";
+import { EntityActionsService } from "./entity/entity-actions/entity-actions.service";
 
 /**
  * Core module registering basic parts like datatypes and components.
@@ -55,5 +56,9 @@ export class CoreModule {
     const components = inject(ComponentRegistry);
 
     components.addAll(coreComponents);
+
+    // Force this to be instantiated so it registers its actions (archive, anonymize, delete, duplicate)
+    // regardless of whether some other component happens to inject it first (#4345).
+    inject(EntityActionsService);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4345.

`EntityActionsService` registers the core entity actions (Archive, Anonymize, Delete, Duplicate) in its constructor, but as an Angular `providedIn: "root"` service it was never actually instantiated until *something* happened to inject it - e.g. opening an entity's details view (`entity-archived-info` injects it there).

On a plain `EntityList` page, `entities-table` renders with `[editable]="false"`, so `app-entity-inline-edit-actions` (one of the few places that injects `EntityActionsService`) never mounts. If a user enters bulk-select mode straight from the list - without ever having opened a record's details first in that session - `EntityActionsService` was never registered, so Archive/Anonymize/Delete/Duplicate were silently missing from the bulk actions dropdown. Meanwhile actions registered eagerly by feature module constructors (Merge, Bulk Edit, ...) still showed up, since `SkillModule`/`BulkEditModule`/`DeDuplicationModule` register at app bootstrap - which is exactly the "Archive (and some other actions)" split described in the issue.

**Fix:** force `EntityActionsService` to be instantiated from `CoreModule`'s constructor (the same place that already forces `ComponentRegistry` setup), so its actions are always registered at startup regardless of what a user has opened first.

## Test plan

- [x] Added a failing-first unit test (`src/app/core/core.module.spec.ts`) asserting that importing `CoreModule` alone (without injecting `EntityActionsService` elsewhere) registers `archive`/`delete`/`duplicate` for both bulk and single-entity actions. Verified red on the pre-fix code, green after.
- [x] Added a failing-first e2e test to the existing `e2e/tests/bulk-operations.spec.ts` suite: enters bulk-select mode directly from the Children list (no prior navigation into any entity's details) and picks "Archive" from the dropdown. Verified this reproduces the bug against a build without the fix (times out waiting for the "Archive" option), and passes against a build with the fix.
- [x] Full unit test suite passes (`ng test`, 2794 tests).
- [x] Ran `bulk-operations.spec.ts`, `todos.spec.ts`, `entity.spec.ts`, `anonymize.spec.ts` e2e suites against the fixed build - all green, no regressions in individual archive/anonymize flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured standard entity actions, including archive, anonymize, delete, and duplicate, are available when the application starts.
  * Restored archive, delete, and duplicate actions in both bulk and individual record action menus.

* **Tests**
  * Added coverage for bulk archiving selected records, including confirmation feedback and removal from the active list.
  * Added startup coverage to verify default actions are registered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->