### PR TITLE
refactor(permissions): extract ADMIN_APP_ROLE constant

### DIFF
--- a/src/app/core/admin/admin.routing.ts
+++ b/src/app/core/admin/admin.routing.ts
@@ -17,8 +17,9 @@ import { UserListComponent } from "../user/user-list/user-list.component";
 import { AdminPrimaryActionComponent } from "./admin-primary-action/admin-primary-action.component";
 import { AdminAiAgentComponent } from "./admin-ai-agent/admin-ai-agent.component";
 import { AdminConfigCleanupComponent } from "./config-cleanup/admin-config-cleanup.component";
+import { ADMIN_APP_ROLE } from "../permissions/permission-types";
 
-const ROLE_MANAGEMENT_ROLES = ["account_manager", "admin_app"];
+const ROLE_MANAGEMENT_ROLES = ["account_manager", ADMIN_APP_ROLE];
 
 export const adminRoutes: Routes = [
   {
@@ -26,7 +27,7 @@ export const adminRoutes: Routes = [
     component: AdminOverviewComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -73,7 +74,7 @@ export const adminRoutes: Routes = [
     component: UserListComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -81,7 +82,7 @@ export const adminRoutes: Routes = [
     component: SubscriptionInfoComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -89,7 +90,7 @@ export const adminRoutes: Routes = [
     component: AdvancedFeaturesComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -97,7 +98,7 @@ export const adminRoutes: Routes = [
     component: DataPrivacyComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -184,7 +185,7 @@ export const adminRoutes: Routes = [
     component: ConflictResolutionListComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -192,7 +193,7 @@ export const adminRoutes: Routes = [
     component: AdminAiAgentComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
   {
@@ -200,7 +201,7 @@ export const adminRoutes: Routes = [
     component: AdminConfigCleanupComponent,
     canActivate: [UserRoleGuard],
     data: {
-      permittedUserRoles: ["admin_app"],
+      permittedUserRoles: [ADMIN_APP_ROLE],
     },
   },
 ];

--- a/src/app/core/config/dynamic-routing/router.service.spec.ts
+++ b/src/app/core/config/dynamic-routing/router.service.spec.ts
@@ -18,6 +18,7 @@ import { AuthGuard } from "../../session/auth.guard";
 import { RoutedViewComponent } from "../../ui/routed-view/routed-view.component";
 import { EntityPermissionGuard } from "../../permissions/permission-guard/entity-permission.guard";
 import { EntityListComponent } from "../../entity-list/entity-list/entity-list.component";
+import { ADMIN_APP_ROLE } from "../../permissions/permission-types";
 
 @Component({ template: "" })
 class TestComponent {}
@@ -136,7 +137,7 @@ describe("RouterService", () => {
     const testViewConfigs: ViewConfig[] = [
       {
         _id: "view:other",
-        permittedUserRoles: ["admin_app"],
+        permittedUserRoles: [ADMIN_APP_ROLE],
         lazyLoaded: true,
       },
     ];
@@ -146,7 +147,7 @@ describe("RouterService", () => {
         component: TestComponent,
         canActivate: [AuthGuard, EntityPermissionGuard, UserRoleGuard],
         canDeactivate: [expect.any(Function) as any],
-        data: { permittedUserRoles: ["admin_app"] },
+        data: { permittedUserRoles: [ADMIN_APP_ROLE] },
       },
       { path: "child", component: EntityListComponent },
     ];

--- a/src/app/core/dashboard/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/dashboard/dashboard/dashboard.component.spec.ts
@@ -7,6 +7,7 @@ import { MockedTestingModule } from "../../../utils/mocked-testing.module";
 import { SessionSubject } from "../../session/auth/session-info";
 import { EntityCountDashboardConfig } from "app/features/dashboard-widgets/entity-count-dashboard-widget/entity-count-dashboard/entity-count-dashboard.component";
 import { ComponentRegistry } from "../../../dynamic-components";
+import { ADMIN_APP_ROLE } from "../../permissions/permission-types";
 
 @Component({
   selector: "app-mock-entity-count-dashboard",
@@ -210,7 +211,7 @@ describe("DashboardComponent", () => {
       {
         component: "EntityCountDashboard",
         config: { entityType: "Todo" } as EntityCountDashboardConfig,
-        permittedUserRoles: ["admin_app"],
+        permittedUserRoles: [ADMIN_APP_ROLE],
       },
       { component: "EntityCountDashboard" },
     ];
@@ -221,7 +222,11 @@ describe("DashboardComponent", () => {
       expect(component.permittedWidgets.value() ?? []).toEqual([widgets[1]]),
     );
 
-    session.next({ name: "admin", id: "2", roles: ["user_app", "admin_app"] });
+    session.next({
+      name: "admin",
+      id: "2",
+      roles: ["user_app", ADMIN_APP_ROLE],
+    });
     await setWidgetsAndStabilize(widgets);
     await vi.waitFor(() =>
       expect(component.permittedWidgets.value() ?? []).toEqual(widgets),

--- a/src/app/core/demo-data/demo-data-initializer.service.spec.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.spec.ts
@@ -18,6 +18,7 @@ import { LoginState } from "../session/session-states/login-state.enum";
 import { DatabaseResolverService } from "../database/database-resolver.service";
 import { MemoryPouchDatabase } from "../database/pouchdb/memory-pouch-database";
 import { Entity } from "../entity/model/entity";
+import { ADMIN_APP_ROLE } from "../permissions/permission-types";
 import type { Mock } from "vitest";
 
 type DemoDataServiceMock = Pick<DemoDataService, "publishDemoData"> & {
@@ -51,7 +52,7 @@ describe("DemoDataInitializerService", () => {
     name: DemoUserGeneratorService.ADMIN_USERNAME,
     id: DemoUserGeneratorService.ADMIN_USERNAME,
     entityId: "User:demo-admin",
-    roles: ["user_app", "admin_app"],
+    roles: ["user_app", ADMIN_APP_ROLE],
   };
   let service: DemoDataInitializerService;
   let mockDemoDataService: DemoDataServiceMock;

--- a/src/app/core/demo-data/demo-data-initializer.service.ts
+++ b/src/app/core/demo-data/demo-data-initializer.service.ts
@@ -14,6 +14,7 @@ import memory from "pouchdb-adapter-memory";
 import PouchDB from "pouchdb-browser";
 import { DatabaseResolverService } from "../database/database-resolver.service";
 import { computeDbNames } from "../database/db-name-helpers";
+import { ADMIN_APP_ROLE } from "../permissions/permission-types";
 
 /**
  * This service handles everything related to the demo-mode
@@ -43,7 +44,7 @@ export class DemoDataInitializerService {
   private readonly adminUser: SessionInfo = {
     name: DemoUserGeneratorService.ADMIN_USERNAME,
     id: DemoUserGeneratorService.ADMIN_USERNAME,
-    roles: ["user_app", "admin_app"],
+    roles: ["user_app", ADMIN_APP_ROLE],
     entityId: `User:${DemoUserGeneratorService.ADMIN_USERNAME}`,
   };
 

--- a/src/app/core/entity-details/entity-details/entity-details.component.spec.ts
+++ b/src/app/core/entity-details/entity-details/entity-details.component.spec.ts
@@ -7,6 +7,7 @@ import { EntityActionsService } from "../../entity/entity-actions/entity-actions
 import { EntityAbility } from "../../permissions/ability/entity-ability";
 import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.service";
 import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { ADMIN_APP_ROLE } from "../../permissions/permission-types";
 import type { Mock } from "vitest";
 
 type ChildrenServiceMock = {
@@ -174,7 +175,7 @@ describe("EntityDetailsComponent", () => {
           components: [
             { title: "Component B", component: "TestComponent", config: {} },
           ],
-          permittedUserRoles: ["admin_app"],
+          permittedUserRoles: [ADMIN_APP_ROLE],
         },
         {
           title: "Default Panel (without stating permitted roles)",

--- a/src/app/core/permissions/ability/ability.service.spec.ts
+++ b/src/app/core/permissions/ability/ability.service.spec.ts
@@ -8,7 +8,11 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { PermissionEnforcerService } from "../permission-enforcer/permission-enforcer.service";
 import { defaultInteractionTypes } from "../../config/default-config/default-interaction-types";
 import { EntityAbility } from "./entity-ability";
-import { DatabaseRule, DatabaseRules } from "../permission-types";
+import {
+  ADMIN_APP_ROLE,
+  DatabaseRule,
+  DatabaseRules,
+} from "../permission-types";
 import { Config } from "../../config/config";
 import { Logging } from "../../logging/logging.service";
 import { UpdatedEntity } from "../../entity/model/entity-update";
@@ -30,7 +34,7 @@ describe("AbilityService", () => {
       { subject: TestEntity.ENTITY_TYPE, action: "read" },
       { subject: Note.ENTITY_TYPE, action: "manage", inverted: true },
     ],
-    admin_app: [{ subject: "all", action: "manage" }],
+    [ADMIN_APP_ROLE]: [{ subject: "all", action: "manage" }],
   };
 
   beforeEach(waitForAsync(() => {
@@ -169,7 +173,7 @@ describe("AbilityService", () => {
       TestBed.inject(SessionSubject).next({
         name: "testAdmin",
         id: "1",
-        roles: ["user_app", "admin_app"],
+        roles: ["user_app", ADMIN_APP_ROLE],
       });
 
       entityUpdates.next({
@@ -179,7 +183,7 @@ describe("AbilityService", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(ability.update).toHaveBeenCalledWith(
-        rules.user_app.concat(rules.admin_app),
+        rules.user_app.concat(rules[ADMIN_APP_ROLE]),
       );
     } finally {
       vi.useRealTimers();
@@ -210,7 +214,7 @@ describe("AbilityService", () => {
       TestBed.inject(SessionSubject).next({
         name: "testAdmin",
         id: "1",
-        roles: ["user_app", "admin_app"],
+        roles: ["user_app", ADMIN_APP_ROLE],
       });
 
       const updatedConfig = new Config(Config.PERMISSION_KEY, rules);
@@ -413,14 +417,14 @@ describe("AbilityService", () => {
       TestBed.inject(SessionSubject).next({
         name: "admin",
         id: "1",
-        roles: ["user_app", "admin_app"],
+        roles: ["user_app", ADMIN_APP_ROLE],
       });
 
       config._rev = "update";
       entityUpdates.next({ entity: config, type: "update" });
       await vi.advanceTimersByTimeAsync(0);
       expect(ability.rules).toEqual(
-        defaultRules.concat(...rules.user_app, ...rules.admin_app),
+        defaultRules.concat(...rules.user_app, ...rules[ADMIN_APP_ROLE]),
       );
     } finally {
       vi.useRealTimers();

--- a/src/app/core/permissions/permission-types.ts
+++ b/src/app/core/permissions/permission-types.ts
@@ -47,6 +47,12 @@ export const LEGACY_PUBLIC_KEY = "public";
 export const RESERVED_ROLE_PREFIX = "_";
 
 /**
+ * The realm role that grants access to the administration features, as checked
+ * by the admin routes' {@link UserRoleGuard} configuration.
+ */
+export const ADMIN_APP_ROLE = "admin_app";
+
+/**
  * All section keys (current and legacy) that must never be resolved as if they
  * were user role names, even if a realm role with the same name exists.
  *

--- a/src/app/core/ui/ui/ui.component.ts
+++ b/src/app/core/ui/ui/ui.component.ts
@@ -60,6 +60,7 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { LoginState } from "../../session/session-states/login-state.enum";
 import { ConfigService } from "../../config/config.service";
 import { SessionSubject } from "../../session/auth/session-info";
+import { ADMIN_APP_ROLE } from "../../permissions/permission-types";
 
 /**
  * The main user interface component as root element for the app structure
@@ -180,7 +181,7 @@ export class UiComponent {
 
   isAdminUser = toSignal(
     this.sessionSubject.pipe(
-      map((session) => session?.roles?.includes("admin_app") ?? false),
+      map((session) => session?.roles?.includes(ADMIN_APP_ROLE) ?? false),
     ),
     { initialValue: false },
   );

--- a/src/app/core/user/user-list/user-list.component.spec.ts
+++ b/src/app/core/user/user-list/user-list.component.spec.ts
@@ -12,6 +12,7 @@ import { SessionSubject } from "../../session/auth/session-info";
 import { SyncStateSubject } from "../../session/session-type";
 import { CurrentUserSubject } from "../../session/current-user-subject";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { ADMIN_APP_ROLE } from "../../permissions/permission-types";
 
 describe("UserListComponent", () => {
   let component: UserListComponent;
@@ -36,7 +37,7 @@ describe("UserListComponent", () => {
       email: "user2@example.com",
       enabled: false,
       emailVerified: false,
-      roles: [{ id: "role2", name: "admin_app" }],
+      roles: [{ id: "role2", name: ADMIN_APP_ROLE }],
     },
     {
       id: "user3",
@@ -66,7 +67,7 @@ describe("UserListComponent", () => {
       email: "user2@example.com",
       enabled: false,
       emailVerified: false,
-      roles: [{ id: "role2", name: "admin_app" }],
+      roles: [{ id: "role2", name: ADMIN_APP_ROLE }],
     },
     {
       id: "user3",

--- a/src/app/features/public-form/public-form-permission.service.spec.ts
+++ b/src/app/features/public-form/public-form-permission.service.spec.ts
@@ -4,6 +4,7 @@ import { EntityMapperService } from "../../core/entity/entity-mapper/entity-mapp
 import { SessionSubject } from "../../core/session/auth/session-info";
 import { Config } from "../../core/config/config";
 import { BehaviorSubject } from "rxjs";
+import { ADMIN_APP_ROLE } from "../../core/permissions/permission-types";
 
 describe("PublicFormPermissionService", () => {
   let service: PublicFormPermissionService;
@@ -126,7 +127,7 @@ describe("PublicFormPermissionService", () => {
   });
 
   it("should detect admin permission when user has admin_app role", () => {
-    mockSessionSubject.next({ roles: ["admin_app", "user"] });
+    mockSessionSubject.next({ roles: [ADMIN_APP_ROLE, "user"] });
 
     const result = service.hasAdminPermission();
 

--- a/src/app/features/public-form/public-form-permission.service.ts
+++ b/src/app/features/public-form/public-form-permission.service.ts
@@ -3,6 +3,7 @@ import { ConfirmationDialogService } from "app/core/common-components/confirmati
 import { inject, Injectable } from "@angular/core";
 import { Config } from "../../core/config/config";
 import {
+  ADMIN_APP_ROLE,
   DatabaseRules,
   DEFAULT_SECTION_KEY,
   LEGACY_PUBLIC_KEY,
@@ -174,7 +175,7 @@ export class PublicFormPermissionService {
    */
   hasAdminPermission(): boolean {
     const userRoles = this.sessionInfo.value?.roles || [];
-    return userRoles.includes("admin_app");
+    return userRoles.includes(ADMIN_APP_ROLE);
   }
 
   /**

--- a/src/app/features/template-export/template-export.module.ts
+++ b/src/app/features/template-export/template-export.module.ts
@@ -9,6 +9,7 @@ import { EntityListConfig } from "../../core/entity-list/EntityListConfig";
 import { DefaultDatatype } from "../../core/entity/default-datatype/default.datatype";
 import { Entity } from "../../core/entity/model/entity";
 import { SessionSubject } from "../../core/session/auth/session-info";
+import { ADMIN_APP_ROLE } from "../../core/permissions/permission-types";
 import { AsyncComponent, ComponentRegistry } from "../../dynamic-components";
 import { TemplateExportFileDatatype } from "./template-export-file-datatype/template-export-file.datatype";
 import { TemplateExportService } from "./template-export-service/template-export.service";
@@ -56,7 +57,7 @@ export class TemplateExportModule {
           const session = sessionSubject.value;
           if (!session) return false;
           // Show for admin users OR when export feature is enabled
-          const isAdmin = session.roles.includes("admin_app");
+          const isAdmin = session.roles.includes(ADMIN_APP_ROLE);
           const isExportEnabled =
             await templateExportService.isExportServerEnabled();
           return isAdmin || isExportEnabled;


### PR DESCRIPTION
## Summary
- Extracted an `ADMIN_APP_ROLE` constant in `permission-types.ts` for the `admin_app` realm role, mirroring the pattern requested in [#4264 (comment)](https://github.com/Aam-Digital/ndb-core/pull/4264/changes#diff-b9d2a4b9e30ad8192b38fe0794c84fcd818d2c93a1990470c094fd9009ddbd6dR46-R51).
- Replaced literal `"admin_app"` role-string usages across guards, services and specs with the new constant, so the role name has a single source of truth.
- Left literal usages in place where a TS constant can't be referenced: JSON base-config assets, `README.md` prose, a JSDoc comment, and test-description strings (`it("...")`).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` clean on all changed files
- [x] `npx prettier --check` clean on all changed files
- [x] Unit tests pass for all 7 affected spec files (74 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)