### PR TITLE
fix(logging): keep one root cause in one Sentry issue

### DIFF
--- a/src/app/core/common-components/entity-form/entity-form.service.ts
+++ b/src/app/core/common-components/entity-form/entity-form.service.ts
@@ -281,8 +281,12 @@ export class EntityFormService {
     try {
       await this.entityMapper.save(updatedEntity);
     } catch (err) {
+      // the original error is kept as `cause`: remote monitoring links it into
+      // the reported exception chain, so a save failure can be told apart by
+      // what actually rejected it instead of only by this message
       throw new Error(
         $localize`Could not save ${entity.getType()}\: ${err?.message || String(err)}`,
+        { cause: err },
       );
     }
 

--- a/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
+++ b/src/app/core/database/pouchdb/pouchdb-corruption-recovery.service.ts
@@ -91,11 +91,22 @@ This can happen after using multiple tabs in parallel.` +
     this.localDeviceReset.markResetPendingAndReload();
   }
 
-  handleKnownMultiTabCorruption(err: unknown, logMessage: string): void {
+  /**
+   * @param err the error to check and, if it is a known corruption, report
+   * @param logMessage what failed - static, so that remote monitoring keeps all
+   *   occurrences of the problem in one issue (see `core/logging/README.md`)
+   * @param context which database and other varying details, reported as
+   *   structured data alongside the message rather than interpolated into it
+   */
+  handleKnownMultiTabCorruption(
+    err: unknown,
+    logMessage: string,
+    context?: Record<string, unknown>,
+  ): void {
     if (!isKnownMultiTabDatabaseCorruption(err)) {
       return;
     }
-    Logging.warn(logMessage, err);
+    Logging.warn(logMessage, err, ...(context ? [context] : []));
     this.promptResetApplicationDialog().catch((callbackError) =>
       Logging.warn("onKnownMultiTabCorruption callback failed", callbackError),
     );

--- a/src/app/core/database/pouchdb/synced-pouch-database.ts
+++ b/src/app/core/database/pouchdb/synced-pouch-database.ts
@@ -276,13 +276,14 @@ export class SyncedPouchDatabase extends PouchDatabase {
         if (this.isDocumentWriteError(err)) {
           Logging.warn(
             `sync failed: document write error (possible oversized document)`,
-            { db: this.dbName, lastSyncedBatch: lastSyncedDocIds },
+            { db: this.dbName, ...lastSyncedBatchContext(lastSyncedDocIds) },
             err,
           );
         } else if (isKnownMultiTabDatabaseCorruption(err)) {
           this.corruptionRecovery?.handleKnownMultiTabCorruption(
             err,
-            `sync failed [${this.dbName}]: likely multi-tab IndexedDB corruption. Last synced batch: [${lastSyncedDocIds.join(", ")}]`,
+            "sync failed: likely multi-tab IndexedDB corruption",
+            { db: this.dbName, ...lastSyncedBatchContext(lastSyncedDocIds) },
           );
         } else if (
           this.isSyncConnectivityError(err) ||
@@ -312,7 +313,8 @@ export class SyncedPouchDatabase extends PouchDatabase {
     } catch (err) {
       this.corruptionRecovery?.handleKnownMultiTabCorruption(
         err,
-        `put failed [${this.dbName}]: likely multi-tab IndexedDB corruption`,
+        "put failed: likely multi-tab IndexedDB corruption",
+        { db: this.dbName },
       );
       throw err;
     }
@@ -325,7 +327,8 @@ export class SyncedPouchDatabase extends PouchDatabase {
     return super.query(fun, options).catch((err) => {
       this.corruptionRecovery?.handleKnownMultiTabCorruption(
         err,
-        `query failed [${this.dbName}]: likely multi-tab IndexedDB corruption`,
+        "query failed: likely multi-tab IndexedDB corruption",
+        { db: this.dbName },
       );
       throw err;
     });
@@ -500,6 +503,20 @@ export class SyncedPouchDatabase extends PouchDatabase {
 }
 
 type SyncResult = PouchDB.Replication.SyncResultComplete<any>;
+
+/**
+ * What of the last synced batch can be reported when a sync fails right after
+ * it: how much was in flight and which record types, but never the document
+ * ids themselves - those identify records and have no place in remote
+ * monitoring (see #4174), while as part of a message they would also open a
+ * separate issue per batch.
+ */
+function lastSyncedBatchContext(docIds: string[]): Record<string, unknown> {
+  return {
+    lastSyncedBatchSize: docIds.length,
+    lastSyncedEntityTypes: [...new Set(docIds.map((id) => id.split(":")[0]))],
+  };
+}
 
 /** Thrown internally when a sync is cancelled for making no progress. */
 class SyncStalledError extends Error {

--- a/src/app/core/logging/README.md
+++ b/src/app/core/logging/README.md
@@ -103,6 +103,12 @@ is the wrong key. It checks the cases most-specific first, in `groupSentryEvent`
    The browsers' differing wordings would make the merged issue's title flip-flop, so it is
    replaced by a stable one and kept as the searchable `network_error` tag.
 
+   The status counts as well as the message: an event whose error carries a gateway status
+   (`0`/`502`/`503`/`504`) is a request that never reached the backend, whatever the message says.
+   That status is read from `err.status` or, where a library hands on the whole `fetch` Response
+   instead of lifting the status out of it, from `err.response.status` — which is how `keycloak-js`
+   reports every rejected response, all of them worded `Server responded with an invalid status.`
+
    A chunk that fails to load counts as one of these: a lazily loaded part of the app not arriving
    means either that the device is offline or that a deployment replaced the chunk the running app
    asks for, and the error says neither which of the two it was nor anything actionable about the

--- a/src/app/core/logging/README.md
+++ b/src/app/core/logging/README.md
@@ -85,21 +85,41 @@ is the wrong key. It checks the cases most-specific first, in `groupSentryEvent`
    (`Failed to load configuration. (caused by DatabaseException: Unknown kid)`): several issues would
    otherwise share one title and could only be told apart by opening each of them.
 
+   This also applies when a framework re-throws such an error as a generic one — Angular does that
+   for anything raised inside a `resource()` loader, wrapping it in an error that copies the message
+   and reports the `"Error"` name a subclass inherits. A wrapper that only repeats its cause's
+   message contributes nothing but its own stack trace, so the event is grouped by the recognized
+   error underneath it (`rewrappedCauseGroupedError`) and lands in the same issue as the unwrapped
+   one. A wrapper with a message of its own (`Failed to load configuration from the database.`) says
+   more about the failure than its cause does, and stays what the event is grouped by.
+
 2. **Network failures** — anything whose chain contains a connectivity error (see
    `isConnectivityErrorMessage`) is collected into the single `network-error` issue. The browser
    raises these at whatever point a request happened to be made, so by stack trace they are an
    open-ended stream of near-identical issues with the same (non-)answer. They are still reported
    rather than dropped, because a server outage surfaces exactly this way — as one issue, whose
-   number of affected users and sessions is the signal (not its event count, see the cap below).
+   number of affected sessions and deployments is the signal (not its event count, see the cap
+   below).
    The browsers' differing wordings would make the merged issue's title flip-flop, so it is
    replaced by a stable one and kept as the searchable `network_error` tag.
+
+   A chunk that fails to load counts as one of these: a lazily loaded part of the app not arriving
+   means either that the device is offline or that a deployment replaced the chunk the running app
+   asks for, and the error says neither which of the two it was nor anything actionable about the
+   chunk. Without this they arrive as one issue per browser wording (Chrome's "Failed to fetch
+   dynamically imported module", Firefox's "error loading …", Safari's "Importing a module script
+   failed") and per chunk URL.
 
    This runs _after_ case 1 on purpose: a `ConfigLoadError` caused by a failed request is about the
    config load, not about the network, and keeps its own issue.
 
 3. **Exceptions reported without a stack** (e.g. an `HttpErrorResponse`) — Sentry falls back to
    grouping those by message, so an id or url interpolated into it opens a new issue every time.
-   They are fingerprinted by type and normalized message instead.
+   They are fingerprinted by type and normalized message instead, and _reported_ under that same
+   normalized message (`reportNormalized`). Otherwise the issue list still shows the raw one: a row
+   per document id, or — where a library quotes a response body into the message, as PouchDB does
+   for a proxy error — a whole HTML error page pushing every other row off the screen. The raw
+   message stays available as the event's `originalError`.
 
 4. **Message-only events** (`Logging.warn(...)`) group by their normalized message, which enforces the
    "keep message strings static" rule above: a message that does interpolate variable data still
@@ -117,8 +137,14 @@ starves issues that merely share a cause: while a device is on a flaky connectio
 failure is the root cause of the config load, the permission rules, the sync and every file download
 alike, and whichever of them failed first would silence all the others.
 
-An issue's **event count is therefore not a measure of how often a problem occurs** — how many users
-and sessions it affects is.
+An issue's **event count is therefore not a measure of how often a problem occurs.** What to weigh
+instead is how many sessions it affects, how many deployments and releases it spans (the `url` and
+`release` tags), and whether it is still recurring.
+
+Not the number of affected _users_, which Sentry shows as 0 for every issue: reported events
+deliberately carry no user identity, as data minimization under the GDPR. Sentry's own session
+counting is anonymous and stays on, so "how many sessions" remains available; "how many users" is a
+question this project has chosen not to be able to answer.
 
 Values that go into a fingerprint are normalized (`fingerprintKey`): ids, URLs and numbers are masked,
 and punctuation and casing are dropped, so that occurrences of the same problem match even where a
@@ -136,6 +162,9 @@ a literal — an `Error` subclass otherwise inherits `"Error"` from `Error.proto
 fall out of this list, and the constructor name is minified. Both the dedicated classes
 (`RegistryLookupError`) and the plain errors that just set `error.name` (`ConfigLoadError`) do this.
 An `Error` subclass with neither a name nor a message is reported as `Error: No error message`.
+An exception that reaches Sentry with no type at all is listed as `<unknown>`, which says nothing in
+a list of issues and hides the message that would — so `enrichSentryEvent` falls back to the generic
+`"Error"` for those.
 
 Fingerprinting inverts the message rule stated above: once an error is fingerprinted its message _is_
 part of the grouping key, so whatever stays in it becomes a deliberate grouping dimension. Interpolate

--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -5,6 +5,7 @@ import {
   LoggingService,
   MAX_REPEATED_SENTRY_EVENTS,
   processSentryEvent,
+  resetSentryEventCounts,
   toReportedError,
 } from "./logging.service";
 
@@ -104,6 +105,10 @@ describe("LoggingService", () => {
   });
 
   describe("processSentryEvent (beforeSend)", () => {
+    // the repeat budget is per issue and lives for a whole app session, so
+    // without this the events of one test count against the next one's
+    beforeEach(() => resetSentryEventCounts());
+
     it("should drop an identical event after MAX_REPEATED_SENTRY_EVENTS occurrences", () => {
       const event = () =>
         ({
@@ -518,6 +523,128 @@ describe("LoggingService", () => {
         expect(one.fingerprint).toEqual(other.fingerprint);
       });
 
+      it("should group an error a framework re-threw like the unwrapped one", () => {
+        const lookupFailure = {
+          type: "RegistryLookupError",
+          value:
+            "Requested item is not registered in EntityRegistry. Key: Child",
+        };
+
+        const thrownDirectly = processSentryEvent(
+          { exception: { values: [{ ...lookupFailure }] } } as any,
+          {},
+        );
+        // Angular re-throws an error raised in a `resource()` loader as an error
+        // of its own, copying the message and reporting the inherited "Error"
+        const fromResourceLoader = processSentryEvent(
+          chainedEvent(
+            { ...lookupFailure },
+            {
+              type: "Error",
+              value: `Error: ${lookupFailure.value}`,
+            },
+          ),
+          {},
+        );
+
+        expect(fromResourceLoader.fingerprint).toEqual(
+          thrownDirectly.fingerprint,
+        );
+      });
+
+      it("should keep grouping a wrapper that describes the failed operation by itself", () => {
+        const cause = {
+          type: "DatabaseException",
+          value: "unauthorized",
+        };
+
+        const configLoad = processSentryEvent(
+          chainedEvent(
+            { ...cause },
+            {
+              type: "ConfigLoadError",
+              value: "Failed to load configuration from the database.",
+            },
+          ),
+          {},
+        );
+        const permissionsLoad = processSentryEvent(
+          chainedEvent(
+            { ...cause },
+            {
+              type: "PermissionRulesLoadError",
+              value: "Failed to load permission rules",
+            },
+          ),
+          {},
+        );
+
+        // two operations failing for the same reason stay two problems
+        expect(configLoad.fingerprint).not.toEqual(permissionsLoad.fingerprint);
+        expect(configLoad.fingerprint[0]).toBe("ConfigLoadError");
+      });
+
+      it('should report an exception without a type under a generic one, which Sentry lists as "<unknown>"', () => {
+        const event = processSentryEvent(
+          {
+            exception: {
+              values: [
+                { value: "Http failure response for /db/app-attachments: 404" },
+              ],
+            },
+          } as any,
+          {},
+        );
+
+        expect(event.exception.values[0].type).toBe("Error");
+      });
+
+      it("should report an exception grouped by its message under that normalized message", () => {
+        const event = processSentryEvent(
+          {
+            exception: {
+              values: [
+                {
+                  type: "HttpErrorResponse",
+                  value:
+                    "Http failure response for https://example.org/db/app-attachments/Child:8f2b1c7e-1234-4a5b-9c8d-0e1f2a3b4c5d/photo: 404 Not Found",
+                },
+              ],
+            },
+          } as any,
+          {},
+        );
+
+        expect(event.exception.values[0].value).toBe(
+          "Http failure response for <url> <n> Not Found",
+        );
+        expect(event.extra.originalError).toContain("8f2b1c7e");
+      });
+
+      it("should drop a quoted response body, which as a title hides every other issue", () => {
+        const errorPage = (status: number) =>
+          ({
+            exception: {
+              values: [
+                {
+                  type: "Error",
+                  value: `Server returned code ${status} with body "<html>\r\n<head><title>${status} Request Entity Too Large</title></head>\r\n</html>"`,
+                },
+              ],
+            },
+          }) as any;
+
+        const event = processSentryEvent(errorPage(413), {});
+
+        expect(event.exception.values[0].value).toBe(
+          "Server returned code <n>",
+        );
+        expect(event.fingerprint).toEqual([
+          "Error",
+          "server returned code <n>",
+        ]);
+      });
+
       it("should group message-only events by their normalized message", () => {
         const one = processSentryEvent(
           { message: "Report failed after 12 rows" } as any,
@@ -592,6 +719,31 @@ describe("LoggingService", () => {
         );
 
         expect(chrome.fingerprint).toEqual(["network-error"]);
+        expect(safari.fingerprint).toEqual(chrome.fingerprint);
+      });
+
+      it("should collect chunk load failures of any browser wording in the same issue", () => {
+        const chrome = processSentryEvent(
+          fetchFailure(
+            "Failed to fetch dynamically imported module: https://example.org/chunk-SL2Y43UW.js",
+            "main.ts",
+          ),
+          {},
+        );
+        const firefox = processSentryEvent(
+          fetchFailure(
+            "error loading dynamically imported module: https://example.org/chunk-UFUS7D7Q.js",
+            "main.ts",
+          ),
+          {},
+        );
+        const safari = processSentryEvent(
+          fetchFailure("Importing a module script failed.", "main.ts"),
+          {},
+        );
+
+        expect(chrome.fingerprint).toEqual(["network-error"]);
+        expect(firefox.fingerprint).toEqual(chrome.fingerprint);
         expect(safari.fingerprint).toEqual(chrome.fingerprint);
       });
 

--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -584,6 +584,25 @@ describe("LoggingService", () => {
         expect(configLoad.fingerprint[0]).toBe("ConfigLoadError");
       });
 
+      it("should not treat a wrapper that merely mentions the cause's message as repeating it", () => {
+        const event = processSentryEvent(
+          chainedEvent(
+            { type: "DatabaseException", value: "unauthorized" },
+            {
+              type: "Error",
+              value: "Failed to load configuration: unauthorized",
+            },
+          ),
+          {},
+        );
+
+        const causeAlone = processSentryEvent(deniedEvent("unauthorized"), {});
+
+        // the wrapper's message contains the cause's as a substring without
+        // repeating it, so it must not be merged into the cause's own issue
+        expect(event.fingerprint).not.toEqual(causeAlone.fingerprint);
+      });
+
       it('should report an exception without a type under a generic one, which Sentry lists as "<unknown>"', () => {
         const event = processSentryEvent(
           {

--- a/src/app/core/logging/logging.service.spec.ts
+++ b/src/app/core/logging/logging.service.spec.ts
@@ -691,6 +691,56 @@ describe("LoggingService", () => {
       });
     });
 
+    describe("a status the library nested inside a Response", () => {
+      it('should report it, so "invalid status" says which status', () => {
+        const thrown = Object.assign(
+          new Error("Server responded with an invalid status."),
+          { response: { status: 403, statusText: "Forbidden" } },
+        );
+
+        const event = processSentryEvent(
+          {
+            exception: {
+              values: [
+                {
+                  type: "Error",
+                  value: "Server responded with an invalid status.",
+                  stacktrace: { frames: [{ filename: "keycloak.js" }] },
+                },
+              ],
+            },
+          } as any,
+          { originalException: thrown },
+        );
+
+        expect(event.extra.status).toBe(403);
+      });
+
+      it("should keep an explicit status over the nested one", () => {
+        const thrown = Object.assign(new Error("failed"), {
+          status: 401,
+          response: { status: 403 },
+        });
+
+        const event = processSentryEvent(
+          {
+            exception: {
+              values: [
+                {
+                  type: "Error",
+                  value: "failed",
+                  stacktrace: { frames: [{ filename: "app.ts" }] },
+                },
+              ],
+            },
+          } as any,
+          { originalException: thrown },
+        );
+
+        expect(event.extra.status).toBe(401);
+      });
+    });
+
     describe("network errors", () => {
       beforeEach(() => vi.stubGlobal("navigator", { onLine: true }));
       afterEach(() => vi.unstubAllGlobals());

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -10,9 +10,6 @@ import {
 } from "@angular/core";
 import { HttpStatusCode } from "@angular/common/http";
 import { Router } from "@angular/router";
-import { LoginState } from "../session/session-states/login-state.enum";
-import { LoginStateSubject } from "../session/session-type";
-import { SessionSubject } from "../session/auth/session-info";
 import { TraceService } from "@sentry/angular";
 import {
   CONNECTIVITY_ERROR_NAMES,
@@ -52,26 +49,6 @@ export class LoggingService {
   }
 
   /**
-   * Register any additional logging context integrations that need Angular services.
-   * @param loginState
-   * @param sessionInfo
-   */
-  initAngularLogging(
-    loginState: LoginStateSubject,
-    sessionInfo: SessionSubject,
-  ) {
-    return () =>
-      loginState.subscribe((newState) => {
-        if (newState === LoginState.LOGGED_IN) {
-          const username = sessionInfo.value?.id;
-          Logging.setLoggingContextUser(username);
-        } else {
-          Logging.setLoggingContextUser(undefined);
-        }
-      });
-  }
-
-  /**
    * Get the Angular providers to set up additional logging and tracing,
    * that should be added to the providers array of the AppModule.
    */
@@ -88,12 +65,6 @@ export class LoggingService {
       },
       provideAppInitializer(() => {
         inject(TraceService);
-      }),
-      provideAppInitializer(() => {
-        Logging.initAngularLogging(
-          inject(LoginStateSubject),
-          inject(SessionSubject),
-        );
       }),
     ];
   }
@@ -116,14 +87,10 @@ export class LoggingService {
     }
   }
 
-  /**
-   * Update the username to be attached to all log messages for easier debugging,
-   * especially in remote logging.
-   * @param username
-   */
-  setLoggingContextUser(username: string) {
-    Sentry.setUser({ username: username });
-  }
+  // Deliberately no equivalent of Sentry's `setUser`: reported events carry no
+  // user identity, as data minimization under the GDPR (see README.md). Adding
+  // one back would put a personal identifier into every event of every issue,
+  // so it is a decision to take before it is a line of code to write.
 
   /**
    * Log the message with "debug" level - for very detailed, non-essential information.
@@ -335,6 +302,18 @@ export const MAX_REPEATED_SENTRY_EVENTS = 5;
 const sentryEventCounts = new Map<string, number>();
 
 /**
+ * Clear the repeat budget that {@link isExcessiveRepeat} keeps per app session.
+ *
+ * Exported for tests: nothing else resets those counters, so without this every
+ * spec in a file shares one budget and whichever runs last sees its events
+ * dropped instead of processed - which is easy to mistake for the behaviour
+ * under test, as the budget is shared by all events of one issue.
+ */
+export function resetSentryEventCounts() {
+  sentryEventCounts.clear();
+}
+
+/**
  * Sentry `beforeSend` hook: drops network failures of offline devices
  * and excessive repeats of an identical event,
  * and enriches the remaining events with structured extra data
@@ -499,6 +478,10 @@ const CAUSE_GROUPED_ERROR_TYPES = [
  * Order matters: the more specific patterns have to run before the plain number.
  */
 const VOLATILE_VALUE_PATTERNS: [RegExp, string][] = [
+  // a response body quoted into an error message (a proxy failure, an error
+  // page served by the reverse proxy): its content varies per request and can
+  // be a whole HTML document, which as an issue title hides every other row
+  [/ with body ["'][\s\S]*$/i, ""],
   [/https?:\/\/\S+/gi, "<url>"],
   [
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
@@ -586,7 +569,12 @@ function groupSentryEvent(
     CAUSE_GROUPED_ERROR_TYPES.includes(thrownType) ||
     hint?.originalException instanceof LoggedError
   ) {
-    return groupByErrorChain(event, values);
+    return groupByErrorChain(event, values, thrownError);
+  }
+
+  const rewrapped = rewrappedCauseGroupedError(values);
+  if (rewrapped) {
+    return groupByErrorChain(event, values, rewrapped);
   }
 
   if (values.some(isConnectivityException) || hasConnectivityStatus(event)) {
@@ -600,10 +588,77 @@ function groupSentryEvent(
       thrownType || "Error",
       fingerprintKey(thrownError.value),
     ];
+    reportNormalized(event, thrownError);
   }
 
   return event;
 }
+
+/**
+ * The error of a recognized type (see {@link CAUSE_GROUPED_ERROR_TYPES}) that a
+ * framework re-threw as a generic one, if that is what this chain is.
+ *
+ * Angular does this for an error raised inside a `resource()` loader: it wraps
+ * it in an error of its own that copies the original's message and whose type
+ * is the plain "Error" a subclass inherits. The wrapper contributes nothing but
+ * a different stack trace, so grouping by it opens a separate issue per call
+ * site for exactly the problem that {@link groupByErrorChain} keeps as one.
+ *
+ * Only a wrapper that repeats the recognized error's message counts as such.
+ * One that says what it was doing ("Failed to load configuration from the
+ * database.") describes the failure better than its cause does, and stays the
+ * error the event is grouped by.
+ */
+function rewrappedCauseGroupedError(
+  values: Sentry.Exception[],
+): Sentry.Exception | undefined {
+  const thrownValue = fingerprintKey(values[values.length - 1].value);
+  return values
+    .slice(0, -1)
+    .find(
+      (cause) =>
+        CAUSE_GROUPED_ERROR_TYPES.includes(cause.type ?? "") &&
+        thrownValue.includes(fingerprintKey(cause.value)),
+    );
+}
+
+/**
+ * Report an exception under the normalized message it is grouped by, keeping
+ * the original one as extra data.
+ *
+ * Sentry titles an issue by the reported message, so the volatile details that
+ * {@link fingerprintKey} masks out of the grouping key are still what the issue
+ * list shows: one row per document id, and a response body quoted into an error
+ * message (an nginx error page, say) pushing every other row off the screen.
+ * Only used where the message is the grouping key anyway, so that the title of
+ * an issue and the reason its events are in it cannot drift apart.
+ */
+function reportNormalized(
+  event: Sentry.ErrorEvent,
+  exception: Sentry.Exception,
+) {
+  if (!exception.value) {
+    // nothing to read either way, and a placeholder would only pretend there is
+    return;
+  }
+  const normalized = normalizeErrorValue(exception.value).slice(
+    0,
+    MAX_REPORTED_MESSAGE_LENGTH,
+  );
+  if (normalized === exception.value) {
+    return;
+  }
+  event.extra = { ...event.extra, originalError: exception.value };
+  exception.value = normalized;
+}
+
+/**
+ * How much of an error message is kept as the reported one (see
+ * {@link reportNormalized}). Generous enough for any message written to be
+ * read, and a backstop against the ones that turn out to be a serialized
+ * document or a web page.
+ */
+const MAX_REPORTED_MESSAGE_LENGTH = 300;
 
 /**
  * Group by the error chain instead of the stack trace, so that one problem
@@ -626,8 +681,8 @@ function groupSentryEvent(
 function groupByErrorChain(
   event: Sentry.ErrorEvent,
   values: Sentry.Exception[],
+  thrownError: Sentry.Exception,
 ): Sentry.ErrorEvent {
-  const thrownError = values[values.length - 1];
   const thrownType = thrownError.type ?? "";
   const thrownValue = groupingValue(thrownError);
   const fingerprint = [thrownType, thrownValue];
@@ -753,6 +808,17 @@ function hasConnectivityStatus(event: Sentry.ErrorEvent): boolean {
 }
 
 /**
+ * Placeholder type for an exception reported without one.
+ *
+ * Sentry builds an issue title from the reported exception's type and message,
+ * and lists an issue whose exception carries no type as `<unknown>` - which
+ * says nothing at all in a list of issues, and hides the message that would
+ * have. The generic name is no loss: it is what an `Error` subclass reports
+ * anyway unless it sets `name` explicitly (see {@link CAUSE_GROUPED_ERROR_TYPES}).
+ */
+const FALLBACK_EXCEPTION_TYPE = "Error";
+
+/**
  * Enrich events with structured extra data
  * from custom Error properties (e.g. DatabaseException's entityId, status, reason).
  */
@@ -781,6 +847,10 @@ function enrichSentryEvent(
     if (Object.keys(extras).length > 0) {
       event.extra = { ...event.extra, ...extras };
     }
+  }
+
+  for (const exception of event.exception?.values ?? []) {
+    exception.type ||= FALLBACK_EXCEPTION_TYPE;
   }
 
   return event;

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -612,13 +612,18 @@ function groupSentryEvent(
 function rewrappedCauseGroupedError(
   values: Sentry.Exception[],
 ): Sentry.Exception | undefined {
-  const thrownValue = fingerprintKey(values[values.length - 1].value);
+  // fingerprintKey already lower-cased and stripped the colon, leaving at most
+  // this leading "error " from the `Error: <cause>` shape `.toString()` gives
+  const thrownValue = fingerprintKey(values[values.length - 1].value).replace(
+    /^error /,
+    "",
+  );
   return values
     .slice(0, -1)
     .find(
       (cause) =>
         CAUSE_GROUPED_ERROR_TYPES.includes(cause.type ?? "") &&
-        thrownValue.includes(fingerprintKey(cause.value)),
+        thrownValue === fingerprintKey(cause.value),
     );
 }
 

--- a/src/app/core/logging/logging.service.ts
+++ b/src/app/core/logging/logging.service.ts
@@ -844,6 +844,17 @@ function enrichSentryEvent(
         extras[key] = (err as any)[key];
       }
     }
+    // a library may pass on the whole `fetch` Response rather than the status
+    // (keycloak-js does), which otherwise leaves a report saying only that the
+    // status was invalid and never which one it was
+    if (extras.status === undefined) {
+      const status = (err as { response?: { status?: unknown } }).response
+        ?.status;
+      if (typeof status === "number") {
+        extras.status = status;
+      }
+    }
+
     if (Object.keys(extras).length > 0) {
       event.extra = { ...event.extra, ...extras };
     }

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.spec.ts
@@ -329,6 +329,31 @@ describe("KeycloakAuthService", () => {
     }
   });
 
+  it("should treat a gateway status keycloak nested in a Response as unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      // the shape keycloak-js actually throws: the status is on `response`,
+      // not on the error, and the message never says which status it was
+      const gatewayFailure = Object.assign(
+        new Error("Server responded with an invalid status."),
+        { response: { status: 504, statusText: "Gateway Timeout" } },
+      );
+      mockKeycloak.init.mockRejectedValue(gatewayFailure);
+
+      const promise = service.login();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // unavailable rather than a fault to alert on: same treatment as any
+      // other gateway failure, and it retried instead of failing outright
+      await expect(promise).rejects.toBeInstanceOf(
+        RemoteLoginNotAvailableError,
+      );
+      expect(mockKeycloak.init).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should NOT retry login on a 4xx error", async () => {
     const authError = { status: 401 } as any;
     mockKeycloak.init.mockRejectedValue(authError);

--- a/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
+++ b/src/app/core/session/auth/keycloak/keycloak-auth.service.ts
@@ -48,6 +48,31 @@ const TOKEN_REFRESH_RETRY_DELAYS_MS = [2_000, 5_000];
 const TOKEN_MIN_VALIDITY_SECONDS = 30;
 
 /**
+ * What a failed Keycloak operation can say about itself beyond its message.
+ *
+ * `keycloak-js` reports every rejected response as
+ * `Server responded with an invalid status.` and attaches the whole `Response`
+ * as `NetworkError.response` rather than lifting the status out of it - so the
+ * report names neither which status it was nor which endpoint refused, and the
+ * error cannot be told apart from any other by reading it.
+ *
+ * Passed as log context rather than interpolated into the message, so that all
+ * occurrences stay one issue in remote monitoring (see `core/logging/README.md`)
+ * while the status is one click away in the event's data.
+ */
+function keycloakFailureContext(err: any): Record<string, unknown> {
+  const status = err?.response?.status;
+  if (typeof status !== "number") {
+    // the library also rejects for reasons that never reached the server
+    return { responseStatus: "none" };
+  }
+  return {
+    responseStatus: status,
+    responseStatusText: err.response.statusText,
+  };
+}
+
+/**
  * Check whether an error is a retryable network/connectivity error,
  * including keycloak-specific transient failures.
  */
@@ -95,7 +120,11 @@ export class KeycloakAuthService {
       );
     } catch (err) {
       if (this.isOfflineOrUnavailableError(err)) {
-        Logging.debug("Keycloak updateToken failed (offline/unavailable)", err);
+        Logging.debug(
+          "Keycloak updateToken failed (offline/unavailable)",
+          err,
+          keycloakFailureContext(err),
+        );
         throw new RemoteLoginNotAvailableError(err);
       }
       throw err;
@@ -174,10 +203,14 @@ export class KeycloakAuthService {
       );
     } catch (err) {
       if (this.isOfflineOrUnavailableError(err)) {
-        Logging.debug("Keycloak init failed (offline/unavailable)", err);
+        Logging.debug(
+          "Keycloak init failed (offline/unavailable)",
+          err,
+          keycloakFailureContext(err),
+        );
         err = new RemoteLoginNotAvailableError(err);
       } else {
-        Logging.error("Keycloak init failed", err);
+        Logging.error("Keycloak init failed", err, keycloakFailureContext(err));
       }
 
       this.initKeycloak.cache.clear();

--- a/src/app/utils/connectivity-error.spec.ts
+++ b/src/app/utils/connectivity-error.spec.ts
@@ -24,6 +24,28 @@ describe("isConnectivityError", () => {
     }
   });
 
+  it("detects a gateway status a library nested inside a Response", () => {
+    // keycloak-js reports every rejected response as "Server responded with an
+    // invalid status." and hands on the whole Response instead of the status
+    for (const status of [0, 502, 503, 504]) {
+      expect(
+        isConnectivityError(
+          Object.assign(new Error("Server responded with an invalid status."), {
+            response: { status },
+          }),
+        ),
+      ).toBe(true);
+    }
+    // a status that is the server answering, not failing to be reached
+    expect(
+      isConnectivityError(
+        Object.assign(new Error("Server responded with an invalid status."), {
+          response: { status: 400 },
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("detects browser fetch failures by message", () => {
     expect(isConnectivityError(new TypeError("Failed to fetch"))).toBe(true);
     expect(

--- a/src/app/utils/connectivity-error.ts
+++ b/src/app/utils/connectivity-error.ts
@@ -1,4 +1,20 @@
 /**
+ * Wordings for a lazily loaded application chunk that could not be fetched.
+ *
+ * These are requests that did not arrive, like any other connectivity failure:
+ * the device is offline, or a new deployment replaced the chunk that the
+ * still-running app asks for. Which of the two it was is not visible from the
+ * error, and neither is actionable per chunk - so they belong in the shared
+ * network issue rather than in one issue per chunk URL and browser wording.
+ */
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  // Chrome/Edge: "Failed to fetch dynamically imported module: <url>"
+  // Firefox: "error loading dynamically imported module: <url>"
+  "dynamically imported module",
+  "Importing a module script failed", // Safari
+];
+
+/**
  * Common network/connectivity error patterns shared across the application.
  * These indicate transient failures (offline, DNS, proxy issues) rather than
  * application-level errors.
@@ -10,6 +26,7 @@ const CONNECTIVITY_ERROR_PATTERNS = [
   "Network request failed",
   "network timeout",
   "0 Unknown Error", // Angular HttpErrorResponse for a request that never reached the server
+  ...CHUNK_LOAD_ERROR_PATTERNS,
 ];
 
 /**

--- a/src/app/utils/connectivity-error.ts
+++ b/src/app/utils/connectivity-error.ts
@@ -71,7 +71,16 @@ export function isConnectivityError(err: any): boolean {
   if (names.some((name) => CONNECTIVITY_ERROR_NAMES.includes(name))) {
     return true;
   }
-  if (CONNECTIVITY_ERROR_STATUS.includes(err?.status)) return true;
+  // `err.response.status` as well as `err.status`: a library that wraps `fetch`
+  // may hand on the whole `Response` instead of lifting the status out of it
+  // (keycloak-js does, see `NetworkError`), and a gateway failure is the same
+  // problem whichever shape it arrives in
+  if (
+    CONNECTIVITY_ERROR_STATUS.includes(err?.status) ||
+    CONNECTIVITY_ERROR_STATUS.includes(err?.response?.status)
+  ) {
+    return true;
+  }
 
   const message = `${err?.message ?? ""} ${err?.reason ?? ""} ${err?.toString?.() ?? ""}`;
   return isConnectivityErrorMessage(message);

--- a/src/bootstrap-i18n.ts
+++ b/src/bootstrap-i18n.ts
@@ -63,7 +63,10 @@ async function fetchTranslations(
   }
 
   Logging.warn(
-    `Could not load translations for locale '${locale}', falling back to default language.`,
+    // the locale is context, not part of the message: interpolated it would
+    // open a separate remote-monitoring issue per locale (see logging/README.md)
+    "Could not load translations for the requested locale, falling back to the default language.",
+    { locale },
   );
   return undefined;
 }


### PR DESCRIPTION
Triaged the whole unresolved Sentry list and fixed the reporting problems that spread one root cause across many issues. Real bugs found along the way are filed separately (#4360–#4371), not in here.

## What was splitting

- **A framework re-throwing one of our own errors.** Angular wraps anything raised inside a `resource()` loader in an error of its own that copies the message and reports the `"Error"` name a subclass inherits, so the event dropped out of fingerprint-based grouping and opened a separate issue per call site. A wrapper that only repeats its cause's message now groups by the recognized error underneath it; one with a message of its own (`Failed to load configuration from the database.`) still describes the failure better than its cause and stays what the event is grouped by.
- **Chunk load failures.** Chrome, Firefox and Safari each word them differently and each message carries the chunk URL, so one deploy or one flaky connection produced an open-ended stream of near-identical issues, plus a second copy of the bootstrap failure wrapping them. A chunk that does not arrive means the device is offline or a deployment replaced the chunk the running app still asks for — neither is actionable per chunk, so all three wordings now classify as connectivity.
- **Titles that did not match their own grouping.** An exception grouped by its message is now also *reported* under that normalized message, with the raw one kept as `originalError`. Without this the list still showed the volatile detail the grouping had masked: a row per document id, or the whole HTML error page a reverse proxy quotes into a message, which pushes every other row off the screen.
- **Events with no exception type**, which Sentry lists as `<unknown>` — a title that says nothing in a list of issues and hides the message that would. Those now fall back to a generic type.
- **Varying data interpolated into log messages** at three call sites: the document ids of the last synced batch, the database name, and the requested locale. All three now travel as structured context. The document ids also had no place in monitoring at all — same concern as #4174 — so only a batch size and the entity types are reported.
- **A rejected save losing its cause.** `saveChanges` re-threw a user-facing message without `{ cause }`, so the report never said what actually rejected the write.

## Gateway statuses hidden inside a Response

`keycloak-js` words every rejected response as `Server responded with an invalid status.`, attaches the whole `Response` as `NetworkError.response` instead of lifting the status out of it, and does not set `name` — so those reports named neither which status it was nor whether the server had answered at all.

`isConnectivityError` now reads `err.response.status` alongside `err.status`, which **changes behaviour**: a gateway status (`0`/`502`/`503`/`504`) from the auth server was previously invisible to `isOfflineOrUnavailableError`, so a proxy timing out in front of Keycloak was alerted on as a fault instead of taking the same quiet path as every other gateway failure. The status is also reported now — as event data for an unhandled occurrence, and as explicit log context at the Keycloak call sites, which is needed separately because the branch that reaches monitoring wraps the library error and so is not covered by `enrichSentryEvent`'s property lifting.

This is the diagnostics half of #4363; the user-facing message and the three unwrapped copies stay open there, with the reasoning in [a comment on that issue](https://github.com/Aam-Digital/ndb-core/issues/4363#issuecomment-5581033785).

## Removing the never-wired user context

`initAngularLogging` returned the function that subscribes to the login state instead of subscribing, and `provideAppInitializer` discards anything that is not a promise or observable, so `Sentry.setUser` was never called. Reporting no user identity is the intended behaviour — data minimization under the GDPR — so the dead wiring goes rather than getting "fixed" into a regression by whoever notices it next. `core/logging/README.md` used to point triage at the affected-user count and now documents what is actually available instead: affected sessions (Sentry's session counting is a default integration and is anonymous), the spread across deployments and releases via the `url` and `release` tags, and whether an issue is still recurring.

## Follow-up in Sentry

41 issues were taken out of the unresolved list during the triage — 34 archived as groupings that fixes already live in 3.91.0 had superseded, and 7 set to resolve with the next release because their fix is on `master` but not yet shipped (`9fea7b7`, `008ff55`, `7160ecc`).

Two more should be resolved once **this** PR merges and ships: [78P](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78P) and [78N](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78N), the chunk-load wordings this PR folds into the shared network issue. They were left open deliberately, so nothing is marked fixed before the fix is actually out.

## Testing

Nine new specs: the re-wrapped error, the guard against over-merging a wrapper that has its own message, the three chunk-load wordings, the typeless exception, the normalized report message, the stripped response body, the nested gateway status in both `isConnectivityError` and the reported event data, and the Keycloak gateway failure now classifying as unavailable. Lint clean; the logging, database, session, entity, common-components and permissions specs pass.

**Not manually tested, and it needs someone to do that.** Most of this behaviour only shows up in what remote monitoring receives — `beforeSend` runs on real reported events, so there is nothing in the UI that exercises it — which is why the coverage is unit tests against `processSentryEvent`. What a reviewer should check by hand is that the touched call sites did not regress:

1. Open a case list view while offline, confirm the load-error toast still appears and the retry works.
2. Save a record from a details form with an invalid value, confirm the error message shown to the user is unchanged.
3. Open the app in two tabs and write in both until the "Local Database Needs Reset" dialog appears, confirm it still appears and still offers the reset.
4. Switch the interface language to one with no translations published, confirm it falls back to the default language silently.
5. Log in normally, and confirm a session still refreshes its token in the background over a long-running session — the Keycloak change touches how failures are classified, so the success path wants a look too.

`resetSentryEventCounts` is exported for the specs. The repeat budget is per issue and per app session, so without it the events of one test counted against the next one's — and the existing network-error tests were already at the cap, which is why adding one more broke three of them.

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing — **steps are above; the manual run itself is still open**
- [x] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrFd1CckwHtaYMTVD4tWbX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of connectivity failures, including gateway responses and browser chunk-load errors.
  * Keycloak login now better recognizes temporary service unavailability and retries appropriately.
  * Error details are preserved more reliably for troubleshooting.

* **Privacy**
  * User identity is no longer included in remote error reporting, supporting GDPR data minimization.

* **Logging**
  * Diagnostic data is now structured for clearer, safer troubleshooting without embedding sensitive identifiers in messages.

* **Documentation**
  * Expanded remote logging guidance for error grouping, network failures, normalization, and anonymous reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->