### PR TITLE
fix: enable editing the linked user entity of a user account

### DIFF
--- a/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.spec.ts
@@ -194,6 +194,66 @@ describe("KeycloakAdminService", () => {
       .flush({});
   });
 
+  it("should preserve unrelated fields and merge attributes when updating only the linked profile", async () => {
+    // given
+    const mockUser = {
+      id: "test-id",
+      email: "existing@example.com",
+      enabled: true,
+      emailVerified: true,
+      attributes: { locale: ["en"] },
+    };
+
+    // when
+    service
+      .updateUser("test-id", { userEntityId: "User:new-entity-id" })
+      .subscribe((result) => {
+        expect(result).toEqual({ userUpdated: true });
+      });
+
+    // then
+    const reqGet = httpTestingController.expectOne(`${BASE_URL}/users/test-id`);
+    expect(reqGet.request.method).toEqual("GET");
+    reqGet.flush(mockUser);
+
+    const reqPut = httpTestingController.expectOne(`${BASE_URL}/users/test-id`);
+    expect(reqPut.request.method).toEqual("PUT");
+    expect(reqPut.request.body).toEqual({
+      id: "test-id",
+      email: "existing@example.com",
+      enabled: true,
+      emailVerified: true,
+      attributes: {
+        locale: ["en"],
+        exact_username: ["User:new-entity-id"],
+      },
+    });
+    reqPut.flush({});
+  });
+
+  it("should send enabled:false as an explicit value, not drop it as an unset key", async () => {
+    // given
+    const mockUser = {
+      id: "test-id",
+      email: "existing@example.com",
+      enabled: true,
+      emailVerified: true,
+    };
+
+    // when
+    service.updateUser("test-id", { enabled: false }).subscribe();
+
+    // then
+    const reqGet = httpTestingController.expectOne(`${BASE_URL}/users/test-id`);
+    reqGet.flush(mockUser);
+
+    const reqPut = httpTestingController.expectOne(`${BASE_URL}/users/test-id`);
+    expect(reqPut.request.body).toEqual(
+      expect.objectContaining({ enabled: false }),
+    );
+    reqPut.flush({});
+  });
+
   it("should handle error when updating user", async () => {
     // when
     service

--- a/src/app/core/user/user-admin-service/keycloak-admin.service.ts
+++ b/src/app/core/user/user-admin-service/keycloak-admin.service.ts
@@ -164,7 +164,19 @@ export class KeycloakAdminService extends UserAdminService {
     }
 
     // first update the user object, then run other actions
-    const newUser = { ...currentUser, ...updatedUser }; // make sure we don't lose unchanged properties
+    const newUser: Record<string, unknown> = {
+      ...currentUser,
+      ...updatedUser, // make sure we don't lose unchanged properties
+      // merge rather than let `updatedUser.attributes` replace the whole map,
+      // which would drop every other Keycloak attribute the user has
+      attributes: { ...currentUser.attributes, ...updatedUser.attributes },
+    };
+    Object.keys(newUser).forEach((key) => {
+      if (newUser[key] === undefined) {
+        delete newUser[key];
+      }
+    });
+
     return this.http
       .put(`${this.keycloakUrl}/users/${currentUser.id}`, newUser)
       .pipe(concatWith(...actions));

--- a/src/app/core/user/user-admin-service/keycloak-user-dto.ts
+++ b/src/app/core/user/user-admin-service/keycloak-user-dto.ts
@@ -14,7 +14,7 @@ export class KeycloakUserDto {
 
   email?: string;
 
-  attributes?: { [key in string]: string };
+  attributes?: { [key in string]: string[] };
 
   requiredActions?: string[];
 
@@ -30,19 +30,34 @@ export class KeycloakUserDto {
       this.requiredActions = ["VERIFY_EMAIL", "UPDATE_PASSWORD"];
     }
     if (userEntityId) {
-      this.attributes = { exact_username: userEntityId };
+      this.attributes = { exact_username: [userEntityId] };
     }
   }
 
-  static fromUserAccount(userAccount: Partial<UserAccount>): KeycloakUserDto {
-    const kcUser = new KeycloakUserDto();
-    kcUser.id = userAccount.id;
-    kcUser.email = userAccount.email;
-    kcUser.enabled = userAccount.enabled;
-    kcUser.emailVerified = userAccount.emailVerified;
+  /**
+   * Builds a partial update from a partial {@link UserAccount}, assigning only the keys the
+   * partial actually defines. This is required for {@link KeycloakAdminService.updateKeycloakUser},
+   * which merges the result onto the current user - an explicit `undefined` here would overwrite
+   * (and effectively clear) that field on the server.
+   */
+  static fromUserAccount(
+    userAccount: Partial<UserAccount>,
+  ): Partial<KeycloakUserDto> {
+    const kcUser: Partial<KeycloakUserDto> = {};
+    if (userAccount.id !== undefined) {
+      kcUser.id = userAccount.id;
+    }
+    if (userAccount.email !== undefined) {
+      kcUser.email = userAccount.email;
+    }
+    if (userAccount.enabled !== undefined) {
+      kcUser.enabled = userAccount.enabled;
+    }
+    if (userAccount.emailVerified !== undefined) {
+      kcUser.emailVerified = userAccount.emailVerified;
+    }
     if (userAccount.userEntityId) {
-      kcUser.attributes = kcUser.attributes ?? {};
-      kcUser.attributes.exact_username = userAccount.userEntityId;
+      kcUser.attributes = { exact_username: [userAccount.userEntityId] };
     }
     return kcUser;
   }

--- a/src/app/core/user/user-admin-service/user-account-action-guard.service.spec.ts
+++ b/src/app/core/user/user-admin-service/user-account-action-guard.service.spec.ts
@@ -1,0 +1,27 @@
+import { entityIdsMatch } from "./user-account-action-guard.service";
+
+describe("entityIdsMatch", () => {
+  it.each([
+    ["identical prefixed ids", "User:abc", "User:abc", true],
+    ["identical unprefixed ids", "abc", "abc", true],
+    ["one prefixed, other not, same trailing id", "User:abc", "abc", true],
+    [
+      "unprefixed first, prefixed second, same trailing id",
+      "abc",
+      "User:abc",
+      true,
+    ],
+    [
+      "both prefixed but with different types or ids",
+      "User:abc",
+      "Child:abc",
+      false,
+    ],
+    ["unrelated ids", "abc", "xyz", false],
+    ["missing first id", undefined, "User:abc", false],
+    ["missing second id", "User:abc", undefined, false],
+    ["both missing", undefined, undefined, true],
+  ])("%s", (_case, a, b, expected) => {
+    expect(entityIdsMatch(a, b)).toBe(expected);
+  });
+});

--- a/src/app/core/user/user-admin-service/user-account-action-guard.service.ts
+++ b/src/app/core/user/user-admin-service/user-account-action-guard.service.ts
@@ -5,6 +5,41 @@ import { SessionSubject } from "../../session/auth/session-info";
 
 export type SelfAccountAction = "delete" | "deactivate";
 
+/**
+ * Compares two entity ids where one or both may be missing the `Type:` prefix
+ * (e.g. a legacy `exact_username` stored without it), treating them as equal
+ * when they refer to the same record.
+ *
+ * Exported for reuse wherever a stored/session entity id needs to be compared
+ * against a value coming from an entity picker (which always includes the prefix).
+ */
+export function entityIdsMatch(
+  entityIdA?: string | null,
+  entityIdB?: string | null,
+): boolean {
+  if (!entityIdA || !entityIdB) {
+    return entityIdA === entityIdB;
+  }
+  if (entityIdA === entityIdB) {
+    return true;
+  }
+
+  const aHasTypePrefix = entityIdA.includes(":");
+  const bHasTypePrefix = entityIdB.includes(":");
+  if (aHasTypePrefix && bHasTypePrefix) {
+    return false;
+  }
+
+  return (
+    getEntityIdWithoutTypePrefix(entityIdA) ===
+    getEntityIdWithoutTypePrefix(entityIdB)
+  );
+}
+
+export function getEntityIdWithoutTypePrefix(entityId: string): string {
+  return entityId.split(":").at(-1) ?? entityId;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -29,7 +64,7 @@ export class UserAccountActionGuardService {
       return false;
     }
 
-    return this.entityIdsMatch(session.entityId, account.userEntityId);
+    return entityIdsMatch(session.entityId, account.userEntityId);
   }
 
   async showSelfAccountActionBlockedWarning(
@@ -49,26 +84,5 @@ export class UserAccountActionGuardService {
       $localize`:self-deletion warning dialog:You cannot delete your own account. Please ask another admin to remove your account if needed.`,
       OkButton,
     );
-  }
-
-  private entityIdsMatch(sessionEntityId: string, accountEntityId: string) {
-    if (sessionEntityId === accountEntityId) {
-      return true;
-    }
-
-    const sessionHasTypePrefix = sessionEntityId.includes(":");
-    const accountHasTypePrefix = accountEntityId.includes(":");
-    if (sessionHasTypePrefix && accountHasTypePrefix) {
-      return false;
-    }
-
-    return (
-      this.getEntityIdWithoutTypePrefix(sessionEntityId) ===
-      this.getEntityIdWithoutTypePrefix(accountEntityId)
-    );
-  }
-
-  private getEntityIdWithoutTypePrefix(entityId: string) {
-    return entityId.split(":").at(-1) ?? entityId;
   }
 }

--- a/src/app/core/user/user-details/user-details.component.html
+++ b/src/app/core/user/user-details/user-details.component.html
@@ -213,10 +213,18 @@
           formControlName="userEntityId"
           [entityType]="userAccountEntityTypes()"
         ></app-edit-entity>
+        @if (getFormError("userEntityId", "required")) {
+          <mat-error i18n>This field is required</mat-error>
+        }
         @if (!creatingNewAccount()) {
-          <mat-hint i18n>
-            Editing linked profile record is not possible here. Please contact
-            user support.
+          <mat-hint
+            i18n="
+              hint explaining the consequence of changing the linked profile
+            "
+          >
+            Changing this links the account to a different profile record. The
+            previous record stays in the database but will no longer have a
+            login account.
           </mat-hint>
         }
       </mat-form-field>

--- a/src/app/core/user/user-details/user-details.component.html
+++ b/src/app/core/user/user-details/user-details.component.html
@@ -216,7 +216,7 @@
         @if (getFormError("userEntityId", "required")) {
           <mat-error i18n>This field is required</mat-error>
         }
-        @if (!creatingNewAccount()) {
+        @if (!creatingNewAccount() && !formDisabled()) {
           <mat-hint
             i18n="
               hint explaining the consequence of changing the linked profile

--- a/src/app/core/user/user-details/user-details.component.spec.ts
+++ b/src/app/core/user/user-details/user-details.component.spec.ts
@@ -27,12 +27,14 @@ type UserAdminServiceMock = {
   updateUser: Mock;
   deleteUser: Mock;
   resendInvitation: Mock;
+  getUser: Mock;
 };
 
 type AlertServiceMock = {
   addInfo: Mock;
   addAlert: Mock;
   addDanger: Mock;
+  addWarning: Mock;
 };
 
 type KeycloakAuthServiceMock = {
@@ -83,14 +85,17 @@ describe("UserDetailsComponent", () => {
         .fn()
         .mockName("UserAdminService.resendInvitation")
         .mockReturnValue(of(undefined)),
+      getUser: vi.fn().mockName("UserAdminService.getUser"),
     };
     mockUserAdminService.getAllRoles.mockReturnValue(of([mockRole]));
     mockUserAdminService.updateUser.mockReturnValue(of({ userUpdated: true }));
+    mockUserAdminService.getUser.mockReturnValue(of(null));
 
     mockAlertService = {
       addInfo: vi.fn().mockName("AlertService.addInfo"),
       addAlert: vi.fn().mockName("AlertService.addAlert"),
       addDanger: vi.fn().mockName("AlertService.addDanger"),
+      addWarning: vi.fn().mockName("AlertService.addWarning"),
     };
     mockKeycloakService = {
       changePassword: vi.fn().mockName("KeycloakAuthService.changePassword"),
@@ -434,5 +439,172 @@ describe("UserDetailsComponent", () => {
     component.save();
 
     expect(mockHttpClient.post).not.toHaveBeenCalled();
+  });
+
+  describe("changing the linked profile", () => {
+    const linkedUserAccount: UserAccount = {
+      ...mockUserAccount,
+      userEntityId: "legacy-id", // no type prefix, as stored by a pre-existing account
+    };
+
+    it("should keep the profile field editable for an existing account", () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+
+      component.editMode();
+      fixture.detectChanges();
+
+      expect(component.form.get("userEntityId").disabled).toBe(false);
+    });
+
+    it("should not allow clearing the linked profile of an already-linked account", () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      component.form.get("userEntityId").setValue(null);
+
+      expect(component.form.get("userEntityId").hasError("required")).toBe(
+        true,
+      );
+      expect(component.form.invalid).toBe(true);
+    });
+
+    it("should allow editing other fields of an account that has no linked profile", async () => {
+      fixture.componentRef.setInput("userAccount", {
+        ...mockUserAccount,
+        userEntityId: undefined,
+      });
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      expect(component.form.get("userEntityId").hasError("required")).toBe(
+        false,
+      );
+
+      component.form.patchValue({ email: "updated@example.com" });
+      await component.save();
+
+      expect(mockUserAdminService.updateUser).toHaveBeenCalledWith(
+        mockUserAccount.id,
+        { email: "updated@example.com" },
+      );
+    });
+
+    it("should not update when re-saving an unchanged profile without a type prefix", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      // form now displays the normalised "User:legacy-id", but nothing was actually changed
+      await component.save();
+
+      expect(mockUserAdminService.getUser).not.toHaveBeenCalled();
+      expect(mockUserAdminService.updateUser).not.toHaveBeenCalled();
+      expect(mockDialogRef.close).toHaveBeenCalledWith({ type: "formCancel" });
+    });
+
+    it("should refuse re-linking to a profile that already has a different account", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(
+        of({ id: "some-other-account-id", enabled: true }),
+      );
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockUserAdminService.getUser).toHaveBeenCalledWith(
+        "User:other-entity",
+      );
+      expect(mockAlertService.addDanger).toHaveBeenCalledWith(
+        expect.stringContaining("Each profile can only be linked"),
+      );
+      expect(mockUserAdminService.updateUser).not.toHaveBeenCalled();
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it("should proceed when the profile lookup resolves back to this very account", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(
+        of({ id: linkedUserAccount.id, enabled: true }),
+      );
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockUserAdminService.updateUser).toHaveBeenCalledWith(
+        linkedUserAccount.id,
+        expect.objectContaining({ userEntityId: "User:other-entity" }),
+      );
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "accountUpdated" }),
+      );
+    });
+
+    it("should not re-link when the user cancels the confirmation", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(of(null));
+      confirmationDialog.getConfirmation.mockResolvedValue(false);
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockUserAdminService.updateUser).not.toHaveBeenCalled();
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it("should trigger sync reset when the linked profile changes, not only on role changes", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(of(null));
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.stringContaining("/admin/clear_local/"),
+        undefined,
+      );
+    });
+
+    it("should surface a re-login notice when re-linking one's own account", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      mockSessionSubject.next({
+        id: linkedUserAccount.id,
+        name: "test",
+        roles: [],
+      });
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(of(null));
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockUserAdminService.updateUser).toHaveBeenCalled();
+      expect(mockAlertService.addWarning).toHaveBeenCalledWith(
+        expect.stringContaining("log out"),
+      );
+    });
   });
 });

--- a/src/app/core/user/user-details/user-details.component.spec.ts
+++ b/src/app/core/user/user-details/user-details.component.spec.ts
@@ -530,6 +530,26 @@ describe("UserDetailsComponent", () => {
       expect(mockDialogRef.close).not.toHaveBeenCalled();
     });
 
+    it("should not re-link when the check for an existing account fails", async () => {
+      fixture.componentRef.setInput("userAccount", linkedUserAccount);
+      fixture.detectChanges();
+      component.editMode();
+      fixture.detectChanges();
+
+      mockUserAdminService.getUser.mockReturnValue(
+        throwError(() => new Error("server unreachable")),
+      );
+      component.form.patchValue({ userEntityId: "User:other-entity" });
+
+      await component.save();
+
+      expect(mockAlertService.addDanger).toHaveBeenCalledWith(
+        expect.stringContaining("Could not check"),
+      );
+      expect(mockUserAdminService.updateUser).not.toHaveBeenCalled();
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
     it("should proceed when the profile lookup resolves back to this very account", async () => {
       fixture.componentRef.setInput("userAccount", linkedUserAccount);
       fixture.detectChanges();

--- a/src/app/core/user/user-details/user-details.component.ts
+++ b/src/app/core/user/user-details/user-details.component.ts
@@ -419,9 +419,23 @@ export class UserDetailsComponent {
     currentUser: UserAccount,
     newEntityId: string,
   ): Promise<boolean> {
-    const conflictingAccount = await firstValueFrom(
-      this.userAdminService.getUser(newEntityId),
-    ).catch(() => null);
+    let conflictingAccount: UserAccount | null;
+    try {
+      // getUser resolves to null when no account is linked to that profile,
+      // and only throws when the lookup itself failed
+      conflictingAccount = await firstValueFrom(
+        this.userAdminService.getUser(newEntityId),
+      );
+    } catch (error) {
+      // a failed lookup is not evidence that the profile is free - refuse the change rather
+      // than risk linking a second account to a profile that already has one
+      Logging.error("Failed to check for an existing user account", error);
+      this.alertService.addDanger(
+        $localize`:Error message:Could not check whether this profile already has a user account. Please try again.`,
+      );
+      return false;
+    }
+
     // getUser looks up by the new profile's exact_username, so on an unchanged save it resolves
     // back to this very account - only a *different* account's id is an actual conflict.
     if (conflictingAccount && conflictingAccount.id !== currentUser.id) {

--- a/src/app/core/user/user-details/user-details.component.ts
+++ b/src/app/core/user/user-details/user-details.component.ts
@@ -46,7 +46,10 @@ import { Entity } from "../../entity/model/entity";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
 import { Logging } from "#src/app/core/logging/logging.service";
 import { catchError, map } from "rxjs/operators";
-import { UserAccountActionGuardService } from "../user-admin-service/user-account-action-guard.service";
+import {
+  entityIdsMatch,
+  UserAccountActionGuardService,
+} from "../user-admin-service/user-account-action-guard.service";
 
 /**
  * Options as input to the UserDetailsComponent when it is opened in a dialog.
@@ -136,11 +139,6 @@ export class UserDetailsComponent {
       this.form.disable();
     } else {
       this.form.enable();
-
-      // profile entity is readonly when editing an existing account
-      if (!this.creatingNewAccount()) {
-        this.form.get("userEntityId").disable();
-      }
     }
   });
 
@@ -206,6 +204,23 @@ export class UserDetailsComponent {
           rolesControl.setValidators([Validators.required]);
         }
         rolesControl.updateValueAndValidity();
+      }
+    });
+
+    // Once an account already has a linked profile, the field can no longer be cleared here
+    // (the control used to be readonly for this exact reason) - only re-linked to a different
+    // profile via `updateAccount()`. An account with no profile at all stays optional to edit,
+    // since #3087 (system-init assistant) relies on that being a valid, silent state.
+    effect(() => {
+      const currentUserEntityId = this.userAccount()?.userEntityId;
+      const profileControl = this.form.get("userEntityId");
+      if (profileControl) {
+        if (!this.creatingNewAccount() && currentUserEntityId) {
+          profileControl.setValidators([Validators.required]);
+        } else {
+          profileControl.clearValidators();
+        }
+        profileControl.updateValueAndValidity();
       }
     });
 
@@ -348,15 +363,44 @@ export class UserDetailsComponent {
       update.roles = formData.roles;
     }
 
+    const profileChanged =
+      !!formData.userEntityId &&
+      !entityIdsMatch(formData.userEntityId, currentUser.userEntityId);
+    if (profileChanged) {
+      update.userEntityId = formData.userEntityId;
+    }
+
     if (Object.keys(update).length === 0) {
       this.closeDialog({ type: "formCancel" });
       return;
     }
 
+    if (
+      profileChanged &&
+      !(await this.confirmProfileChange(currentUser, formData.userEntityId))
+    ) {
+      return;
+    }
+
+    // capture before the update overwrites `userAccount()` with the new profile
+    const isOwnAccountRelink =
+      profileChanged &&
+      this.accountActionGuard.isOwnAccount({
+        userAccountId: currentUser.id,
+        userEntityId: currentUser.userEntityId,
+      });
+
     const result = await this.updateUserAccount(
       update,
       $localize`:Snackbar message:Successfully updated user`,
     );
+
+    if (result && isOwnAccountRelink) {
+      this.alertService.addWarning(
+        $localize`:own account relink notice:Your account is now linked to a different profile. You need to log out and log back in for this to take effect in your current session.`,
+      );
+    }
+
     this.formDisabled.set(true);
     this.closeDialog({
       type: "accountUpdated",
@@ -364,6 +408,34 @@ export class UserDetailsComponent {
         user: result,
       },
     });
+  }
+
+  /**
+   * Checks the one-account-per-profile rule and asks the admin to confirm re-linking the
+   * account, since the previous profile record stays in the database but stops being anyone's
+   * login profile.
+   */
+  private async confirmProfileChange(
+    currentUser: UserAccount,
+    newEntityId: string,
+  ): Promise<boolean> {
+    const conflictingAccount = await firstValueFrom(
+      this.userAdminService.getUser(newEntityId),
+    ).catch(() => null);
+    // getUser looks up by the new profile's exact_username, so on an unchanged save it resolves
+    // back to this very account - only a *different* account's id is an actual conflict.
+    if (conflictingAccount && conflictingAccount.id !== currentUser.id) {
+      this.alertService.addDanger(
+        $localize`:Error message:A user account already exists for this profile. Each profile can only be linked to one account.`,
+      );
+      return false;
+    }
+
+    const confirmed = await this.confirmationDialog.getConfirmation(
+      $localize`:confirm changing linked profile title:Change linked profile?`,
+      $localize`:confirm changing linked profile message:This account will be linked to the newly selected profile record instead. The previous profile record stays in the database, but will no longer be linked to a login account. Permission rules based on this user's identity, as well as records created, updated or assigned to this user going forward, will use the new profile record instead.`,
+    );
+    return confirmed === true;
   }
 
   private async updateUserAccount(
@@ -387,7 +459,9 @@ export class UserDetailsComponent {
           const updatedUser = { ...currentUser, ...update };
           this.userAccount.set(updatedUser);
 
-          if (update.roles?.length > 0) {
+          if (update.roles?.length > 0 || update.userEntityId) {
+            // roles and the linked profile both affect which documents the permission backend
+            // replicates to this user (rules keyed on `${user.roles}` / `${user.entityId}`)
             this.triggerSyncReset();
           }
 


### PR DESCRIPTION
## Summary

Fixes #4373. The profile record linked to a login account was fixed at creation time and read-only afterwards, with no way to fix a mislinked account short of deleting and recreating it.

- **Write-path fix (own commit):** `KeycloakUserDto.fromUserAccount` always assigned `email`/`enabled`/`emailVerified`, even as explicit `undefined` when a partial update omitted them. Spreading that onto the current user in `updateKeycloakUser` overwrote real values with `undefined`, and `attributes` was rebuilt from scratch instead of merged — so any update carrying `userEntityId` would have wiped every other Keycloak attribute (and email/enabled with it). No current caller trips this today (only `email`/`roles` are ever sent), but it made it unsafe to ever update just the linked profile.
- **Feature:** the "Profile" field in the user account admin UI is no longer disabled for existing accounts. Saving now diffs the linked profile prefix-tolerantly (so a legacy `exact_username` without a `Type:` prefix doesn't look changed on every save), enforces the one-account-per-profile rule (comparing by account id, not entity id, so re-saving an account's own current profile isn't refused), confirms before re-linking, resets sync state on a profile change, and warns an admin when they re-link their own account (their session's `entityId` won't update until next login).
- The newly-enabled field also exposes the entity picker's clear ("×") action, which could otherwise silently no-op a save; the field is now required once an account already has a linked profile, while accounts with no profile at all (a valid, intentional state) stay optional to edit.
- Also includes a small unrelated docs commit (`src/app/core/setup/README.md`) documenting the existing system-init flow, carried over from a parallel branch since it's used as research context for a follow-up PR (#3087) that depends on this one.

## Test plan

- [x] `npm run test -- --watch=false --include='**/keycloak-admin.service.spec.ts' --include='**/user-details.component.spec.ts' --include='**/user-account-action-guard.service.spec.ts'`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual, against real Keycloak: user administration → open an account → change the linked profile → confirm; check in Keycloak that `exact_username` is the new id and email/enabled/other attributes are untouched
- [ ] Manual: verify `EntityUserComponent` re-runs its `getUser` lookup for the now-orphaned old profile record rather than showing stale account data (flagged as a follow-up decision, not changed in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Existing accounts can now change their linked profile.
  - Profile changes require confirmation, detect conflicts, and warn when relinking the current user’s account.
  - Changing a linked profile triggers a synchronization reset.

- **Bug Fixes**
  - Linked profiles are correctly validated, while unlinked accounts may remain without one.
  - Failed profile conflict checks now stop relinking and display an alert.
  - Updating user details preserves unrelated profile information and explicitly handles disabled accounts.
  - Linked-profile guidance and required-field messages have been updated for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->