### PR TITLE
feat: link the initial admin account to an entity during system setup

### DIFF
--- a/src/app/core/setup/README.md
+++ b/src/app/core/setup/README.md
@@ -20,8 +20,39 @@ exists.
    permissions, enum definitions, site settings, sample reports/forms, etc.
 4. Once the config document is saved, the app reconfigures itself reactively — routing and entity
    types are rebuilt and the current page re-renders. There's no redirect and no page reload.
-5. From then on, the Assistant instead shows context-aware guidance and, until it's marked finished,
+5. If the logged-in account isn't linked to any profile yet, a second step offers to create one and
+   link the account to it (see below) before showing "Start Exploring".
+6. From then on, the Assistant instead shows context-aware guidance and, until it's marked finished,
    the multi-step [Setup Wizard](../admin/setup-wizard/) for further onboarding.
+
+## Linking the initial admin's account to a profile
+
+Keycloak's very first user is created with no `exact_username` attribute, so nothing links their login
+account to a "profile" entity (the record `${user.entityId}` permission rules and `createdBy`/`updatedBy`
+resolve to). `UserEntityLinkService` and a step in `system-init-assistant/` close that gap, once per
+account, right after setup:
+
+- **Only offered when `SessionInfo.entityId` is unset** (`UserEntityLinkService.shouldOfferStep`) - the
+  same "no linked profile" state that's already valid and silent for any account outside setup (see
+  above). This is also what makes demo mode skip the step automatically: its hardcoded session already
+  sets `entityId`.
+- **Which entity type to create is asked, not assumed.** `getUserEntityTypes()` returns every type with
+  `enableUserAccounts` set, in entity-registry order - there is no defensible "first" one. The step
+  renders nothing for zero types, skips the picker for exactly one, and shows a dropdown for several.
+- **The form reuses the type's own details-view config** (its first panel's `Form` component, falling
+  back to `toStringAttributes` if there is none) rather than a setup-specific field list, and saves
+  through `EntityFormService` like any other form.
+- **The account is linked only after the entity is saved**, via the same `updateUser(accountId, {
+  userEntityId })` write path the user administration UI (`../user/user-details/`) uses to re-link an
+  existing account - this step is really just that same operation, automated for the very first login.
+- **A successful link reloads the app.** `SessionInfo.entityId` comes from a token claim set at login;
+  writing the Keycloak attribute server-side doesn't change an already-issued token, so the app has to
+  do a fresh login (`init()`'s SSO check) to pick it up - the reload is only skipped when the write
+  wasn't actually persisted, which is also what keeps this safe on a demo/e2e session (excluded by the
+  gate above regardless, but asserted explicitly in tests as the invariant that matters).
+- **Never rolled back.** The entity is saved before the link is attempted, so a failed link (missing
+  permission, network error) leaves a real, unlinked record behind rather than losing the user's input;
+  the user is told an admin can link it later.
 
 ## Base configs
 
@@ -53,8 +84,10 @@ offer their own use cases without a code change. The picker filters these to the
   question been settled yet"
 - `assistant.service.ts` / `assistant-dialog/` — opens and manages the Assistant panel and its tabs
 - `assistant-button/` — toolbar entry point that auto-opens the panel when no config exists
-- `system-init-assistant/` — the initial setup UI, including the `?useCase=` shortcut and use-case
-  picker
+- `system-init-assistant/` — the initial setup UI, including the `?useCase=` shortcut, use-case picker,
+  and the post-setup account-linking step
+- `user-entity-link.service.ts` — resolves which entity type(s) can be linked, the form fields for
+  creating one, and performs the account link
 - `context-aware-assistant/` — the post-setup guidance tab
 - `../../../assets/base-configs/` — the shipped base configs and the descriptors listing them
 - `../admin/setup-wizard/` — the post-setup stepper

--- a/src/app/core/setup/README.md
+++ b/src/app/core/setup/README.md
@@ -43,7 +43,7 @@ account, right after setup:
   back to `toStringAttributes` if there is none) rather than a setup-specific field list, and saves
   through `EntityFormService` like any other form.
 - **The account is linked only after the entity is saved**, via the same `updateUser(accountId, {
-  userEntityId })` write path the user administration UI (`../user/user-details/`) uses to re-link an
+userEntityId })` write path the user administration UI (`../user/user-details/`) uses to re-link an
   existing account - this step is really just that same operation, automated for the very first login.
 - **A successful link reloads the app.** `SessionInfo.entityId` comes from a token claim set at login;
   writing the Keycloak attribute server-side doesn't change an already-issued token, so the app has to

--- a/src/app/core/setup/README.md
+++ b/src/app/core/setup/README.md
@@ -1,0 +1,61 @@
+# Initial System Setup
+
+A newly deployed instance starts with an **empty database**: no `Config:CONFIG_ENTITY`, no entity types
+beyond those defined in code, no records. This module turns such an empty instance into a usable system
+by letting the first user pick a "use case" (a _base config_) and importing it.
+
+It also hosts the **Assistant**, the side panel the setup UI is shown in, which later doubles as
+context-aware guidance and the entry point to the [Setup Wizard](../admin/setup-wizard/) once a config
+exists.
+
+## Flow
+
+1. On login, the toolbar checks whether a config has loaded yet. If not, it opens the Assistant
+   directly — there's no route guard or app initializer for this, so setup only ever happens as an
+   authenticated user.
+2. The Assistant shows a "Create System" tab that lets the user pick a use case (and optionally
+   generate demo data), then triggers the import.
+3. Importing a base config means fetching its JSON documents and saving them as entities, force-
+   overwriting anything already there. `Config:CONFIG_ENTITY` is just one of these documents, alongside
+   permissions, enum definitions, site settings, sample reports/forms, etc.
+4. Once the config document is saved, the app reconfigures itself reactively — routing and entity
+   types are rebuilt and the current page re-renders. There's no redirect and no page reload.
+5. From then on, the Assistant instead shows context-aware guidance and, until it's marked finished,
+   the multi-step [Setup Wizard](../admin/setup-wizard/) for further onboarding.
+
+## Base configs
+
+A base config is a small descriptor (id, name, description, locale) plus a list of JSON documents to
+import. Configs come from two places: the ones shipped with the app, and external URLs so partners can
+offer their own use cases without a code change. The picker filters these to the current locale.
+
+## Things worth knowing before changing this flow
+
+- Setup can be driven entirely by a `?useCase=<id>` URL parameter, skipping the picker — this is how
+  e2e tests bootstrap a system. Any new step must work on this fully-automated path too. An unknown id
+  fails silently (the picker just stays on screen), by design.
+- Config-derived entity types and metadata (e.g. the `User` entity type) only exist once the app has
+  finished reacting to the new config — code that reads config-derived entity info needs to wait for
+  that, not just for the config document itself.
+- Saved configs go through migrations on load, so what the app ends up with isn't always byte-identical
+  to the imported JSON (e.g. user accounts get enabled by migration regardless of what a use case
+  declares).
+- `SystemResetService` (in `../admin/system-reset/`) wipes a system back to this empty state (except
+  the current user's own profile) — the standard way to re-test setup against a real database.
+- In demo mode the session and database are both in-memory and unauthenticated against any real
+  backend, so anything that talks to an external server (e.g. Keycloak) must be skipped. The generated
+  data also only exists until the page is reloaded, so setup code must never trigger a reload on a demo
+  session.
+
+## Key files
+
+- `setup.service.ts` — lists and imports base configs; also hosts the app-wide gate for "has the config
+  question been settled yet"
+- `assistant.service.ts` / `assistant-dialog/` — opens and manages the Assistant panel and its tabs
+- `assistant-button/` — toolbar entry point that auto-opens the panel when no config exists
+- `system-init-assistant/` — the initial setup UI, including the `?useCase=` shortcut and use-case
+  picker
+- `context-aware-assistant/` — the post-setup guidance tab
+- `../../../assets/base-configs/` — the shipped base configs and the descriptors listing them
+- `../admin/setup-wizard/` — the post-setup stepper
+- `../admin/system-reset/` — resets a system back into this flow

--- a/src/app/core/setup/system-init-assistant/system-init-assistant.component.html
+++ b/src/app/core/setup/system-init-assistant/system-init-assistant.component.html
@@ -51,18 +51,87 @@
     </div>
   } @else if (generatingData()) {
     <p i18n>Generating sample data for this demo ...</p>
-  } @else {
-    <p i18n>
-      We have loaded some sample data into this demo system. Explore and play
-      around – you can’t break anything!<br />
-      Changes you make in this demo will <em>not</em> be saved anywhere. The
-      system is reset after you close or reload the page.
-    </p>
+  } @else if (!profileStepReady()) {
+    <p i18n>Preparing your workspace ...</p>
+  } @else if (showProfileStep()) {
+    @if (profileEntityTypes().length > 1 && !selectedProfileType()) {
+      <p i18n>
+        Choose what kind of record represents you, so that your login account
+        can be linked to it.
+      </p>
 
-    <p i18n>
-      You can get assistance by clicking the "Assistant" button on the top right
-      of the toolbar. From there you can also switch to other demo scenarios.
-    </p>
+      <mat-form-field>
+        <mat-label i18n>Profile type</mat-label>
+        <mat-select (selectionChange)="onProfileTypeSelected($event.value)">
+          @for (type of profileEntityTypes(); track type.ENTITY_TYPE) {
+            <mat-option [value]="type">{{ type.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    @if (selectedProfileType() && profileForm()) {
+      <p i18n>
+        Create your own "{{ selectedProfileType().label }}" record, so that your
+        login account is linked to it.
+      </p>
+
+      <app-entity-form
+        [entity]="profileEntity()"
+        [fieldGroups]="profileFieldGroups()"
+        [form]="profileForm()"
+      ></app-entity-form>
+    }
+
+    <div class="demo-actions">
+      @if (selectedProfileType() && profileForm()) {
+        <button
+          mat-raised-button
+          class="full-width"
+          color="accent"
+          (click)="saveProfile()"
+          [disabled]="savingProfile()"
+          i18n
+        >
+          Create profile
+        </button>
+      }
+      <button
+        mat-stroked-button
+        class="full-width"
+        (click)="skipProfileStep()"
+        [disabled]="savingProfile()"
+        i18n
+      >
+        Skip for now
+      </button>
+    </div>
+  } @else {
+    @if (environment.demo_mode) {
+      <p i18n>
+        We have loaded some sample data into this demo system. Explore and play
+        around – you can’t break anything!<br />
+        Changes you make in this demo will <em>not</em> be saved anywhere. The
+        system is reset after you close or reload the page.
+      </p>
+
+      <p i18n>
+        You can get assistance by clicking the "Assistant" button on the top
+        right of the toolbar. From there you can also switch to other demo
+        scenarios.
+      </p>
+    } @else {
+      <p i18n>Your system is ready to use.</p>
+
+      @if (profileStepNotice()) {
+        <p>{{ profileStepNotice() }}</p>
+      }
+
+      <p i18n>
+        You can get assistance any time by clicking the "Assistant" button on
+        the top right of the toolbar.
+      </p>
+    }
 
     <div class="demo-actions">
       <button

--- a/src/app/core/setup/system-init-assistant/system-init-assistant.component.spec.ts
+++ b/src/app/core/setup/system-init-assistant/system-init-assistant.component.spec.ts
@@ -1,77 +1,79 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { SystemInitAssistantComponent } from "./system-init-assistant.component";
 import { KeycloakAuthService } from "../../session/auth/keycloak/keycloak-auth.service";
-import {
-  LoginStateSubject,
-  SyncStateSubject,
-} from "../../session/session-type";
-import {
-  LOCATION_TOKEN,
-  NAVIGATOR_TOKEN,
-  WINDOW_TOKEN,
-} from "app/utils/di-tokens";
-import { CurrentUserSubject } from "../../session/current-user-subject";
-import {
-  entityRegistry,
-  EntityRegistry,
-} from "../../entity/database-entity.decorator";
-import { DemoDataInitializerService } from "../../demo-data/demo-data-initializer.service";
-import {
-  DemoDataService,
-  DemoDataServiceConfig,
-} from "../../demo-data/demo-data.service";
-import { SessionManagerService } from "../../session/session-service/session-manager.service";
-import { SessionSubject } from "../../session/auth/session-info";
+import { LOCATION_TOKEN } from "app/utils/di-tokens";
 import { MatDialogRef } from "@angular/material/dialog";
 import { ActivatedRoute } from "@angular/router";
 import { LanguageService } from "app/core/language/language.service";
-import { EntityAbility } from "app/core/permissions/ability/entity-ability";
+import { MockedTestingModule } from "../../../utils/mocked-testing.module";
+import { UserEntityLinkService } from "../user-entity-link.service";
+import { Entity } from "../../entity/model/entity";
+import { DatabaseField } from "../../entity/database-field.decorator";
+import { AlertService } from "../../alerts/alert.service";
+
+class ProfileTestEntity extends Entity {
+  static override ENTITY_TYPE = "ProfileTestEntity";
+  static override toStringAttributes = ["name"];
+  static override label = "Profile";
+
+  @DatabaseField() name: string;
+}
+
+class OtherProfileTestEntity extends Entity {
+  static override ENTITY_TYPE = "OtherProfileTestEntity";
+  static override toStringAttributes = ["name"];
+  static override label = "Other Profile";
+
+  @DatabaseField() name: string;
+}
 
 describe("SystemInitAssistantComponent", () => {
   let component: SystemInitAssistantComponent;
   let fixture: ComponentFixture<SystemInitAssistantComponent>;
-  const mockLocation = {} as Location;
+  let mockLocation: { pathname: string };
+  let mockUserEntityLinkService: {
+    shouldOfferStep: ReturnType<typeof vi.fn>;
+    getUserEntityTypes: ReturnType<typeof vi.fn>;
+    getProfileFieldGroups: ReturnType<typeof vi.fn>;
+    linkAccountToEntity: ReturnType<typeof vi.fn>;
+  };
 
-  beforeEach(async () => {
+  async function configureComponent() {
+    mockLocation = { pathname: "/some/path" };
+    mockUserEntityLinkService = {
+      shouldOfferStep: vi.fn().mockReturnValue(false),
+      getUserEntityTypes: vi.fn().mockReturnValue([]),
+      getProfileFieldGroups: vi.fn().mockReturnValue([{ fields: ["name"] }]),
+      linkAccountToEntity: vi.fn().mockResolvedValue(true),
+    };
+
     await TestBed.configureTestingModule({
-      imports: [SystemInitAssistantComponent, HttpClientTestingModule],
+      imports: [SystemInitAssistantComponent, MockedTestingModule.withState()],
       providers: [
-        CurrentUserSubject,
-        DemoDataInitializerService,
-        DemoDataService,
-        DemoDataServiceConfig,
-        LoginStateSubject,
-        { provide: EntityRegistry, useValue: entityRegistry },
         { provide: KeycloakAuthService, useValue: {} },
+        { provide: MatDialogRef, useValue: { updateSize: vi.fn() } },
         {
-          provide: MatDialogRef,
-          useValue: {
-            updateSize: vi.fn(),
-          },
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: new Map() } },
         },
-        { provide: NAVIGATOR_TOKEN, useValue: {} },
-        { provide: ActivatedRoute, useValue: {} },
         {
           provide: LanguageService,
           useValue: {
             getCurrentLocale: vi.fn(),
+            initDefaultLanguage: vi.fn(),
           },
         },
         { provide: LOCATION_TOKEN, useValue: mockLocation },
-        { provide: EntityAbility, useValue: { can: () => true } },
-        SyncStateSubject,
-        SessionManagerService,
-        SessionSubject,
+        { provide: UserEntityLinkService, useValue: mockUserEntityLinkService },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SystemInitAssistantComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  }
 
   it("should preselect use case from route param and initialize system", async () => {
+    await configureComponent();
     const mockConfigs = [{ id: "basic_setup" }] as any;
     vi.spyOn(
       component["setupService"],
@@ -87,5 +89,127 @@ describe("SystemInitAssistantComponent", () => {
 
     expect(component.selectedUseCase()).toEqual(mockConfigs[0]);
     expect((component as any).initializeSystem).toHaveBeenCalled();
+  });
+
+  describe("profile linking step", () => {
+    it("skips the step (with no notice) when shouldOfferStep is false, e.g. demo mode or missing permission", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+      ]);
+
+      await component["prepareProfileStep"]();
+
+      expect(component.showProfileStep()).toBe(false);
+      expect(component.profileStepReady()).toBe(true);
+      expect(component.profileStepNotice()).toBeNull();
+      // the type list is never even resolved when the step isn't offered at all
+      expect(
+        mockUserEntityLinkService.getUserEntityTypes,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("shows a notice and skips the step when no configured type supports accounts", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([]);
+
+      await component["prepareProfileStep"]();
+
+      expect(component.showProfileStep()).toBe(false);
+      expect(component.profileStepReady()).toBe(true);
+      expect(component.profileStepNotice()).toBeTruthy();
+    });
+
+    it("prepares a form for the single account-enabled type without a picker", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+      ]);
+
+      await component["prepareProfileStep"]();
+
+      expect(component.showProfileStep()).toBe(true);
+      expect(component.selectedProfileType()).toBe(ProfileTestEntity);
+      expect(component.profileForm()).toBeTruthy();
+    });
+
+    it("waits for a selection instead of auto-selecting when several types are offered", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+        OtherProfileTestEntity,
+      ]);
+
+      await component["prepareProfileStep"]();
+
+      expect(component.showProfileStep()).toBe(true);
+      expect(component.selectedProfileType()).toBeNull();
+      expect(component.profileForm()).toBeNull();
+
+      await component.onProfileTypeSelected(ProfileTestEntity);
+
+      expect(component.selectedProfileType()).toBe(ProfileTestEntity);
+      expect(component.profileForm()).toBeTruthy();
+    });
+
+    it("reloads the app only when the account link was actually written", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+      ]);
+      await component["prepareProfileStep"]();
+      (component.profileForm().formGroup.get("name") as any)?.setValue(
+        "Test Admin",
+      );
+
+      await component.saveProfile();
+
+      expect(mockUserEntityLinkService.linkAccountToEntity).toHaveBeenCalled();
+      expect(mockLocation.pathname).toBe("");
+    });
+
+    it("does not reload and warns the user when the link could not be written", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+      ]);
+      mockUserEntityLinkService.linkAccountToEntity.mockResolvedValue(false);
+      await component["prepareProfileStep"]();
+      (component.profileForm().formGroup.get("name") as any)?.setValue(
+        "Test Admin",
+      );
+
+      const alertService = TestBed.inject(AlertService);
+      vi.spyOn(alertService, "addWarning");
+
+      await component.saveProfile();
+
+      expect(mockLocation.pathname).toBe("/some/path");
+      expect(alertService.addWarning).toHaveBeenCalled();
+      expect(component.showProfileStep()).toBe(false);
+      // persists beyond the transient toast, so the created-but-unlinked profile isn't lost
+      expect(component.profileStepNotice()).toBeTruthy();
+    });
+
+    it("does not attempt to link when the user skips the step", async () => {
+      await configureComponent();
+      mockUserEntityLinkService.shouldOfferStep.mockReturnValue(true);
+      mockUserEntityLinkService.getUserEntityTypes.mockReturnValue([
+        ProfileTestEntity,
+      ]);
+      await component["prepareProfileStep"]();
+
+      component.skipProfileStep();
+
+      expect(component.showProfileStep()).toBe(false);
+      expect(
+        mockUserEntityLinkService.linkAccountToEntity,
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/core/setup/system-init-assistant/system-init-assistant.component.ts
+++ b/src/app/core/setup/system-init-assistant/system-init-assistant.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -18,8 +19,18 @@ import { ConfigurableEnumValue } from "app/core/basic-datatypes/configurable-enu
 import { MatDialogRef } from "@angular/material/dialog";
 import { MatCheckbox } from "@angular/material/checkbox";
 import { FormsModule } from "@angular/forms";
+import { MatSelectModule } from "@angular/material/select";
 import { environment } from "#src/environments/environment";
 import { AssistantService } from "#src/app/core/setup/assistant.service";
+import { UserEntityLinkService } from "../user-entity-link.service";
+import { Entity, EntityConstructor } from "../../entity/model/entity";
+import { EntityForm } from "#src/app/core/common-components/entity-form/entity-form";
+import { EntityFormService } from "../../common-components/entity-form/entity-form.service";
+import { EntityFormComponent } from "../../common-components/entity-form/entity-form/entity-form.component";
+import { InvalidFormFieldError } from "../../common-components/entity-form/invalid-form-field.error";
+import { FieldGroup } from "../../entity-details/form/field-group";
+import { AlertService } from "../../alerts/alert.service";
+import { LOCATION_TOKEN } from "../../../utils/di-tokens";
 
 /**
  * UI for initial system setup and use case selection,
@@ -34,6 +45,8 @@ import { AssistantService } from "#src/app/core/setup/assistant.service";
     LanguageSelectComponent,
     MatCheckbox,
     FormsModule,
+    MatSelectModule,
+    EntityFormComponent,
   ],
   templateUrl: "./system-init-assistant.component.html",
   styleUrl: "./system-init-assistant.component.scss",
@@ -42,9 +55,17 @@ export class SystemInitAssistantComponent implements OnInit {
   private dialogRef =
     inject<MatDialogRef<SystemInitAssistantComponent>>(MatDialogRef);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
+  private location = inject(LOCATION_TOKEN);
 
   private readonly demoDataInitializer = inject(DemoDataInitializerService);
   private readonly setupService = inject(SetupService);
+  private readonly userEntityLinkService = inject(UserEntityLinkService);
+  private readonly entityFormService = inject(EntityFormService);
+  private readonly alertService = inject(AlertService);
+
+  /** exposed for the template to branch copy that only applies to the public in-memory demo */
+  protected readonly environment = environment;
 
   availableUseCases = signal<BaseConfig[]>([]);
   selectedUseCase = signal<BaseConfig | null>(null);
@@ -53,6 +74,19 @@ export class SystemInitAssistantComponent implements OnInit {
   demoInitialized = signal<boolean>(false);
   generatingData = signal<boolean>(false);
   availableLocales = signal<ConfigurableEnumValue[]>([]);
+
+  /** Whether the "create your profile" step has been evaluated and, if applicable, is shown. */
+  profileStepReady = signal<boolean>(false);
+  showProfileStep = signal<boolean>(false);
+  /** Set when no configured type supports login accounts, to inform the user on the final screen. */
+  profileStepNotice = signal<string | null>(null);
+
+  profileEntityTypes = signal<EntityConstructor[]>([]);
+  selectedProfileType = signal<EntityConstructor | null>(null);
+  profileEntity = signal<Entity | null>(null);
+  profileFieldGroups = signal<FieldGroup[]>([]);
+  profileForm = signal<EntityForm<Entity> | null>(null);
+  savingProfile = signal<boolean>(false);
 
   async ngOnInit(): Promise<void> {
     this.adjustAssistantDialogPanel();
@@ -122,6 +156,9 @@ export class SystemInitAssistantComponent implements OnInit {
       }
 
       this.demoInitialized.set(true);
+      // only after a successful import: on failure there is no new config to read entity
+      // types from, and waitForConfigReady() could hang on a system that never got one.
+      await this.prepareProfileStep();
     } catch (error) {
       Logging.error("Error initializing demo data:", error);
     } finally {
@@ -131,6 +168,112 @@ export class SystemInitAssistantComponent implements OnInit {
 
   onUseCaseSelected(selected: BaseConfig) {
     this.selectedUseCase.set(selected);
+  }
+
+  /**
+   * Determine whether to offer linking the just-created account to a profile entity,
+   * and if so, prepare the form for it (or for its only option, if there is just one).
+   * @private
+   */
+  private async prepareProfileStep() {
+    if (!this.userEntityLinkService.shouldOfferStep()) {
+      this.profileStepReady.set(true);
+      return;
+    }
+
+    await this.setupService.waitForConfigReady();
+    const types = this.userEntityLinkService.getUserEntityTypes();
+
+    if (types.length === 0) {
+      this.profileStepNotice.set(
+        $localize`:no user-linkable type notice:No record type in this configuration supports login accounts, so no profile was created for your account.`,
+      );
+      this.profileStepReady.set(true);
+      return;
+    }
+
+    this.profileEntityTypes.set(types);
+    this.showProfileStep.set(true);
+    this.profileStepReady.set(true);
+
+    if (types.length === 1) {
+      await this.selectProfileType(types[0]);
+    }
+  }
+
+  async onProfileTypeSelected(type: EntityConstructor) {
+    await this.selectProfileType(type);
+  }
+
+  private async selectProfileType(type: EntityConstructor) {
+    this.selectedProfileType.set(type);
+
+    const entity = new type();
+    const fieldGroups = this.userEntityLinkService.getProfileFieldGroups(type);
+    const fields = fieldGroups.flatMap((group) => group.fields);
+
+    this.profileEntity.set(entity);
+    this.profileFieldGroups.set(fieldGroups);
+    this.profileForm.set(
+      // field-level permission checks are skipped: this runs right after importing the config
+      // whose permission rules govern this type, and AbilityService may not have re-applied
+      // them yet (no signal exists to await that) - without this, fields could silently render
+      // as blank/disabled. The save-time ability check in saveChanges() is separate and not
+      // skipped; it fails loudly (a caught error) rather than silently, which is acceptable here.
+      await this.entityFormService.createEntityForm(
+        fields,
+        entity,
+        this.destroyRef,
+        false,
+        false,
+      ),
+    );
+  }
+
+  async saveProfile() {
+    const form = this.profileForm();
+    const entity = this.profileEntity();
+    if (!form || !entity) {
+      return;
+    }
+
+    this.savingProfile.set(true);
+    try {
+      const saved = await this.entityFormService.saveChanges(form, entity);
+
+      // the entity is already saved at this point: a failure below must never roll it back,
+      // only report that it is not yet linked.
+      const linked = await this.userEntityLinkService.linkAccountToEntity(
+        saved.getId(),
+      );
+
+      if (linked) {
+        // reload so Keycloak's next init() issues a token carrying the new `username` claim -
+        // writing the attribute server-side does not change the already-issued token.
+        this.location.pathname = "";
+        return;
+      }
+
+      const notLinkedMessage = $localize`:profile created but not linked warning:Your profile "${saved.toString()}:profileName:" was created, but could not be linked to your account automatically. An administrator can link it to your account later from user administration.`;
+      // shown twice: as a toast now, and kept on profileStepNotice so the entity id/name is
+      // still visible on the final screen even if the toast is missed - it's the only place
+      // an admin would otherwise learn there is an orphaned profile to link.
+      this.alertService.addWarning(notLinkedMessage);
+      this.profileStepNotice.set(notLinkedMessage);
+      this.skipProfileStep();
+    } catch (err) {
+      // InvalidFormFieldError is already surfaced as inline field highlighting - an alert on
+      // top would be redundant (same convention as FormComponent.saveClicked).
+      if (!(err instanceof InvalidFormFieldError)) {
+        this.alertService.addDanger(err.message);
+      }
+    } finally {
+      this.savingProfile.set(false);
+    }
+  }
+
+  skipProfileStep() {
+    this.showProfileStep.set(false);
   }
 
   startExploring() {

--- a/src/app/core/setup/user-entity-link.service.spec.ts
+++ b/src/app/core/setup/user-entity-link.service.spec.ts
@@ -1,0 +1,211 @@
+import { TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+import { UserEntityLinkService } from "./user-entity-link.service";
+import { EntityRegistry } from "../entity/database-entity.decorator";
+import { SessionSubject } from "../session/auth/session-info";
+import {
+  UserAdminService,
+  UserAdminApiError,
+} from "../user/user-admin-service/user-admin.service";
+import { EntityConfigService } from "../entity/entity-config.service";
+import { Entity, EntityConstructor } from "../entity/model/entity";
+import { BehaviorSubject } from "rxjs";
+import { SessionInfo } from "../session/auth/session-info";
+
+class AccountEnabledEntity extends Entity {
+  static override ENTITY_TYPE = "AccountEnabledEntity";
+  static override enableUserAccounts = true;
+  static override toStringAttributes = ["name"];
+  static override label = "Profile";
+}
+
+class OtherAccountEnabledEntity extends Entity {
+  static override ENTITY_TYPE = "OtherAccountEnabledEntity";
+  static override enableUserAccounts = true;
+  static override label = "Other Profile";
+}
+
+class NonAccountEntity extends Entity {
+  static override ENTITY_TYPE = "NonAccountEntity";
+}
+
+describe("UserEntityLinkService", () => {
+  let service: UserEntityLinkService;
+  let sessionInfo: BehaviorSubject<SessionInfo>;
+  let mockUserAdminService: any;
+  let mockEntityConfigService: any;
+
+  function setup(entityTypes: EntityConstructor[]) {
+    sessionInfo = new BehaviorSubject<SessionInfo>({
+      id: "account-1",
+      name: "Test Admin",
+      roles: ["account_manager"],
+    });
+    mockUserAdminService = {
+      canManageAccounts: vi.fn().mockReturnValue(true),
+      updateUser: vi.fn().mockReturnValue(of({ userUpdated: true })),
+    };
+    mockEntityConfigService = {
+      getDetailsViewConfig: vi.fn().mockReturnValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        UserEntityLinkService,
+        {
+          provide: EntityRegistry,
+          useValue: {
+            getEntityTypes: () =>
+              entityTypes.map((value) => ({ key: value.ENTITY_TYPE, value })),
+          },
+        },
+        { provide: SessionSubject, useValue: sessionInfo },
+        { provide: UserAdminService, useValue: mockUserAdminService },
+        { provide: EntityConfigService, useValue: mockEntityConfigService },
+      ],
+    });
+
+    service = TestBed.inject(UserEntityLinkService);
+  }
+
+  describe("getUserEntityTypes", () => {
+    it("returns only entity types with enableUserAccounts, in registry order", () => {
+      setup([
+        NonAccountEntity,
+        AccountEnabledEntity,
+        OtherAccountEnabledEntity,
+      ]);
+
+      expect(service.getUserEntityTypes()).toEqual([
+        AccountEnabledEntity,
+        OtherAccountEnabledEntity,
+      ]);
+    });
+
+    it("returns an empty array when no type supports accounts", () => {
+      setup([NonAccountEntity]);
+
+      expect(service.getUserEntityTypes()).toEqual([]);
+    });
+  });
+
+  describe("shouldOfferStep", () => {
+    it("is true when the account has no linked entity and can manage accounts", () => {
+      setup([]);
+
+      expect(service.shouldOfferStep()).toBe(true);
+    });
+
+    it("is false when the account already has a linked entity (e.g. demo mode)", () => {
+      setup([]);
+      sessionInfo.next({ ...sessionInfo.value, entityId: "User:demo-admin" });
+
+      expect(service.shouldOfferStep()).toBe(false);
+    });
+
+    it("is false when the account cannot manage accounts", () => {
+      setup([]);
+      mockUserAdminService.canManageAccounts.mockReturnValue(false);
+
+      expect(service.shouldOfferStep()).toBe(false);
+    });
+  });
+
+  describe("getProfileFieldGroups", () => {
+    it("uses the fieldGroups of the first panel's Form component, verbatim", () => {
+      setup([AccountEnabledEntity]);
+      const fieldGroups = [{ fields: ["name", "other"] }];
+      mockEntityConfigService.getDetailsViewConfig.mockReturnValue({
+        config: {
+          panels: [
+            {
+              title: "Basic",
+              components: [
+                { component: "Form", config: { fieldGroups } },
+                { component: "RelatedEntities", config: {} },
+              ],
+            },
+            {
+              title: "More",
+              components: [
+                {
+                  component: "Form",
+                  config: { fieldGroups: [{ fields: ["ignored"] }] },
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(service.getProfileFieldGroups(AccountEnabledEntity)).toBe(
+        fieldGroups,
+      );
+    });
+
+    it("falls back to toStringAttributes when there is no details view config", () => {
+      setup([AccountEnabledEntity]);
+      mockEntityConfigService.getDetailsViewConfig.mockReturnValue(undefined);
+
+      expect(service.getProfileFieldGroups(AccountEnabledEntity)).toEqual([
+        { fields: AccountEnabledEntity.toStringAttributes },
+      ]);
+    });
+
+    it("falls back to toStringAttributes when the first panel has no Form component", () => {
+      setup([AccountEnabledEntity]);
+      mockEntityConfigService.getDetailsViewConfig.mockReturnValue({
+        config: {
+          panels: [
+            { title: "Basic", components: [{ component: "RelatedEntities" }] },
+          ],
+        },
+      });
+
+      expect(service.getProfileFieldGroups(AccountEnabledEntity)).toEqual([
+        { fields: AccountEnabledEntity.toStringAttributes },
+      ]);
+    });
+  });
+
+  describe("linkAccountToEntity", () => {
+    it("calls updateUser with the account id and profile entity id, returning whether it was written", async () => {
+      setup([]);
+      mockUserAdminService.updateUser.mockReturnValue(
+        of({ userUpdated: true }),
+      );
+
+      const result = await service.linkAccountToEntity(
+        "AccountEnabledEntity:1",
+      );
+
+      expect(mockUserAdminService.updateUser).toHaveBeenCalledWith(
+        "account-1",
+        { userEntityId: "AccountEnabledEntity:1" },
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false (without throwing) when the write fails to be persisted", async () => {
+      setup([]);
+      mockUserAdminService.updateUser.mockReturnValue(
+        of({ userUpdated: false }),
+      );
+
+      expect(await service.linkAccountToEntity("AccountEnabledEntity:1")).toBe(
+        false,
+      );
+    });
+
+    it("returns false (without throwing) when the account cannot manage accounts (403)", async () => {
+      setup([]);
+      mockUserAdminService.updateUser.mockReturnValue(
+        throwError(() => new UserAdminApiError(403)),
+      );
+
+      expect(await service.linkAccountToEntity("AccountEnabledEntity:1")).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/app/core/setup/user-entity-link.service.ts
+++ b/src/app/core/setup/user-entity-link.service.ts
@@ -1,0 +1,102 @@
+import { inject, Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+import { EntityConstructor } from "../entity/model/entity";
+import { EntityRegistry } from "../entity/database-entity.decorator";
+import { SessionSubject } from "../session/auth/session-info";
+import { UserAdminService } from "../user/user-admin-service/user-admin.service";
+import { EntityConfigService } from "../entity/entity-config.service";
+import { FieldGroup } from "../entity-details/form/field-group";
+import { Logging } from "../logging/logging.service";
+
+/**
+ * Non-UI logic for the initial-setup step that links the first admin's login account
+ * to a "profile" entity they create during setup.
+ *
+ * @see /src/app/core/setup/README.md
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class UserEntityLinkService {
+  private readonly entityRegistry = inject(EntityRegistry);
+  private readonly sessionInfo = inject(SessionSubject);
+  private readonly userAdminService = inject(UserAdminService);
+  private readonly entityConfigService = inject(EntityConfigService);
+
+  /**
+   * Entity types that can be linked to a login account, in entity-registry (import/creation)
+   * order. There is no single "correct" default among them, so callers decide how to present
+   * none / one / several options to the user.
+   *
+   * Only call this after {@link EntityConfigReadyService.setupCompleted$} has fired for the
+   * newly imported config - `enableUserAccounts` is a config-applied static that is not set
+   * until then.
+   */
+  getUserEntityTypes(): EntityConstructor[] {
+    return this.entityRegistry
+      .getEntityTypes()
+      .filter(({ value }) => value.enableUserAccounts)
+      .map(({ value }) => value);
+  }
+
+  /**
+   * Whether the initial-setup flow should offer to link the current account to a profile:
+   * only true for an account that has no linked profile yet and can actually write the link.
+   *
+   * A missing `entityId` is a valid, silent state outside of initial setup (e.g. this is also
+   * how demo mode - which sets a fixed `entityId` - skips this step), so this is not an error
+   * check, just a gate for whether to offer the convenience.
+   */
+  shouldOfferStep(): boolean {
+    return (
+      !this.sessionInfo.value?.entityId &&
+      this.userAdminService.canManageAccounts()
+    );
+  }
+
+  /**
+   * The field groups to render for creating a profile of the given type: the first panel's
+   * `Form` component config from the type's details view, or a fallback built from
+   * `toStringAttributes` if there is no details view config yet (e.g. a type added later via
+   * the admin UI) or its first panel does not configure a `Form`.
+   */
+  getProfileFieldGroups(type: EntityConstructor): FieldGroup[] {
+    const firstPanel =
+      this.entityConfigService.getDetailsViewConfig(type)?.config?.panels?.[0];
+    const formComponent = firstPanel?.components.find(
+      (c) => c.component === "Form",
+    );
+    const fieldGroups = formComponent?.config?.fieldGroups as FieldGroup[];
+
+    return fieldGroups?.length
+      ? fieldGroups
+      : [{ fields: type.toStringAttributes }];
+  }
+
+  /**
+   * Link the current session's account to the given profile entity id.
+   *
+   * The entity has already been saved before this is called, so a failure here is never rolled
+   * back - it is reported to the caller (via the returned `false`) so the user can be told the
+   * profile was created but is not yet linked.
+   *
+   * @returns whether the link was actually written on the server. Only reload the app when this
+   *   is `true` - never merely because the step finished.
+   */
+  async linkAccountToEntity(entityId: string): Promise<boolean> {
+    try {
+      const { userUpdated } = await firstValueFrom(
+        this.userAdminService.updateUser(this.sessionInfo.value.id, {
+          userEntityId: entityId,
+        }),
+      );
+      return userUpdated;
+    } catch (err) {
+      Logging.warn(
+        "Failed to link the initial admin account to a profile",
+        err,
+      );
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a step to the system-init assistant, shown after a base config is imported, that lets the first user create their own profile record and links their Keycloak account to it.
- `UserEntityLinkService` resolves which entity types accept accounts (offering a picker only when there are several), reuses the type's own details-view form config, and writes the link via the account-update path fixed in #4374.
- A successful link reloads the app so the next login issues a token carrying the new `username` claim; a failed link leaves the created entity in place and tells the user an admin can link it later.
- Documents the new step in `src/app/core/setup/README.md`.

Depends on #4374 (merged).

Closes #3087.

## Test plan
- [x] Unit tests: `user-profile-setup.component.spec.ts` (15 tests), `system-init-assistant.component.spec.ts` (3 tests) — type resolution (none/one/several), the profile reaching the server before the account is linked, reload only when the link was actually written, skip/notice/warning paths.
- [x] `npm run lint`
- [x] `npm run build` (dev + prod)
- [x] e2e: ran `app.spec.ts` and `admin.spec.ts` locally against a built app — all scenarios that boot via `?useCase=all-features` pass, confirming the new step correctly skips itself on the e2e mock session and doesn't block or trigger a reload.
- [x] Manual verification against a real Keycloak instance, on a local full stack (CouchDB + Keycloak + replication-backend behind the reverse proxy), with an account holding `admin_app` + `account_manager` and no `exact_username`:
  - the step offers the single account-enabled type without a picker and builds the form from that type's own details-view config
  - after saving, the entity is in CouchDB **and** `exact_username` is set on the account, the app reloads, and the User Account screen resolves the new profile
  - with the database unreachable, the account is left unlinked: no `exact_username` is written, there is no reload, the warning is shown as a toast and kept on the final screen, and the profile syncs up by itself once the server is reachable again

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional first-time setup step for creating and linking an administrator profile.
  * Users can select a profile type, complete its form, save it, or skip setup for later.
  * Added setup status messages, including workspace preparation, successful completion, and profile-linking notices.
  * Demo mode continues to show sample-data guidance, while standard setups display a system-ready message.

* **Documentation**
  * Added documentation covering initial system setup, profile creation, configuration sources, reset options, and demo-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->