### PR TITLE
fix(import): resolve entity reference fields that allow several record types

### DIFF
--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.html
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.html
@@ -12,7 +12,7 @@
   <div class="flex-row gap-regular align-center">
     <mat-form-field class="margin-left-small">
       <mat-label i18n="import - entity - match by property label">
-        Match by {{ referencedEntity()?.label }} property
+        Match by {{ referencedEntityLabel() }} property
       </mat-label>
       <mat-select
         [ngModel]="selectedRefField()"

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.html
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.html
@@ -19,7 +19,14 @@
         (ngModelChange)="onRefFieldChange($event)"
       >
         @for (prop of availableProperties(); track prop.property) {
-          <mat-option [value]="prop.property">{{ prop.label }}</mat-option>
+          <mat-option [value]="prop.property">
+            {{ prop.label }}
+            @if (prop.typeHint) {
+              <span class="hint-text margin-left-small">{{
+                prop.typeHint
+              }}</span>
+            }
+          </mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
@@ -60,4 +60,17 @@ describe("EntityImportConfigComponent", () => {
 
     expect(component.selectedRefField()).toBe("name");
   });
+
+  it("should not throw and should offer properties from every allowed type for a multi-type reference field", () => {
+    const col: ColumnMapping = {
+      column: "test",
+      propertyName: "refMixed",
+    };
+    fixture.componentRef.setInput("col", col);
+    fixture.componentRef.setInput("entityType", TestEntity);
+    fixture.componentRef.setInput("otherColumnMappings", []);
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(component.availableProperties().length).toBeGreaterThan(0);
+  });
 });

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
@@ -10,7 +10,7 @@ import { Entity } from "../../../entity/model/entity";
 /** first allowed type of the multi-type field below, without a "startDate" field */
 @DatabaseEntity("MultiRefTypeA")
 class MultiRefTypeA extends Entity {
-  static override label = "Type A";
+  static override readonly label = "Type A";
 
   @DatabaseField({ label: "Name" }) name: string;
 }
@@ -18,7 +18,7 @@ class MultiRefTypeA extends Entity {
 /** second allowed type, the only one declaring "startDate" */
 @DatabaseEntity("MultiRefTypeB")
 class MultiRefTypeB extends Entity {
-  static override label = "Type B";
+  static override readonly label = "Type B";
 
   @DatabaseField({ label: "Name" }) name: string;
   @DatabaseField({ label: "Start date", dataType: "date" }) startDate: Date;

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.spec.ts
@@ -3,6 +3,36 @@ import { EntityImportConfigComponent } from "./entity-import-config.component";
 import { MockedTestingModule } from "../../../../utils/mocked-testing.module";
 import { TestEntity } from "../../../../utils/test-utils/TestEntity";
 import { ColumnMapping } from "../../../import/column-mapping";
+import { DatabaseEntity } from "../../../entity/database-entity.decorator";
+import { DatabaseField } from "../../../entity/database-field.decorator";
+import { Entity } from "../../../entity/model/entity";
+
+/** first allowed type of the multi-type field below, without a "startDate" field */
+@DatabaseEntity("MultiRefTypeA")
+class MultiRefTypeA extends Entity {
+  static override label = "Type A";
+
+  @DatabaseField({ label: "Name" }) name: string;
+}
+
+/** second allowed type, the only one declaring "startDate" */
+@DatabaseEntity("MultiRefTypeB")
+class MultiRefTypeB extends Entity {
+  static override label = "Type B";
+
+  @DatabaseField({ label: "Name" }) name: string;
+  @DatabaseField({ label: "Start date", dataType: "date" }) startDate: Date;
+}
+
+@DatabaseEntity("MultiRefImportTarget")
+class MultiRefImportTarget extends Entity {
+  @DatabaseField({
+    label: "Ref",
+    dataType: "entity",
+    additional: [MultiRefTypeA.ENTITY_TYPE, MultiRefTypeB.ENTITY_TYPE],
+  })
+  ref: string;
+}
 
 describe("EntityImportConfigComponent", () => {
   let component: EntityImportConfigComponent;
@@ -27,7 +57,7 @@ describe("EntityImportConfigComponent", () => {
     fixture.componentRef.setInput("otherColumnMappings", []);
     fixture.detectChanges();
 
-    expect(component.referencedEntity()).not.toBeNull();
+    expect(component.referencedEntities()).not.toHaveLength(0);
     expect(component.availableProperties().length).toBeGreaterThan(0);
   });
 
@@ -59,6 +89,55 @@ describe("EntityImportConfigComponent", () => {
     fixture.detectChanges();
 
     expect(component.selectedRefField()).toBe("name");
+  });
+
+  it("should name the declaring types for each property of a multi-type reference field", () => {
+    const col: ColumnMapping = { column: "test", propertyName: "ref" };
+    fixture.componentRef.setInput("col", col);
+    fixture.componentRef.setInput("entityType", MultiRefImportTarget);
+    fixture.componentRef.setInput("otherColumnMappings", []);
+    fixture.detectChanges();
+
+    const properties = component.availableProperties();
+    const sharedProperty = properties.find((p) => p.property === "name");
+    const typeBOnlyProperty = properties.find(
+      (p) => p.property === "startDate",
+    );
+
+    // "name" exists on both types, so the collapsed entry names both
+    expect(sharedProperty.typeHint).toContain(MultiRefTypeA.label);
+    expect(sharedProperty.typeHint).toContain(MultiRefTypeB.label);
+    expect(typeBOnlyProperty.typeHint).toBe(MultiRefTypeB.label);
+  });
+
+  it("should not add a type hint when the field allows only a single type", () => {
+    const col: ColumnMapping = { column: "test", propertyName: "ref" };
+    fixture.componentRef.setInput("col", col);
+    fixture.componentRef.setInput("entityType", TestEntity);
+    fixture.componentRef.setInput("otherColumnMappings", []);
+    fixture.detectChanges();
+
+    expect(
+      component.availableProperties().every((p) => !p.typeHint),
+    ).toBeTruthy();
+  });
+
+  it("should resolve the sub-field config from whichever allowed type declares the selected property", () => {
+    const col: ColumnMapping = {
+      column: "test",
+      propertyName: "ref",
+      // "startDate" only exists on the second allowed type
+      additional: { refField: "startDate" },
+    };
+    fixture.componentRef.setInput("col", col);
+    fixture.componentRef.setInput("entityType", MultiRefImportTarget);
+    fixture.componentRef.setInput("otherColumnMappings", []);
+    fixture.detectChanges();
+
+    const subFieldConfig = component.subFieldInlineConfig();
+
+    expect(subFieldConfig).not.toBeNull();
+    expect(subFieldConfig.config.entityType).toBe(MultiRefTypeB);
   });
 
   it("should not throw and should offer properties from every allowed type for a multi-type reference field", () => {

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.ts
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.ts
@@ -23,6 +23,7 @@ import {
 } from "../entity.datatype";
 import { isInheritanceSourceReferenceField } from "../../../import/import-inheritance-warning.util";
 import { EntitySchemaService } from "../../../entity/schema/entity-schema.service";
+import { asArray } from "../../../../utils/asArray";
 
 /**
  * Inline import configuration component for entity reference fields.
@@ -61,30 +62,62 @@ export class EntityImportConfigComponent {
     return current?.refField ?? "";
   });
 
-  referencedEntity = computed<EntityConstructor | null>(() => {
+  /**
+   * All entity types this column's target field allows referencing.
+   * Normally a single type, but a field can allow linking to several record
+   * types, in which case the schema's `additional` is an array rather than a
+   * single type name - each is resolved individually here (an unregistered
+   * type is skipped rather than throwing, since `EntityRegistry.get()` only
+   * accepts one registered key at a time).
+   */
+  referencedEntities = computed<EntityConstructor[]>(() => {
     const col = this.col();
     const entityType = this.entityType();
-    if (!col?.propertyName || !entityType) return null;
+    if (!col?.propertyName || !entityType) return [];
 
     const fieldSchema = entityType.schema.get(col.propertyName);
-    const entityName = fieldSchema?.additional;
-    if (!entityName) return null;
-
-    return this.entityRegistry.get(entityName) ?? null;
+    return asArray(fieldSchema?.additional)
+      .filter((entityName) => this.entityRegistry.has(entityName))
+      .map((entityName) => this.entityRegistry.get(entityName));
   });
 
+  /**
+   * The first of the allowed referenced types, for UI that can only
+   * reasonably work off a single type (e.g. the referenced-entity label, the
+   * nested value-mapping component's target schema).
+   */
+  referencedEntity = computed<EntityConstructor | null>(
+    () => this.referencedEntities()[0] ?? null,
+  );
+
+  /** Display label for the "Match by ... property" dropdown, joining every allowed type's label. */
+  referencedEntityLabel = computed(() =>
+    this.referencedEntities()
+      .map((entity) => entity.label)
+      .join(" / "),
+  );
+
+  /**
+   * The union of matchable properties across every allowed referenced type,
+   * so a multi-type field still offers a full "match by" property list
+   * instead of only the first type's properties.
+   */
   availableProperties = computed(() => {
-    const entity = this.referencedEntity();
-    if (!entity) return [];
-    return [...entity.schema.entries()]
-      .filter(
-        ([prop, schema]) =>
-          (!!schema.label && !schema.isInternalField) || prop === "_id",
-      )
-      .map(([prop, schema]) => ({
-        label: schema.label ?? prop,
-        property: prop,
-      }));
+    const seenProperties = new Set<string>();
+    const properties: { label: string; property: string }[] = [];
+
+    for (const entity of this.referencedEntities()) {
+      for (const [prop, schema] of entity.schema.entries()) {
+        if (seenProperties.has(prop)) continue;
+        if (!((!!schema.label && !schema.isInternalField) || prop === "_id"))
+          continue;
+
+        seenProperties.add(prop);
+        properties.push({ label: schema.label ?? prop, property: prop });
+      }
+    }
+
+    return properties;
   });
 
   showInheritanceHint = computed(() => {

--- a/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.ts
+++ b/src/app/core/basic-datatypes/entity/entity-import-config/entity-import-config.component.ts
@@ -82,18 +82,27 @@ export class EntityImportConfigComponent {
   });
 
   /**
-   * The first of the allowed referenced types, for UI that can only
-   * reasonably work off a single type (e.g. the referenced-entity label, the
-   * nested value-mapping component's target schema).
+   * The allowed type that declares the currently selected match property.
+   *
+   * With several allowed types the selected property may exist on only one of
+   * them, so the value-transformation config has to be built from that type's
+   * schema rather than from an arbitrary (e.g. the first) one.
    */
-  referencedEntity = computed<EntityConstructor | null>(
-    () => this.referencedEntities()[0] ?? null,
-  );
+  selectedRefFieldEntity = computed<EntityConstructor | null>(() => {
+    const refField = this.selectedRefField();
+    if (!refField) return null;
+
+    return (
+      this.referencedEntities().find((entity) => entity.schema.has(refField)) ??
+      null
+    );
+  });
 
   /** Display label for the "Match by ... property" dropdown, joining every allowed type's label. */
   referencedEntityLabel = computed(() =>
     this.referencedEntities()
-      .map((entity) => entity.label)
+      // a type configured without a label falls back to its id, as elsewhere
+      .map((entity) => entity.label ?? entity.ENTITY_TYPE)
       .join(" / "),
   );
 
@@ -101,23 +110,51 @@ export class EntityImportConfigComponent {
    * The union of matchable properties across every allowed referenced type,
    * so a multi-type field still offers a full "match by" property list
    * instead of only the first type's properties.
+   *
+   * Properties sharing an id across several types are deliberately collapsed
+   * into one entry: matching compares that same property on candidates of
+   * every allowed type (see `EntityDatatype.importMatchField`), so offering it
+   * once matches against all of them. `typeHint` then names every type that
+   * declares it, so users can tell a shared property from one that only
+   * narrows the match to a single type. It stays empty for a single-type
+   * field, where naming the one allowed type would just be noise.
    */
   availableProperties = computed(() => {
-    const seenProperties = new Set<string>();
-    const properties: { label: string; property: string }[] = [];
+    const referencedEntities = this.referencedEntities();
+    const isMultiType = referencedEntities.length > 1;
+    const properties = new Map<
+      string,
+      { property: string; label: string; declaringTypes: string[] }
+    >();
 
-    for (const entity of this.referencedEntities()) {
+    for (const entity of referencedEntities) {
+      const entityLabel = entity.label ?? entity.ENTITY_TYPE;
+
       for (const [prop, schema] of entity.schema.entries()) {
-        if (seenProperties.has(prop)) continue;
         if (!((!!schema.label && !schema.isInternalField) || prop === "_id"))
           continue;
 
-        seenProperties.add(prop);
-        properties.push({ label: schema.label ?? prop, property: prop });
+        const existing = properties.get(prop);
+        if (existing) {
+          existing.declaringTypes.push(entityLabel);
+          continue;
+        }
+
+        properties.set(prop, {
+          property: prop,
+          label: schema.label ?? prop,
+          declaringTypes: [entityLabel],
+        });
       }
     }
 
-    return properties;
+    return [...properties.values()].map(
+      ({ property, label, declaringTypes }) => ({
+        property,
+        label,
+        typeHint: isMultiType ? declaringTypes.join(", ") : "",
+      }),
+    );
   });
 
   showInheritanceHint = computed(() => {
@@ -141,7 +178,7 @@ export class EntityImportConfigComponent {
   /** Config for the sub-field's inline component (for value transformation config) */
   subFieldInlineConfig = computed(() => {
     const refField = this.selectedRefField();
-    const refEntity = this.referencedEntity();
+    const refEntity = this.selectedRefFieldEntity();
     if (!refField || !refEntity) return null;
 
     const refFieldSchema = refEntity.schema.get(refField);

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -30,6 +30,7 @@ import {
   ExportColumnMapping,
 } from "../../entity/default-datatype/default.datatype";
 import { EntityRegistry } from "../../entity/database-entity.decorator";
+import { asArray } from "../../../utils/asArray";
 
 /**
  * Datatype for the EntitySchemaService to handle a single reference to another entity.
@@ -279,7 +280,11 @@ export class EntityDatatype extends StringDatatype {
       return normalizeValue(rawValue);
     }
 
-    const refFieldSchema = context.refEntityCtor?.schema?.get(refField);
+    // multiple allowed types could in principle disagree on refField's schema;
+    // use the first one that actually declares it
+    const refFieldSchema = context.refEntityCtors
+      ?.map((ctor) => ctor.schema?.get(refField))
+      .find((schema) => !!schema);
     const refDatatype = refFieldSchema
       ? this.schemaService.getDatatypeOrDefault(refFieldSchema.dataType)
       : null;
@@ -308,24 +313,46 @@ export class EntityDatatype extends StringDatatype {
 
   /**
    * Load the required entity type's entities into context's cache if not available yet.
+   *
+   * A field can allow referencing several entity types at once, in which case
+   * `entityType` is an array rather than a single type name - candidates are
+   * loaded per type and merged (as `EditEntityComponent` does for its own
+   * multi-type autocomplete, see `edit-entity.component.ts`). Each type is
+   * resolved independently so that one unresolvable type (e.g. a stale or
+   * removed registration) does not prevent matching against the other,
+   * still-valid types.
    */
   private async loadImportMapEntities(
-    entityType: string,
+    entityType: string | string[],
     context: EntityFieldImportContext,
   ): Promise<void> {
     if (context.entities) {
       return;
     }
 
-    try {
-      context.entities = (await this.entityMapper.loadType(entityType)).map(
-        (e) => this.schemaService.transformEntityToDatabaseFormat(e),
-      );
-      context.refEntityCtor = this.entityRegistry.get(entityType);
-    } catch (error) {
-      Logging.error("Error loading entities for import mapping:", error);
-      context.entities = [];
+    const results = await Promise.allSettled(
+      asArray(entityType).map(async (type) => ({
+        entities: await this.entityMapper.loadType(type),
+        ctor: this.entityRegistry.get(type),
+      })),
+    );
+
+    const loaded: { entities: Entity[]; ctor: EntityConstructor }[] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        loaded.push(result.value);
+      } else {
+        Logging.error(
+          "Error loading entities for import mapping:",
+          result.reason,
+        );
+      }
     }
+
+    context.entities = loaded
+      .flatMap((r) => r.entities)
+      .map((e) => this.schemaService.transformEntityToDatabaseFormat(e));
+    context.refEntityCtors = loaded.map((r) => r.ctor);
   }
 
   /**
@@ -441,13 +468,13 @@ class EntityFieldImportContext {
   }
 
   /**
-   * Constructor of the referenced entity type (to access schema for value mapping)
+   * Constructors of the allowed referenced entity type(s) (to access schema for value mapping)
    */
-  get refEntityCtor(): EntityConstructor | undefined {
-    return this.globalContext[`ctor_${this.schemaField.additional}`];
+  get refEntityCtors(): EntityConstructor[] | undefined {
+    return this.globalContext[`ctors_${this.schemaField.additional}`];
   }
 
-  set refEntityCtor(value: EntityConstructor) {
-    this.globalContext[`ctor_${this.schemaField.additional}`] = value;
+  set refEntityCtors(value: EntityConstructor[]) {
+    this.globalContext[`ctors_${this.schemaField.additional}`] = value;
   }
 }

--- a/src/app/core/basic-datatypes/entity/entity.datatype.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype.ts
@@ -24,7 +24,7 @@ import { ImportProcessingContext } from "../../import/import-processing-context"
 import { splitArrayValue } from "../../import/split-array-value";
 import { ColumnMapping } from "../../import/column-mapping";
 import { EntitySchemaService } from "../../entity/schema/entity-schema.service";
-import { Entity, EntityConstructor } from "../../entity/model/entity";
+import { Entity } from "../../entity/model/entity";
 import {
   ColumnImportInput,
   ExportColumnMapping,
@@ -115,7 +115,7 @@ export class EntityDatatype extends StringDatatype {
       schemaField,
     );
     await this.loadImportMapEntities(schemaField.additional, context);
-    const candidates = context.entities ?? [];
+    const candidates = context.entities;
 
     const criteria = await this.buildMatchCriteria(
       columns,
@@ -280,11 +280,7 @@ export class EntityDatatype extends StringDatatype {
       return normalizeValue(rawValue);
     }
 
-    // multiple allowed types could in principle disagree on refField's schema;
-    // use the first one that actually declares it
-    const refFieldSchema = context.refEntityCtors
-      ?.map((ctor) => ctor.schema?.get(refField))
-      .find((schema) => !!schema);
+    const refFieldSchema = this.getRefFieldSchema(context.types, refField);
     const refDatatype = refFieldSchema
       ? this.schemaService.getDatatypeOrDefault(refFieldSchema.dataType)
       : null;
@@ -312,47 +308,61 @@ export class EntityDatatype extends StringDatatype {
   }
 
   /**
-   * Load the required entity type's entities into context's cache if not available yet.
+   * Load the candidates of every entity type the field may reference into the
+   * context's cache, skipping types that are cached already.
    *
    * A field can allow referencing several entity types at once, in which case
-   * `entityType` is an array rather than a single type name - candidates are
-   * loaded per type and merged (as `EditEntityComponent` does for its own
-   * multi-type autocomplete, see `edit-entity.component.ts`). Each type is
-   * resolved independently so that one unresolvable type (e.g. a stale or
-   * removed registration) does not prevent matching against the other,
-   * still-valid types.
+   * `entityType` is an array rather than a single type name (as
+   * `EditEntityComponent` handles for its own multi-type autocomplete, see
+   * `edit-entity.component.ts`). Each type is loaded independently so that one
+   * unresolvable type (e.g. a stale or removed registration) does not prevent
+   * matching against the other, still-valid types.
    */
   private async loadImportMapEntities(
     entityType: string | string[],
     context: EntityFieldImportContext,
   ): Promise<void> {
-    if (context.entities) {
-      return;
-    }
-
-    const results = await Promise.allSettled(
-      asArray(entityType).map(async (type) => ({
-        entities: await this.entityMapper.loadType(type),
-        ctor: this.entityRegistry.get(type),
-      })),
+    const missingTypes = asArray(entityType).filter(
+      (type) => !context.hasEntitiesOfType(type),
     );
 
-    const loaded: { entities: Entity[]; ctor: EntityConstructor }[] = [];
-    for (const result of results) {
-      if (result.status === "fulfilled") {
-        loaded.push(result.value);
-      } else {
-        Logging.error(
-          "Error loading entities for import mapping:",
-          result.reason,
-        );
-      }
-    }
+    await Promise.all(
+      missingTypes.map(async (type) => {
+        try {
+          const entities = await this.entityMapper.loadType(type);
+          context.setEntitiesOfType(
+            type,
+            entities.map((e) =>
+              this.schemaService.transformEntityToDatabaseFormat(e),
+            ),
+          );
+        } catch (error) {
+          Logging.error("Error loading entities for import mapping:", error);
+          // cache the empty result so the failing type is not retried for every
+          // other field referencing it in this same import run
+          context.setEntitiesOfType(type, []);
+        }
+      }),
+    );
+  }
 
-    context.entities = loaded
-      .flatMap((r) => r.entities)
-      .map((e) => this.schemaService.transformEntityToDatabaseFormat(e));
-    context.refEntityCtors = loaded.map((r) => r.ctor);
+  /**
+   * Schema of the matching property, taken from whichever of the allowed types
+   * declares it (they could in principle disagree on its datatype - first wins).
+   */
+  private getRefFieldSchema(
+    types: string[],
+    refField: string,
+  ): EntitySchemaField | undefined {
+    for (const type of types) {
+      if (!this.entityRegistry.has(type)) continue;
+
+      const refFieldSchema = this.entityRegistry
+        .get(type)
+        .schema?.get(refField);
+      if (refFieldSchema) return refFieldSchema;
+    }
+    return undefined;
   }
 
   /**
@@ -457,24 +467,34 @@ class EntityFieldImportContext {
   ) {}
 
   /**
-   * Entities (in database format for easier comparison!)
+   * All entity types this field may reference
+   * (an array when the field allows several target types).
    */
-  get entities(): any[] | undefined {
-    return this.globalContext[`entities_${this.schemaField.additional}`];
-  }
-
-  set entities(value: any[]) {
-    this.globalContext[`entities_${this.schemaField.additional}`] = value;
+  get types(): string[] {
+    return asArray(this.schemaField.additional);
   }
 
   /**
-   * Constructors of the allowed referenced entity type(s) (to access schema for value mapping)
+   * Candidates (in database format for easier comparison!) of every type this
+   * field allows, merged.
+   *
+   * Cached per entity type rather than per field, so a type loaded for one
+   * field is reused by every other field referencing it in the same import
+   * run - including fields that allow only a subset of these types.
    */
-  get refEntityCtors(): EntityConstructor[] | undefined {
-    return this.globalContext[`ctors_${this.schemaField.additional}`];
+  get entities(): any[] {
+    return this.types.flatMap((type) => this.entitiesOfType(type) ?? []);
   }
 
-  set refEntityCtors(value: EntityConstructor[]) {
-    this.globalContext[`ctors_${this.schemaField.additional}`] = value;
+  hasEntitiesOfType(type: string): boolean {
+    return !!this.entitiesOfType(type);
+  }
+
+  setEntitiesOfType(type: string, entities: any[]) {
+    this.globalContext[`entities_${type}`] = entities;
+  }
+
+  private entitiesOfType(type: string): any[] | undefined {
+    return this.globalContext[`entities_${type}`];
   }
 }

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -11,7 +11,10 @@ import { EntityMapperService } from "../../entity/entity-mapper/entity-mapper.se
 import { CoreTestingModule } from "../../../utils/core-testing.module";
 import { ImportService } from "../../import/import.service";
 import { ColumnMapping } from "../../import/column-mapping";
-import { EntityRegistry } from "../../entity/database-entity.decorator";
+import {
+  DatabaseEntity,
+  EntityRegistry,
+} from "../../entity/database-entity.decorator";
 import { DatabaseField } from "../../entity/database-field.decorator";
 import { Entity } from "../../entity/model/entity";
 
@@ -223,6 +226,9 @@ describe("Schema data type: entity (advanced functionality)", () => {
  * can be triggered by mapping columns onto the matching field.
  */
 describe("Schema data type: entity (import matching, end-to-end via ImportService)", () => {
+  @DatabaseEntity("OtherReferencedEntity")
+  class OtherReferencedEntity extends Entity {}
+
   class ImportTarget extends Entity {
     @DatabaseField({
       dataType: EntityDatatype.dataType,
@@ -236,6 +242,15 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
       additional: TestEntity.ENTITY_TYPE,
     })
     arrayRef: string[];
+
+    // a field allowing several referenced record types: `additional` is an
+    // array rather than a single entity type name
+    @DatabaseField({
+      dataType: EntityDatatype.dataType,
+      isArray: true,
+      additional: [TestEntity.ENTITY_TYPE, OtherReferencedEntity.ENTITY_TYPE],
+    })
+    multiRef: string[];
   }
 
   let service: ImportService;
@@ -342,5 +357,27 @@ describe("Schema data type: entity (import matching, end-to-end via ImportServic
       expect.arrayContaining([john.getId(), jane.getId()]),
     );
     expect(result?.arrayRef).toHaveLength(2);
+  });
+
+  it("links records across every type allowed by a multi-type reference field", async () => {
+    const child = TestEntity.create({ name: "Child A" });
+    const otherTarget = new OtherReferencedEntity("other1");
+    await entityMapper.saveAll([child, otherTarget]);
+
+    const result = await runImport(
+      { ids: `${child.getId()},${otherTarget.getId()}` },
+      [
+        {
+          column: "ids",
+          propertyName: "multiRef",
+          additional: { refField: "_id" },
+        },
+      ],
+    );
+
+    expect(result?.multiRef).toEqual(
+      expect.arrayContaining([child.getId(), otherTarget.getId()]),
+    );
+    expect(result?.multiRef).toHaveLength(2);
   });
 });

--- a/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
+++ b/src/app/core/basic-datatypes/entity/entity.datatype_advanced.spec.ts
@@ -21,6 +21,12 @@ import { Entity } from "../../entity/model/entity";
 // separate test file for custom functionality of the EntityDatatype
 // because there were conflicts with the standard tests in entity.datatype.spec.ts
 
+/** a second referenced type, to exercise fields allowing several target types */
+@DatabaseEntity("SecondRefTestEntity")
+class SecondRefTestEntity extends Entity {
+  @DatabaseField({ label: "Name" }) name: string;
+}
+
 describe("Schema data type: entity (advanced functionality)", () => {
   let entityMapper: MockEntityMapperService;
   let dataType: EntityDatatype;
@@ -184,6 +190,39 @@ describe("Schema data type: entity (advanced functionality)", () => {
         },
       ]),
     ).resolves.toBeUndefined();
+  });
+
+  it("should load each referenced type's candidates only once across fields", async () => {
+    await entityMapper.saveAll([TestEntity.create({ name: "A" })]);
+    const loadType = vi.spyOn(entityMapper, "loadType");
+
+    // one shared context, as during a real import run
+    const importContext = new ImportProcessingContext({
+      entityType: TestEntity.ENTITY_TYPE,
+      columnMapping: [],
+    });
+    const fieldOf = (additional: any): EntitySchemaField => ({
+      id: "ref",
+      dataType: "entity",
+      additional,
+    });
+
+    // a field allowing both types, then another field allowing only one of them
+    await dataType.importMatchField(
+      fieldOf([TestEntity.ENTITY_TYPE, SecondRefTestEntity.ENTITY_TYPE]),
+      [],
+      importContext,
+    );
+    await dataType.importMatchField(
+      fieldOf(TestEntity.ENTITY_TYPE),
+      [],
+      importContext,
+    );
+
+    const testEntityLoads = loadType.mock.calls.filter(
+      (call) => call[0] === TestEntity.ENTITY_TYPE,
+    );
+    expect(testEntityLoads).toHaveLength(1);
   });
 
   /**

--- a/src/app/core/import/additional-actions/additional-import-action.ts
+++ b/src/app/core/import/additional-actions/additional-import-action.ts
@@ -13,7 +13,7 @@ interface AdditionalImportBaseAction {
    */
   sourceType: string;
 
-  targetType?: string;
+  targetType?: string | string[];
   targetId?: string;
 
   /**
@@ -30,7 +30,10 @@ export interface AdditonalDirectLinkAction extends AdditionalImportBaseAction {
   mode: "direct";
 
   /**
-   * EntityType of the target entity (into which the entities should be linked)
+   * EntityType of the target entity (into which the entities should be linked).
+   * Always a single type in practice - a "direct" action updates one field on
+   * one target entity, unlike an "indirect" action's relationship field which
+   * can allow several target types (see AdditionalIndirectLinkAction.targetType).
    */
   targetType: string;
 
@@ -73,7 +76,8 @@ export interface AdditionalIndirectLinkAction extends AdditionalImportBaseAction
   relationshipTargetProperty: string;
 
   /**
-   * EntityType of the target entity (to which the entities should be linked)
+   * EntityType(s) of the target entity (to which the entities should be linked).
+   * An array when the relationship field allows linking to several record types.
    */
-  targetType: string;
+  targetType: string | string[];
 }

--- a/src/app/core/import/additional-actions/import-additional.service.spec.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.spec.ts
@@ -49,6 +49,12 @@ describe("ImportAdditionalService", () => {
   @DatabaseEntity("GroupEntity")
   class GroupEntity extends Entity {}
 
+  @DatabaseEntity("OtherGroupEntity")
+  class OtherGroupEntity extends Entity {}
+
+  @DatabaseEntity("YetAnotherGroupEntity")
+  class YetAnotherGroupEntity extends Entity {}
+
   @DatabaseEntity("RelationshipEntity")
   class RelationshipEntity extends Entity {
     @DatabaseField({
@@ -64,6 +70,16 @@ describe("ImportAdditionalService", () => {
     // a config where the referenced type was renamed or removed leaves such a dangling reference behind
     @DatabaseField({ dataType: "entity", additional: "RemovedEntity" })
     removedGroup: string;
+
+    // a relationship field allowing several target record types: `additional` is an array
+    @DatabaseField({
+      dataType: "entity",
+      additional: [
+        OtherGroupEntity.ENTITY_TYPE,
+        YetAnotherGroupEntity.ENTITY_TYPE,
+      ],
+    })
+    groupOrOther: string;
   }
 
   beforeEach(async () => {
@@ -106,6 +122,18 @@ describe("ImportAdditionalService", () => {
         targetType: GroupEntity.ENTITY_TYPE,
         expertOnly: false,
       },
+      {
+        sourceType: ImportedEntity.ENTITY_TYPE,
+        mode: "indirect",
+        relationshipEntityType: RelationshipEntity.ENTITY_TYPE,
+        relationshipProperty: "participant",
+        relationshipTargetProperty: "groupOrOther",
+        targetType: [
+          OtherGroupEntity.ENTITY_TYPE,
+          YetAnotherGroupEntity.ENTITY_TYPE,
+        ],
+        expertOnly: false,
+      },
       // the action for RelationshipEntity.removedGroup is omitted because "RemovedEntity" is not registered
     ]);
   });
@@ -133,6 +161,23 @@ describe("ImportAdditionalService", () => {
         relationshipProperty: "participant",
         relationshipTargetProperty: "group",
         targetType: GroupEntity.ENTITY_TYPE,
+      }),
+    ]);
+  });
+
+  it("should get actions linking imported data to a target type referenced via a multi-type relationship field", async () => {
+    const actual = service.getActionsLinkingTo(OtherGroupEntity.ENTITY_TYPE);
+    expect(actual).toEqual([
+      expect.objectContaining({
+        sourceType: ImportedEntity.ENTITY_TYPE,
+        mode: "indirect",
+        relationshipEntityType: RelationshipEntity.ENTITY_TYPE,
+        relationshipProperty: "participant",
+        relationshipTargetProperty: "groupOrOther",
+        targetType: [
+          OtherGroupEntity.ENTITY_TYPE,
+          YetAnotherGroupEntity.ENTITY_TYPE,
+        ],
       }),
     ]);
   });

--- a/src/app/core/import/additional-actions/import-additional.service.ts
+++ b/src/app/core/import/additional-actions/import-additional.service.ts
@@ -147,7 +147,9 @@ export class ImportAdditionalService {
 
     for (const entityType of this.linkableEntities.keys()) {
       const matchingActions = (this.linkableEntities.get(entityType) ?? [])
-        .filter((a) => a.targetType === targetEntityType)
+        // targetType can be an array (a relationship field allowing several
+        // target types), so a plain `===` would never match such an action
+        .filter((a) => asArray(a.targetType).includes(targetEntityType))
         .filter((a) => this.hasAllReferencedTypes(a));
       linkingTypes.push(...matchingActions);
     }


### PR DESCRIPTION
- closes #4360
- closes #4364
- closes #4275

## Manual testing steps

Setup: Create System → use case "[All Features]" (demo mode) → open **Import**.

1. Upload a small CSV, e.g.: 
[todo-import.csv](https://github.com/user-attachments/files/32091755/todo-import.csv)

2. Import as → **Task**.
3. Map Columns → map the second column to **"Related Records"** (a field that allows Child/School/RecurringActivity).
   - Before fix: settings area next to the dropdown stays blank.
   - After fix: a "Match by Child / School / ..." dropdown appears with the union of matchable properties (ID, Name, ...).
4. Pick a property (e.g. Child Name) → Continue → "Review & Edit Data".
   - Before fix: screen goes fully blank.
   - After fix: a normal preview table renders with the mapped data. The child is correctly linked
   - test the same by mapping "School Title" --> the school should now also be shown correctly mapped
5. Pick a property of a complex field type (e.g. "gender") --> should offer the correct field mapping dialog button
6. Open the "Match by ..." dropdown again and check the type hints next to each property (added from review feedback):
   - each entry names the record type(s) that declare it, in smaller secondary text — e.g. `ID (internal unique ID) — Child, School, Recurring Activity`, `Name — Child, School`, `Project Number — Child`
   - a property that exists on several of the allowed types stays a single entry (matching compares it against candidates of every type), and its hint lists all of them
   - map a column to a single-type reference field instead (e.g. a field allowing only School) → no type hints are shown there, as before
7. Pick a property that only exists on one of the later allowed types (e.g. a School-only field) and check its value-transformation button still appears
   - before this round: the transformation UI silently disappeared for such properties, because the config was built from the first allowed type only

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---
