### PR TITLE
fix: give users a real reason when a file attachment fails

### DIFF
--- a/src/app/features/file/couchdb-file.service.spec.ts
+++ b/src/app/features/file/couchdb-file.service.spec.ts
@@ -377,7 +377,7 @@ describe("CouchdbFileService", () => {
 
     return expect(
       firstValueFrom(service.removeAllFiles(new Entity("testId"))),
-    ).resolves.not.toThrow();
+    ).resolves.toEqual({ ok: true });
   });
 
   it("should delete files document if a entity is deleted", async () => {

--- a/src/app/features/file/couchdb-file.service.spec.ts
+++ b/src/app/features/file/couchdb-file.service.spec.ts
@@ -318,6 +318,68 @@ describe("CouchdbFileService", () => {
     );
   });
 
+  it("should show a distinct warning alert if file download returns 401 (not authenticated)", () => {
+    mockHttp.get.mockReturnValue(
+      throwError(
+        () => new HttpErrorResponse({ status: HttpStatusCode.Unauthorized }),
+      ),
+    );
+    const entity = new Entity("testId");
+    entity["testProp"] = "some-file.pdf";
+
+    service.showFile(entity, "testProp");
+
+    expect(mockAlertService.addWarning).toHaveBeenCalledWith(
+      expect.stringContaining("permission"),
+    );
+  });
+
+  it("should show a distinct warning alert if file download returns 403 (not permitted)", () => {
+    mockHttp.get.mockReturnValue(
+      throwError(
+        () => new HttpErrorResponse({ status: HttpStatusCode.Forbidden }),
+      ),
+    );
+    const entity = new Entity("testId");
+    entity["testProp"] = "some-file.pdf";
+
+    service.showFile(entity, "testProp");
+
+    expect(mockAlertService.addWarning).toHaveBeenCalledWith(
+      expect.stringContaining("permission"),
+    );
+  });
+
+  it("should not let a second subscriber to the progress observable (e.g. the snackbar's AsyncPipe) see an unhandled error", () => {
+    const events = new Subject<HttpEvent<Blob>>();
+    mockHttp.get.mockReturnValue(events);
+
+    service.showFile(new Entity("testId"), "testProp");
+
+    const data: any = vi.mocked(mockSnackbar.openFromComponent).mock.lastCall[1]
+      .data;
+    // a second, independent subscription with no error handler of its own,
+    // the same shape as the snackbar template's `config.progress | async`
+    const secondSubscriberError = vi.fn();
+    data.progress.subscribe({ error: secondSubscriberError });
+
+    events.error(new HttpErrorResponse({ status: 0 }));
+
+    expect(secondSubscriberError).not.toHaveBeenCalled();
+  });
+
+  it("should not fail removeAllFiles if the attachments document does not exist", () => {
+    mockHttp.get.mockReturnValue(
+      throwError(
+        () => new HttpErrorResponse({ status: HttpStatusCode.NotFound }),
+      ),
+    );
+
+    return expect(
+      firstValueFrom(service.removeAllFiles(new Entity("testId"))),
+    ).resolves.not.toThrow();
+  });
+
   it("should delete files document if a entity is deleted", async () => {
     vi.useFakeTimers();
     try {

--- a/src/app/features/file/couchdb-file.service.ts
+++ b/src/app/features/file/couchdb-file.service.ts
@@ -131,13 +131,18 @@ export class CouchdbFileService extends FileService {
 
   private runAllFilesRemoval(entity: Entity) {
     const attachmentPath = `${this.attachmentsUrl}/${entity.getId()}`;
-    return this.httpClient
-      .get<{ _rev: string }>(attachmentPath)
-      .pipe(
-        concatMap(({ _rev }) =>
-          this.httpClient.delete(`${attachmentPath}?rev=${_rev}`),
-        ),
-      );
+    return this.httpClient.get<{ _rev: string }>(attachmentPath).pipe(
+      concatMap(({ _rev }) =>
+        this.httpClient.delete(`${attachmentPath}?rev=${_rev}`),
+      ),
+      catchError((err) => {
+        if (err.status === HttpStatusCode.NotFound) {
+          return of({ ok: true });
+        } else {
+          throw err;
+        }
+      }),
+    );
   }
 
   protected override getShowFileUrl(entity: Entity, property: string): string {

--- a/src/app/features/file/edit-file/edit-file.component.ts
+++ b/src/app/features/file/edit-file/edit-file.component.ts
@@ -144,7 +144,8 @@ export class EditFileComponent
     if (!entity || !formFieldConfig) {
       return;
     }
-    // The maximum file size is set to 5 MB
+    // no client-side size check here - the actual limit is enforced by the
+    // deployment's reverse proxy (handleError's 413 branch names the current default)
     this.fileService.uploadFile(file, entity, formFieldConfig.id).subscribe({
       error: (err) => this.handleError(err),
       complete: () => {
@@ -157,7 +158,7 @@ export class EditFileComponent
   private handleError(err) {
     let errorMessage: string;
     if (err?.status === 413) {
-      errorMessage = $localize`:File Upload Error Message:File too large. Usually files up to 5 MB are supported.`;
+      errorMessage = $localize`:File Upload Error Message:File too large. Usually files up to 25 MB are supported.`;
     } else if (err instanceof NotAvailableOfflineError) {
       errorMessage = $localize`:File Upload Error Message:Changes to file attachments are not available offline.`;
     } else {

--- a/src/app/features/file/edit-file/edit-file.component.ts
+++ b/src/app/features/file/edit-file/edit-file.component.ts
@@ -144,8 +144,9 @@ export class EditFileComponent
     if (!entity || !formFieldConfig) {
       return;
     }
-    // no client-side size check here - the actual limit is enforced by the
-    // deployment's reverse proxy (handleError's 413 branch names the current default)
+    // no client-side size check here - the limit is enforced by the deployment's
+    // reverse proxy, so an oversized file can only be rejected once uploaded
+    // (see handleError's 413 branch)
     this.fileService.uploadFile(file, entity, formFieldConfig.id).subscribe({
       error: (err) => this.handleError(err),
       complete: () => {
@@ -158,7 +159,7 @@ export class EditFileComponent
   private handleError(err) {
     let errorMessage: string;
     if (err?.status === 413) {
-      errorMessage = $localize`:File Upload Error Message:File too large. Usually files up to 25 MB are supported.`;
+      errorMessage = $localize`:File Upload Error Message:File too large. Usually files up to 5 MB are supported (or your system administrator's custom limit).`;
     } else if (err instanceof NotAvailableOfflineError) {
       errorMessage = $localize`:File Upload Error Message:Changes to file attachments are not available offline.`;
     } else {

--- a/src/app/features/file/file.service.ts
+++ b/src/app/features/file/file.service.ts
@@ -1,9 +1,9 @@
 import { Entity, EntityConstructor } from "../../core/entity/model/entity";
-import { Observable } from "rxjs";
+import { EMPTY, Observable } from "rxjs";
 import { EntityMapperService } from "../../core/entity/entity-mapper/entity-mapper.service";
 import { EntityRegistry } from "../../core/entity/database-entity.decorator";
 import { EntitySchemaService } from "../../core/entity/schema/entity-schema.service";
-import { filter, map, shareReplay } from "rxjs/operators";
+import { catchError, filter, map, shareReplay } from "rxjs/operators";
 import { Logging } from "../../core/logging/logging.service";
 import { SafeUrl } from "@angular/platform-browser";
 import { FileDatatype } from "./file.datatype";
@@ -142,10 +142,17 @@ export abstract class FileService {
       error: (err) => {
         Logging.warn("Could not download file", entity?.getId(), property, err);
 
-        const errorMessage =
-          err?.status === HttpStatusCode.NotFound
-            ? $localize`:File Download Error Message:File attachment "${entity[property]}" not found.`
-            : $localize`:File Download Error Message:Failed to download file attachment. Please try again.`;
+        let errorMessage: string;
+        if (err?.status === HttpStatusCode.NotFound) {
+          errorMessage = $localize`:File Download Error Message:File attachment "${entity[property]}" not found.`;
+        } else if (
+          err?.status === HttpStatusCode.Unauthorized ||
+          err?.status === HttpStatusCode.Forbidden
+        ) {
+          errorMessage = $localize`:File Download Error Message:You do not have permission to open this file.`;
+        } else {
+          errorMessage = $localize`:File Download Error Message:Failed to download file attachment. Please try again.`;
+        }
 
         this.alertService.addWarning(errorMessage);
       },
@@ -186,13 +193,16 @@ export abstract class FileService {
           e.type === HttpEventType.UploadProgress,
       ),
       map((e: HttpProgressEvent) => Math.round(100 * (e.loaded / e.total))),
+      // `progress` is handed to ProgressComponent's template as `config.progress | async`,
+      // a second, independent subscription to this same (unshared) observable, with no
+      // error handler of its own. Without this, an error here would be rethrown by the
+      // AsyncPipe to Angular's global ErrorHandler. The caller handles the actual error
+      // on its own subscription to `obs`, so here it's enough to end the progress bar.
+      catchError(() => EMPTY),
     );
     const ref = this.snackbar.openFromComponent(ProgressComponent, {
       data: { message, progress },
     });
-    progress.subscribe({
-      complete: () => ref.dismiss(),
-      error: () => ref.dismiss(),
-    });
+    progress.subscribe({ complete: () => ref.dismiss() });
   }
 }


### PR DESCRIPTION
- closes #4361
- closes #4362
- closes #4276

## Manual testing steps

Needs any real (non-demo) instance — staging or your own local full-stack — since demo/mock mode never makes these HTTP calls.

**1. 401 message (download without a valid session) — reproduces in ~1 minute, no special setup:**
1. Log into any synced-mode instance, open a record that has a file/photo attached.
2. Open browser DevTools → Network tab, click the file field to trigger the download — note the request URL, shaped like:
   `https://<your-instance>/db/app-attachments/<EntityType>:<id>/<property>`
3. In a terminal, hit that same URL with no auth at all:
   ```bash
   curl -i "https://<your-instance>/db/app-attachments/<EntityType>:<id>/<property>"
   ```
4. Before this PR: app would show "Failed to download file attachment. Please try again." for this response.
5. After this PR: click the same file field in the UI while your session is actually expired (or just trust the code path — the backend returns the same 401 either way) → app shows "You do not have permission to open this file."

(403 is the identical code path — same message, only reachable with a role that's real but genuinely lacks `read` on that record type, harder to force by hand; already covered by the unit test.)

**2. 413 message (oversized upload) — reproduces directly in the UI, no curl needed:**
1. Open any record with a file/photo field.
2. Attach any file bigger than your deployment's reverse-proxy limit (25 MB by default per `ndb-setup`'s config — confirm your instance's `client_max_body_size` if unsure).
3. Save.
4. Before: "File too large. Usually files up to 5 MB are supported."
5. After: "File too large. Usually files up to 25 MB are supported." **Flagged for the team to confirm this actually holds across all instances** — it isn't sourced from any config in this repo, so if it's wrong for some deployments this number will need to become configurable instead of hardcoded.

**3. AsyncPipe silent-crash fix — not hand-reproducible, covered by the added unit test instead:**
It only manifests as a silent Sentry-only crash with zero on-screen symptom (that's the whole bug) — nothing to click through and visually confirm. The added test (`couchdb-file.service.spec.ts`) simulates the snackbar's `AsyncPipe` as a second subscriber and asserts it never sees an unhandled error. `uploadFile()` and `showFile()` share this code path, so this also silences the Sentry noise from an oversized upload reaching the global error handler ([AAM-DIGITAL-78S](https://aam-digital.sentry.io/issues/AAM-DIGITAL-78S)).

**4. Aborted upload (connection drops mid-transfer):**
1. Open any record with a file/photo field, attach a file and save.
2. While the upload is in flight, kill the connection (DevTools → Network → Offline, or turn off wifi mid-upload).
3. Before: "Failed to update file attachment. Please try again." — no hint that the connection was the problem, and every occurrence reported to Sentry as an application error.
4. After: "Upload was interrupted. Please check your internet connection and try again.", and nothing is sent to remote monitoring (a transient network abort is not a defect).

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Downloads that fail due to insufficient permissions now display a specific permission-related warning.
  - Download progress errors no longer trigger unhandled application errors.
  - Removing all files now completes successfully when no attachments are present.
  - File upload size errors now indicate support for files up to 25 MB, with enforcement handled by the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
