### PR TITLE
Guard async initialization against destroyed views

### DIFF
--- a/.github/instructions/angular-components.instructions.md
+++ b/.github/instructions/angular-components.instructions.md
@@ -49,6 +49,38 @@ Use `linkedSignal` for state that depends on other signals
 and `resource` for async data fetching.
 Try to avoid init methods to make code easier to read.
 
+## Async Work and the Component Lifetime
+
+A component can be destroyed while one of its `async` methods is still waiting — the user
+navigates away, a dialog is closed, a route changes. Everything after an `await` therefore
+runs for a view that may no longer exist:
+
+- Registering a destroy callback on a destroyed view throws
+  `NG0911: View has already been destroyed.` This covers everything that needs an injection
+  context, e.g. `effect()`, `toSignal()`, `runInInjectionContext()` and `DestroyRef.onDestroy()`.
+- Writing to signals does not throw, but it is wasted work and can leave a half-finished
+  action behind.
+
+So:
+
+- Do the injection-context work **before** the first `await` — e.g. start parallel loads with
+  `Promise.all` instead of awaiting one after the other.
+- Guard continuations that touch the view with `DestroyRef.destroyed` and simply drop the work:
+
+```typescript
+private readonly destroyRef = inject(DestroyRef);
+
+async ngOnInit() {
+  const records = await this.entityMapper.loadType(Child);
+  if (this.destroyRef.destroyed) {
+    return;
+  }
+  this.records.set(records);
+}
+```
+
+- For observables use `takeUntilDestroyed()`, which already guards against this internally.
+
 ## Template Control Flow
 
 Use native control flow — **not** structural directives (`*ngIf`, `*ngFor`, `*ngSwitch`):

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.spec.ts
@@ -220,6 +220,22 @@ describe("MatchingEntitiesComponent", () => {
     expect(component.sideDetails()![1].columns).toEqual(["name", "phone"]);
   });
 
+  it("drops the initialization when the view is destroyed while records are still loading", async () => {
+    let resolveLoad: (records: TestEntity[]) => void;
+    vi.spyOn(TestBed.inject(EntityMapperService), "loadType").mockReturnValue(
+      new Promise<TestEntity[]>((resolve) => (resolveLoad = resolve)),
+    );
+    setInputs(testConfig);
+
+    const initialization = component.ngOnInit();
+    fixture.destroy();
+    resolveLoad([TestEntity.create("1")]);
+
+    // must not throw NG0911 by setting up a data source for the destroyed view
+    await expect(initialization).resolves.toBeUndefined();
+    expect(component.sideDetails()).toBeUndefined();
+  });
+
   it("should select only one entity at a time in single select mode", async () => {
     const matchedEntity = TestEntity.create("matched child");
     const otherMatchedEntity = TestEntity.create("second matched child");

--- a/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
+++ b/src/app/features/matching-entities/matching-entities/matching-entities.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   ElementRef,
   inject,
   Injector,
@@ -117,6 +118,7 @@ export class MatchingEntitiesComponent implements OnInit {
   private entityRegistry = inject(EntityRegistry);
   private filterService = inject(FilterService);
   private injector = inject(Injector);
+  private destroyRef = inject(DestroyRef);
   static DEFAULT_CONFIG_KEY = "appConfig:matching-entities";
 
   entity = input<Entity>();
@@ -197,10 +199,22 @@ export class MatchingEntitiesComponent implements OnInit {
 
   async ngOnInit() {
     this.comparisonColumns.set(this.cloneColumns(this.resolvedColumns()));
-    const sides: [MatchingSide, MatchingSide] = [
-      await this.initSideDetails(this.resolvedLeftSide(), 0),
-      await this.initSideDetails(this.resolvedRightSide(), 1),
-    ];
+
+    // Both sides are started before the first `await` so that their data sources
+    // (which need an injection context, see `initSideDetails`) are created while
+    // this component is certainly still alive. Loading the records then happens
+    // in parallel instead of one side after the other.
+    const sides = await Promise.all([
+      this.initSideDetails(this.resolvedLeftSide(), 0),
+      this.initSideDetails(this.resolvedRightSide(), 1),
+    ]);
+
+    if (this.destroyRef.destroyed) {
+      // the user navigated away while the records were still loading:
+      // drop the half-finished setup instead of writing it into a destroyed view
+      return;
+    }
+
     this.sideDetails.set(sides);
     sides.forEach((side, index) => this.initDistanceColumn(side, index));
   }


### PR DESCRIPTION
## Description

Adds safeguards to prevent errors and wasted work when async component initialization completes after the view has been destroyed (e.g., user navigates away during data loading).

### Changes

1. **Documentation** (`angular-components.instructions.md`):
   - Added new "Async Work and the Component Lifetime" section explaining the `NG0911` error and best practices
   - Documents the pattern of doing injection-context work before the first `await`
   - Recommends guarding continuations with `DestroyRef.destroyed`

2. **Component Implementation** (`MatchingEntitiesComponent`):
   - Injected `DestroyRef` to track component destruction
   - Refactored `ngOnInit()` to start both side initializations in parallel using `Promise.all()` before the first `await`, ensuring data sources (which require injection context) are created while the component is alive
   - Added guard check after async work completes: if the view was destroyed during loading, the method returns early instead of writing to signals on a destroyed view

3. **Test Coverage** (`MatchingEntitiesComponent.spec.ts`):
   - Added test verifying that initialization gracefully handles view destruction during async loading
   - Confirms no `NG0911` error is thrown and `sideDetails` remains unset

### Why This Matters

When an async method awaits, the component can be destroyed before the continuation runs. This causes:
- `NG0911: View has already been destroyed` when registering destroy callbacks or using `effect()`, `toSignal()`, etc.
- Wasted work and incomplete state updates when writing to signals

The fix ensures injection-context work happens before any `await`, and guards all post-await work with `DestroyRef.destroyed`.

### Scope of the reported errors

`NG0911` is thrown only from Angular's `storeLViewOnDestroy`, i.e. when a destroy callback is registered on an already-destroyed view. Of the three reported stacks:

- Two (a record list route and `/matching/`) come from `MatchingEntitiesComponent` building its second side's `InMemoryDataSource` after the first `await` — fixed here.
- The third (a public form) came from `EntityFormService.createEntityForm`, which already carries a `destroyRef.destroyed` guard on `master`, added after that error's last occurrence.

The rest of the codebase was checked for the same shape: the only other `runInInjectionContext` call runs inside a `computed()`, every explicit `destroyRef.onDestroy(...)` is in a constructor or field initializer, and `takeUntilDestroyed()` guards internally.

### Verification

- The new spec reproduces the reported stack: with the fix reverted it fails with `NG0911 ... toSignal ... new InMemoryDataSource`, and passes with the fix in place.
- 143 tests across 17 related spec files (matching-entities, entities-table, entity-list, related-entities) pass; typecheck, eslint and prettier are clean.
- The full unit suite could not be completed locally (the runner ran out of memory partway through), so that check is left to CI.

- closes #4370

## PR Checklist

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

https://claude.ai/code/session_01Hj7w1RYtubkYcpY17DZutz