### PR TITLE
feat: resolved relations for pdf exports

### DIFF
--- a/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.spec.ts
+++ b/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.spec.ts
@@ -70,6 +70,17 @@ describe("EntityRelationResolverService", () => {
     expect(result).toEqual(plain);
   });
 
+  it("preserves enumerable properties that are not part of the schema", async () => {
+    const primary = TestEntity.create("Primary");
+    (primary as any).extraRuntimeProp = "computed value";
+
+    const result = await service.resolveRelations(primary);
+
+    expect((result as any).extraRuntimeProp).toBe("computed value");
+    // schema fields are still processed as usual alongside it
+    expect(result.name).toBe("Primary");
+  });
+
   it("resolves a property holding a single entity reference id", async () => {
     const related = TestEntity.create("Related");
     entityMapper.add(related);

--- a/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.spec.ts
+++ b/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.spec.ts
@@ -1,0 +1,236 @@
+import { TestBed } from "@angular/core/testing";
+import { vi } from "vitest";
+
+import { EntityRelationResolverService } from "./entity-relation-resolver.service";
+import { CoreTestingModule } from "../../../utils/core-testing.module";
+import { MockEntityMapperService } from "../entity-mapper/mock-entity-mapper-service";
+import { EntityMapperService } from "../entity-mapper/entity-mapper.service";
+import { DatabaseEntity } from "../database-entity.decorator";
+import { Entity } from "../model/entity";
+import { DatabaseField } from "../database-field.decorator";
+import { TestEntity } from "../../../utils/test-utils/TestEntity";
+import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
+import { AttendanceItem } from "#src/app/features/attendance/model/attendance-item";
+
+describe("EntityRelationResolverService", () => {
+  let service: EntityRelationResolverService;
+  let entityMapper: MockEntityMapperService;
+
+  /** holds relations nested inside embedded (non-entity) objects, like Note.childrenAttendance */
+  @DatabaseEntity("EntityWithAttendanceItems")
+  class EntityWithAttendanceItems extends Entity {
+    @DatabaseField()
+    attendanceItems: AttendanceItem[] = [];
+  }
+
+  /** an entity-reference field without a configured fallback entity type */
+  @DatabaseEntity("EntityWithUntypedRef")
+  class EntityWithUntypedRef extends Entity {
+    @DatabaseField({ dataType: EntityDatatype.dataType })
+    ref: string;
+  }
+
+  /** a second, unrelated entity type, to test relations to different target types */
+  @DatabaseEntity("OtherTestEntity")
+  class OtherTestEntity extends Entity {
+    @DatabaseField()
+    name: string;
+  }
+
+  /** two relation properties, referencing two different entity types */
+  @DatabaseEntity("EntityWithMultipleRelations")
+  class EntityWithMultipleRelations extends Entity {
+    @DatabaseField({
+      dataType: EntityDatatype.dataType,
+      additional: TestEntity.ENTITY_TYPE,
+    })
+    refA: string;
+
+    @DatabaseField({
+      dataType: EntityDatatype.dataType,
+      isArray: true,
+      additional: OtherTestEntity.ENTITY_TYPE,
+    })
+    refsB: string[];
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [CoreTestingModule] });
+    service = TestBed.inject(EntityRelationResolverService);
+    entityMapper = TestBed.inject(
+      EntityMapperService,
+    ) as MockEntityMapperService;
+  });
+
+  it("returns data without an entity schema unchanged", async () => {
+    const plain = { foo: "bar" };
+
+    const result = await service.resolveRelations(plain);
+
+    expect(result).toEqual(plain);
+  });
+
+  it("resolves a property holding a single entity reference id", async () => {
+    const related = TestEntity.create("Related");
+    entityMapper.add(related);
+    const primary = TestEntity.create("Primary");
+    primary.ref = related.getId();
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.ref).toEqual(
+      expect.objectContaining({ name: "Related", _id: related.getId() }),
+    );
+  });
+
+  it("resolves a property holding multiple entity reference ids", async () => {
+    const related1 = TestEntity.create("Related1");
+    const related2 = TestEntity.create("Related2");
+    entityMapper.addAll([related1, related2]);
+    const primary = TestEntity.create("Primary");
+    primary.refMixed = [related1.getId(), related2.getId()];
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.refMixed).toEqual([
+      expect.objectContaining({ name: "Related1" }),
+      expect.objectContaining({ name: "Related2" }),
+    ]);
+  });
+
+  it("resolves entity references nested inside array-of-embedded-object properties (AttendanceItem)", async () => {
+    const child1 = TestEntity.create("Child1");
+    const child2 = TestEntity.create("Child2");
+    entityMapper.addAll([child1, child2]);
+    const primary = new EntityWithAttendanceItems();
+    primary.attendanceItems = [
+      new AttendanceItem(undefined, "on time", child1.getId()),
+      new AttendanceItem(undefined, "late", child2.getId()),
+    ];
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.attendanceItems).toEqual([
+      expect.objectContaining({
+        remarks: "on time",
+        participant: expect.objectContaining({ name: "Child1" }),
+      }),
+      expect.objectContaining({
+        remarks: "late",
+        participant: expect.objectContaining({ name: "Child2" }),
+      }),
+    ]);
+  });
+
+  it("resolves multiple properties with relationships on the same entity, loading each referenced type only once", async () => {
+    const relatedA = TestEntity.create("RelatedA");
+    const relatedB1 = Object.assign(new OtherTestEntity(), {
+      name: "RelatedB1",
+    });
+    const relatedB2 = Object.assign(new OtherTestEntity(), {
+      name: "RelatedB2",
+    });
+    entityMapper.addAll([relatedA, relatedB1, relatedB2]);
+    const loadTypeSpy = vi.spyOn(entityMapper, "loadType");
+
+    const primary = new EntityWithMultipleRelations();
+    primary.refA = relatedA.getId();
+    primary.refsB = [relatedB1.getId(), relatedB2.getId()];
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.refA).toEqual(expect.objectContaining({ name: "RelatedA" }));
+    expect(result.refsB).toEqual([
+      expect.objectContaining({ name: "RelatedB1" }),
+      expect.objectContaining({ name: "RelatedB2" }),
+    ]);
+    // one loadType call for "TestEntity" (refA) and one for "OtherTestEntity" (refsB's two ids), not three
+    expect(loadTypeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a stub object for an entity reference that cannot be found", async () => {
+    const primary = TestEntity.create("Primary");
+    primary.ref = TestEntity.createPrefixedId(
+      TestEntity.ENTITY_TYPE,
+      "does-not-exist",
+    );
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.ref).toEqual({ _id: primary.ref });
+  });
+
+  it("creates a stub object when the referenced entity type cannot be determined", async () => {
+    const primary = new EntityWithUntypedRef();
+    primary.ref = "some-id-without-a-type-prefix";
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.ref).toEqual({ _id: "some-id-without-a-type-prefix" });
+  });
+
+  it("creates stub objects when loading the referenced type fails", async () => {
+    const primary = TestEntity.create("Primary");
+    primary.ref = TestEntity.createPrefixedId(TestEntity.ENTITY_TYPE, "x");
+    vi.spyOn(entityMapper, "loadType").mockRejectedValue(
+      new Error("failed to load"),
+    );
+
+    const result = await service.resolveRelations(primary);
+
+    expect(result.ref).toEqual({ _id: primary.ref });
+  });
+
+  it("does not resolve the relations of a newly resolved related entity", async () => {
+    const grandchild = TestEntity.create("Grandchild");
+    const related = TestEntity.create("Related");
+    related.ref = grandchild.getId();
+    entityMapper.addAll([related, grandchild]);
+    const primary = TestEntity.create("Primary");
+    primary.ref = related.getId();
+
+    const result = await service.resolveRelations(primary);
+
+    // related is resolved to an object, but *its* ref stays the raw, unresolved id
+    const resolvedRef = result.ref as unknown as TestEntity;
+    expect(resolvedRef.name).toBe("Related");
+    expect(resolvedRef.ref).toBe(grandchild.getId());
+  });
+
+  it("does not modify the original entities passed in", async () => {
+    const related = TestEntity.create("Related");
+    entityMapper.add(related);
+    const primary = TestEntity.create("Primary");
+    primary.ref = related.getId();
+    const attendanceItem = new AttendanceItem(undefined, "", related.getId());
+    const primaryWithAttendance = new EntityWithAttendanceItems();
+    primaryWithAttendance.attendanceItems = [attendanceItem];
+
+    const result = await service.resolveRelations(primary);
+    const resultWithAttendance = await service.resolveRelations(
+      primaryWithAttendance,
+    );
+
+    // originals still hold the raw, unresolved id(s)
+    expect(primary.ref).toBe(related.getId());
+    expect(attendanceItem.participant).toBe(related.getId());
+    // the resolved related entity is a copy, not the same object still used elsewhere
+    expect(result.ref).not.toBe(related);
+    expect(resultWithAttendance.attendanceItems[0]).not.toBe(attendanceItem);
+  });
+
+  it("resolves relations for every record in an array input", async () => {
+    const related = TestEntity.create("Related");
+    entityMapper.add(related);
+    const primary1 = TestEntity.create("Primary1");
+    primary1.ref = related.getId();
+    const primary2 = TestEntity.create("Primary2");
+    primary2.ref = related.getId();
+
+    const result = await service.resolveRelations([primary1, primary2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].ref).toEqual(expect.objectContaining({ name: "Related" }));
+    expect(result[1].ref).toEqual(expect.objectContaining({ name: "Related" }));
+  });
+});

--- a/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.ts
+++ b/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.ts
@@ -1,0 +1,215 @@
+import { inject, Injectable } from "@angular/core";
+import { Entity } from "../model/entity";
+import { EntityMapperService } from "../entity-mapper/entity-mapper.service";
+import { EntitySchema } from "../schema/entity-schema";
+import { EntitySchemaField } from "../schema/entity-schema-field";
+import { EntityDatatype } from "../../basic-datatypes/entity/entity.datatype";
+import { Logging } from "../../logging/logging.service";
+
+/**
+ * A related entity that could not be found in the database is represented by
+ * this minimal stub instead, so that templates can still access its id.
+ */
+export interface UnresolvedEntityStub {
+  _id: string;
+}
+
+/**
+ * Resolve entity-reference fields (`dataType: "entity"`) within a record's data,
+ * replacing the plain id string(s) with the actual referenced {@link Entity} objects.
+ *
+ * This is used to give file/PDF templates access to the details of linked records
+ * (e.g. a Note's related Child) instead of only their id.
+ *
+ * Only the relations found directly on the given data (including relations nested
+ * inside embedded objects/arrays that have their own schema, e.g. `AttendanceItem`)
+ * are resolved. The relations *of* a newly resolved entity are deliberately left
+ * untouched, to avoid pulling in an ever-growing tree of linked records.
+ *
+ * The input data is never modified - resolved data is always built as a new,
+ * deep copy so that entity objects still in use elsewhere in the app remain unaffected.
+ *
+ * Note: this is unrelated to {@link EntityRelationsService}, which instead finds
+ * entities that reference a given entity (the reverse direction).
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class EntityRelationResolverService {
+  private readonly entityMapper = inject(EntityMapperService);
+
+  /**
+   * Resolve entity-reference fields within the given record (or array of records).
+   * @param data A single record or an array of records to resolve relations for.
+   */
+  async resolveRelations<T = any>(data: T): Promise<T>;
+  async resolveRelations<T = any>(data: T[]): Promise<T[]>;
+  async resolveRelations(data: any): Promise<any> {
+    // cache loaded entities per type for the duration of this call,
+    // so that every referenced type is loaded via `loadType` at most once,
+    // no matter how many records or ids reference it.
+    const loadedEntitiesByType = new Map<
+      string,
+      Promise<Map<string, Entity>>
+    >();
+
+    if (Array.isArray(data)) {
+      return Promise.all(
+        data.map((item) => this.resolveValue(item, loadedEntitiesByType)),
+      );
+    }
+    return this.resolveValue(data, loadedEntitiesByType);
+  }
+
+  /**
+   * Resolve one value: if it has an entity schema, return a new object with its
+   * relation fields resolved (recursing into nested schema-holding values found
+   * on it); otherwise return the value unchanged.
+   */
+  private async resolveValue(
+    value: any,
+    loadedEntitiesByType: Map<string, Promise<Map<string, Entity>>>,
+  ): Promise<any> {
+    if (value === null || typeof value !== "object") {
+      return value;
+    }
+
+    const schema = this.getSchema(value);
+    if (!schema) {
+      return value;
+    }
+
+    const resolved: Record<string, any> = {};
+    for (const [fieldId, fieldSchema] of schema) {
+      const raw = value[fieldId];
+      if (raw === undefined) {
+        continue;
+      }
+
+      if (fieldSchema.dataType === EntityDatatype.dataType) {
+        resolved[fieldId] = Array.isArray(raw)
+          ? await Promise.all(
+              raw.map((id) =>
+                this.resolveReference(id, fieldSchema, loadedEntitiesByType),
+              ),
+            )
+          : await this.resolveReference(raw, fieldSchema, loadedEntitiesByType);
+      } else if (Array.isArray(raw)) {
+        resolved[fieldId] = await Promise.all(
+          raw.map((item) => this.resolveValue(item, loadedEntitiesByType)),
+        );
+      } else if (typeof raw === "object") {
+        resolved[fieldId] = await this.resolveValue(raw, loadedEntitiesByType);
+      } else {
+        resolved[fieldId] = raw;
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolve a single entity-reference id to the actual entity
+   * (or an {@link UnresolvedEntityStub} if it cannot be resolved).
+   * Deliberately does *not* resolve the relations of the returned entity itself.
+   */
+  private async resolveReference(
+    id: unknown,
+    fieldSchema: EntitySchemaField,
+    loadedEntitiesByType: Map<string, Promise<Map<string, Entity>>>,
+  ): Promise<Entity | UnresolvedEntityStub | unknown> {
+    if (typeof id !== "string" || !id) {
+      return id;
+    }
+
+    const entityType = this.getReferencedEntityType(id, fieldSchema);
+    if (!entityType) {
+      return { _id: id };
+    }
+
+    try {
+      const entitiesOfType = await this.loadAllOfType(
+        entityType,
+        loadedEntitiesByType,
+      );
+      const match = entitiesOfType.get(id);
+      // a shallow, one-level copy: protects the entity instance still held
+      // elsewhere in the app from being mutated through the resolved data,
+      // without resolving (and thereby recursing into) its own relations.
+      return match ? this.copySchemaFieldsShallow(match) : { _id: id };
+    } catch (err) {
+      Logging.warn(
+        `EntityRelationResolverService: failed to load entities of type "${entityType}" ` +
+          `to resolve relation field "${fieldSchema.id}"`,
+        err,
+      );
+      return { _id: id };
+    }
+  }
+
+  /**
+   * Determine the entity type an id belongs to: primarily from the id's own
+   * type prefix (e.g. "Child:123"), falling back to the field's `additional`
+   * config (a single type, or the first of multiple possible types) for the
+   * rare case of an id stored without a prefix.
+   */
+  private getReferencedEntityType(
+    id: string,
+    fieldSchema: EntitySchemaField,
+  ): string | undefined {
+    const typeFromId = Entity.extractTypeFromId(id);
+    if (typeFromId) {
+      return typeFromId;
+    }
+
+    const { additional } = fieldSchema;
+    if (typeof additional === "string") {
+      return additional;
+    }
+    if (Array.isArray(additional) && typeof additional[0] === "string") {
+      return additional[0];
+    }
+    return undefined;
+  }
+
+  /**
+   * Load all entities of the given type, indexed by id.
+   * Memoized in `loadedEntitiesByType` so repeated ids/records of the same
+   * type only trigger a single `loadType` database request.
+   */
+  private loadAllOfType(
+    entityType: string,
+    loadedEntitiesByType: Map<string, Promise<Map<string, Entity>>>,
+  ): Promise<Map<string, Entity>> {
+    if (!loadedEntitiesByType.has(entityType)) {
+      loadedEntitiesByType.set(
+        entityType,
+        this.entityMapper
+          .loadType(entityType)
+          .then((entities) => new Map(entities.map((e) => [e.getId(), e]))),
+      );
+    }
+    return loadedEntitiesByType.get(entityType);
+  }
+
+  /**
+   * Copy every schema field's current value onto a new plain object, one level deep.
+   * Relation fields are copied as their raw (unresolved) id(s) - used for a resolved
+   * related entity, which must not have its own relations resolved further.
+   */
+  private copySchemaFieldsShallow(value: Entity): Record<string, any> {
+    const schema = this.getSchema(value);
+    const copy: Record<string, any> = {};
+    for (const [fieldId] of schema) {
+      const raw = value[fieldId];
+      if (raw !== undefined) {
+        copy[fieldId] = raw;
+      }
+    }
+    return copy;
+  }
+
+  private getSchema(value: object): EntitySchema | undefined {
+    const schema = (value.constructor as { schema?: unknown })?.schema;
+    return schema instanceof Map ? (schema as EntitySchema) : undefined;
+  }
+}

--- a/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.ts
+++ b/src/app/core/entity/entity-relation-resolver/entity-relation-resolver.service.ts
@@ -79,7 +79,10 @@ export class EntityRelationResolverService {
       return value;
     }
 
-    const resolved: Record<string, any> = {};
+    // start from a full copy so enumerable properties that aren't part of the
+    // schema (e.g. runtime-attached/computed values) are preserved as-is;
+    // the loop below then overwrites every schema field with its resolved value.
+    const resolved: Record<string, any> = { ...value };
     for (const [fieldId, fieldSchema] of schema) {
       const raw = value[fieldId];
       if (raw === undefined) {

--- a/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.spec.ts
@@ -139,6 +139,33 @@ describe("TemplateExportApiService", () => {
     );
   });
 
+  it("should fall back to fallbackFilename when Content-Disposition cannot be decoded", async () => {
+    const templateEntity = new TemplateExport("test-template-id");
+    templateEntity.title = "My Welcome Letter";
+    const dataEntity = { name: "abc" };
+
+    const mockResponse = new HttpResponse({
+      body: new ArrayBuffer(10),
+      headers: new HttpHeaders({
+        // "%_o" is not a valid percent-escape, so decodeURIComponent throws
+        "Content-Disposition": 'filename="100%_off.pdf"',
+      }),
+      status: 200,
+    });
+    vi.spyOn(TestBed.inject(HttpClient), "post").mockReturnValue(
+      of(mockResponse),
+    );
+
+    const result = await lastValueFrom(
+      service.generatePdfFromTemplate(templateEntity, dataEntity),
+    );
+
+    expect(result).toEqual({
+      filename: "My Welcome Letter",
+      file: mockResponse.body,
+    });
+  });
+
   it("should request a generated file from API with default fileName derived from the template title", async () => {
     const templateEntity = new TemplateExport("test-template-id");
     templateEntity.title = "My Welcome Letter";

--- a/src/app/features/template-export/template-export-api/template-export-api.service.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.ts
@@ -155,9 +155,21 @@ export class TemplateExportApiService extends FileService {
       switchMap(async (res: HttpResponse<ArrayBuffer>) => {
         // the API returns the filename in the Content-Disposition header as a URL-encoded string with special delimiters
         const disposition = res.headers.get("Content-Disposition");
-        const filenameMatch = disposition
-          ? decodeURIComponent(disposition).match(/filename="?([^";]+)"?/)
-          : null;
+        let filenameMatch: RegExpMatchArray | null = null;
+        if (disposition) {
+          try {
+            filenameMatch = decodeURIComponent(disposition).match(
+              /filename="?([^";]+)"?/,
+            );
+          } catch (err) {
+            // malformed percent-encoding must not fail an otherwise successful
+            // download - fall back to fallbackFilename below
+            Logging.warn(
+              "TemplateExportApiService: could not decode Content-Disposition filename",
+              err,
+            );
+          }
+        }
 
         return {
           filename: filenameMatch?.[1] ?? fallbackFilename,

--- a/src/app/features/template-export/template-export-api/template-export-api.service.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from "@angular/core";
 import { FileService } from "../../file/file.service";
 import { SafeUrl } from "@angular/platform-browser";
 import { Entity } from "app/core/entity/model/entity";
-import { Observable, of, throwError } from "rxjs";
+import { from, Observable, of, throwError } from "rxjs";
 import { HttpResponse } from "@angular/common/http";
 import { NotAvailableOfflineError } from "../../../core/session/not-available-offline.error";
 import { NAVIGATOR_TOKEN } from "../../../utils/di-tokens";
@@ -14,6 +14,7 @@ import {
   TemplateExportComplement,
   TemplateExportContextService,
 } from "../template-export-context/template-export-context.service";
+import { EntityRelationResolverService } from "../../../core/entity/entity-relation-resolver/entity-relation-resolver.service";
 
 /**
  * Format of API response body upon uploading a new template file.
@@ -60,6 +61,7 @@ export interface TemplateExportResult {
 export class TemplateExportApiService extends FileService {
   private navigator = inject<Navigator>(NAVIGATOR_TOKEN);
   private readonly exportContext = inject(TemplateExportContextService);
+  private readonly relationResolver = inject(EntityRelationResolverService);
 
   readonly API_URL = environment.API_PROXY_PREFIX + "/v1/export";
 
@@ -136,30 +138,33 @@ export class TemplateExportApiService extends FileService {
   ): Observable<TemplateExportResult> {
     const complement = this.exportContext.getComplement();
 
-    return this.httpClient
-      .post(
-        url,
-        {
-          convertTo: "pdf",
-          data,
-          ...(complement ? { complement } : {}),
-        } as TemplateRenderRequestDto,
-        { observe: "response", responseType: "arraybuffer" },
-      )
-      .pipe(
-        switchMap(async (res: HttpResponse<ArrayBuffer>) => {
-          // the API returns the filename in the Content-Disposition header as a URL-encoded string with special delimiters
-          const disposition = res.headers.get("Content-Disposition");
-          const filenameMatch = disposition
-            ? decodeURIComponent(disposition).match(/filename="?([^";]+)"?/)
-            : null;
+    // give the template access to details of linked records (e.g. a Note's related
+    // Child) instead of just their id - resolved one level deep, see the service.
+    return from(this.relationResolver.resolveRelations(data)).pipe(
+      switchMap((resolvedData) =>
+        this.httpClient.post(
+          url,
+          {
+            convertTo: "pdf",
+            data: resolvedData,
+            ...(complement ? { complement } : {}),
+          } as TemplateRenderRequestDto,
+          { observe: "response", responseType: "arraybuffer" },
+        ),
+      ),
+      switchMap(async (res: HttpResponse<ArrayBuffer>) => {
+        // the API returns the filename in the Content-Disposition header as a URL-encoded string with special delimiters
+        const disposition = res.headers.get("Content-Disposition");
+        const filenameMatch = disposition
+          ? decodeURIComponent(disposition).match(/filename="?([^";]+)"?/)
+          : null;
 
-          return {
-            filename: filenameMatch?.[1] ?? fallbackFilename,
-            file: res.body,
-          };
-        }),
-      );
+        return {
+          filename: filenameMatch?.[1] ?? fallbackFilename,
+          file: res.body,
+        };
+      }),
+    );
   }
 
   /**

--- a/src/app/features/template-export/template-export-api/template-export-api.service.ts
+++ b/src/app/features/template-export/template-export-api/template-export-api.service.ts
@@ -23,8 +23,11 @@ interface TemplateUploadResponseDto {
 }
 
 /**
- * Format of API request body to render a PDF from a template.
+ * Format of API request body to render one or more files from a template.
  * TemplateId is provided via URL path.
+ *
+ * `data` is a single record for `/render`, or an array of records for `/render-batch`
+ * (the backend renders each one and returns either a ZIP or a combined PDF).
  */
 interface TemplateRenderRequestDto {
   /**
@@ -35,7 +38,7 @@ interface TemplateRenderRequestDto {
   /**
    * The data used to fill placeholders in the template.
    */
-  data: Object;
+  data: Object | Object[];
 
   /**
    * Additional context data available in the template under the `{c.…}` prefix.
@@ -43,27 +46,7 @@ interface TemplateRenderRequestDto {
   complement?: TemplateExportComplement;
 }
 
-/**
- * Format of API request body to render a batch of files from one template.
- * `data` is an array of records; the backend will render each one and return a ZIP.
- */
-interface TemplateRenderBatchRequestDto {
-  convertTo: string;
-  data: Object[];
-
-  /**
-   * Additional context data, shared by all records of the batch,
-   * available in the template under the `{c.…}` prefix.
-   */
-  complement?: TemplateExportComplement;
-}
-
 export interface TemplateExportResult {
-  filename: string;
-  file: ArrayBuffer;
-}
-
-export interface TemplateExportBatchResult {
   filename: string;
   file: ArrayBuffer;
 }
@@ -140,6 +123,46 @@ export class TemplateExportApiService extends FileService {
   */
 
   /**
+   * POST a render request to the given endpoint and resolve the response's Content-Disposition
+   * filename, falling back to `fallbackFilename` if the header is missing or cannot be parsed.
+   *
+   * Shared by the single-record and batch render methods below, which only differ in the
+   * endpoint URL, the shape of `data`, and the fallback filename.
+   */
+  private renderTemplate(
+    url: string,
+    data: Object | Object[],
+    fallbackFilename: string,
+  ): Observable<TemplateExportResult> {
+    const complement = this.exportContext.getComplement();
+
+    return this.httpClient
+      .post(
+        url,
+        {
+          convertTo: "pdf",
+          data,
+          ...(complement ? { complement } : {}),
+        } as TemplateRenderRequestDto,
+        { observe: "response", responseType: "arraybuffer" },
+      )
+      .pipe(
+        switchMap(async (res: HttpResponse<ArrayBuffer>) => {
+          // the API returns the filename in the Content-Disposition header as a URL-encoded string with special delimiters
+          const disposition = res.headers.get("Content-Disposition");
+          const filenameMatch = disposition
+            ? decodeURIComponent(disposition).match(/filename="?([^";]+)"?/)
+            : null;
+
+          return {
+            filename: filenameMatch?.[1] ?? fallbackFilename,
+            file: res.body,
+          };
+        }),
+      );
+  }
+
+  /**
    * Generate a PDF applying actual data to an existing template.
    * @param template The TemplateExport entity to render
    * @param data The data object (typically an entity) to be applied to the template
@@ -149,36 +172,11 @@ export class TemplateExportApiService extends FileService {
     template: TemplateExport,
     data: Object,
   ): Observable<TemplateExportResult> {
-    const complement = this.exportContext.getComplement();
-
-    return this.httpClient
-      .post(
-        this.API_URL + "/render/" + template.getId(),
-        {
-          convertTo: "pdf",
-          data: data,
-          ...(complement ? { complement } : {}),
-        } as TemplateRenderRequestDto,
-        { observe: "response", responseType: "arraybuffer" },
-      )
-      .pipe(
-        switchMap(async (res: HttpResponse<ArrayBuffer>) => {
-          // the API returns the filename in the Content-Disposition header as a URL-encoded string with special delimiters
-          const filenameMatch = decodeURIComponent(
-            res.headers.get("Content-Disposition"),
-          ).match(/filename="(.+)"/);
-
-          const fileName =
-            filenameMatch && filenameMatch.length > 1
-              ? filenameMatch[1]
-              : template.title;
-
-          return {
-            filename: fileName,
-            file: res.body,
-          };
-        }),
-      );
+    return this.renderTemplate(
+      this.API_URL + "/render/" + template.getId(),
+      data,
+      template.title,
+    );
   }
 
   /**
@@ -198,36 +196,11 @@ export class TemplateExportApiService extends FileService {
     template: TemplateExport,
     dataList: Object[],
     mode: "zip" | "combined" = "zip",
-  ): Observable<TemplateExportBatchResult> {
-    const fallbackExtension = mode === "combined" ? ".pdf" : ".zip";
-    const complement = this.exportContext.getComplement();
-
-    return this.httpClient
-      .post(
-        this.API_URL + "/render-batch/" + template.getId() + "?mode=" + mode,
-        {
-          convertTo: "pdf",
-          data: dataList,
-          ...(complement ? { complement } : {}),
-        } as TemplateRenderBatchRequestDto,
-        { observe: "response", responseType: "arraybuffer" },
-      )
-      .pipe(
-        switchMap(async (res: HttpResponse<ArrayBuffer>) => {
-          const disposition = res.headers.get("Content-Disposition");
-          const filenameMatch = disposition
-            ? decodeURIComponent(disposition).match(/filename="?([^";]+)"?/)
-            : null;
-          const filename =
-            filenameMatch && filenameMatch.length > 1
-              ? filenameMatch[1]
-              : template.title + fallbackExtension;
-
-          return {
-            filename,
-            file: res.body,
-          };
-        }),
-      );
+  ): Observable<TemplateExportResult> {
+    return this.renderTemplate(
+      this.API_URL + "/render-batch/" + template.getId() + "?mode=" + mode,
+      dataList,
+      template.title + (mode === "combined" ? ".pdf" : ".zip"),
+    );
   }
 }

--- a/src/app/features/template-export/template-export-selection-dialog/template-export-selection-dialog.component.spec.ts
+++ b/src/app/features/template-export/template-export-selection-dialog/template-export-selection-dialog.component.spec.ts
@@ -5,7 +5,6 @@ import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { Entity } from "../../../core/entity/model/entity";
 import {
   TemplateExportApiService,
-  TemplateExportBatchResult,
   TemplateExportResult,
 } from "../template-export-api/template-export-api.service";
 import { DownloadService } from "../../../core/export/download-service/download.service";
@@ -258,7 +257,7 @@ describe("TemplateExportSelectionDialogComponent", () => {
     });
 
     it("should call the batch endpoint once with the array and trigger a single zip download", async () => {
-      const batchResponse: TemplateExportBatchResult = {
+      const batchResponse: TemplateExportResult = {
         filename: "report.zip",
         file: new ArrayBuffer(16),
       };
@@ -293,7 +292,7 @@ describe("TemplateExportSelectionDialogComponent", () => {
     it("should use combined mode and download a single PDF when the combine-into-single-PDF signal is enabled", async () => {
       bulkComponent.combineIntoSinglePdf.set(true);
 
-      const combinedResponse: TemplateExportBatchResult = {
+      const combinedResponse: TemplateExportResult = {
         filename: "combined.pdf",
         file: new ArrayBuffer(16),
       };


### PR DESCRIPTION
- closes #4232 

## PR Checklist

_Before you request a manual PR review from someone, please go through all of this list:_

- [ ] manually tested (all) required functionality yourself and added comment with clear steps for manual testing
- [ ] reviewed the "Files changed" section of the PR briefly
- [ ] added label **"Final Review"** to trigger UI regression testing (Argos visual review)
- [ ] triggered CodeRabbit AI review by commenting **"@coderabbitai review"** (e2e tests run automatically on every push)
- [ ] marked each code review comment as resolved (or commented on it with a question, if unsure)

--> then mark the PR "Ready for Review"

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template exports now support linked entity data in both single-record and batch rendering.
  * Batch exports provide consistent results for ZIP and combined-output modes.
  * Export filenames now use a fallback when response metadata is unavailable or invalid.

* **Bug Fixes**
  * Improved handling of missing, invalid, or unavailable linked records during template rendering.

* **Refactor**
  * Single and batch template rendering now share consistent processing and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->